### PR TITLE
Add event to SB vinter februari 2026: Testar hemsida (2026-02-23)

### DIFF
--- a/source/data/2026-02-testar.yaml
+++ b/source/data/2026-02-testar.yaml
@@ -368,3 +368,19 @@ events:
   meta:
     created_at: 2026-02-23 10:34
     updated_at: 2026-02-23 10:34
+- id: testar-hemsida-2026-02-23-1430
+  title: Testar hemsida
+  date: '2026-02-23'
+  start: '14:30'
+  end: '16:00'
+  location: GA Datorsal
+  responsible: jag
+  description: |
+    Men vadårår
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-23 11:11
+    updated_at: 2026-02-23 11:11


### PR DESCRIPTION
Automatically generated by the SB Sommar add-event API.