### PR TITLE
Fix CORS to support QA origin via QA_ORIGIN env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,8 @@ GITHUB_BRANCH=main
 # Restrict CORS to this origin. Leave empty to disable CORS header entirely.
 ALLOWED_ORIGIN=https://sbsommar.se
 
+# Optional second allowed origin (e.g. QA/staging environment).
+# QA_ORIGIN=https://sommar.digitalasynctransparency.com
+
 # Port for the Node.js server (Passenger sets this automatically on Inleed).
 PORT=3000

--- a/app.js
+++ b/app.js
@@ -12,12 +12,15 @@ const app = express();
 
 app.use(express.json());
 
-const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '';
+const ALLOWED_ORIGINS = new Set(
+  [process.env.ALLOWED_ORIGIN, process.env.QA_ORIGIN].filter(Boolean)
+);
 
 app.use((req, res, next) => {
-  if (ALLOWED_ORIGIN && req.headers.origin === ALLOWED_ORIGIN) {
-    res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  const origin = req.headers.origin;
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   }
   if (req.method === 'OPTIONS') return res.sendStatus(204);


### PR DESCRIPTION
The browser preflight (OPTIONS) was failing because ALLOWED_ORIGIN only matched the production domain. Added QA_ORIGIN env var; middleware now checks both and reflects the matched origin in the response header.