### PR TITLE
fix: pull Git LFS files in CI so images are deployed correctly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
actions/checkout@v4 does not download LFS files by default. Images are tracked via LFS (.gitattributes), so without lfs:true the build copies LFS pointer files into public/ and uploads those to FTP instead of the real images.