### PR TITLE
docs: add Phase 7 (rebase and pull request) to feature development li…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,28 @@ After each pass: fix any issues found, then commit: `fix: post-review improvemen
 
 If a pass finds nothing to fix, stop — no commit needed. The feature is done.
 
+## Phase 7 — Rebase and Pull Request
+
+Before opening a PR, ensure the branch is up to date with `main`. <!-- CL-§11.15 -->
+
+**Rebase step:**
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+- If there are conflicts, resolve them, then `git add` the resolved files and `git rebase --continue`. <!-- CL-§11.16 -->
+- After a successful rebase, run `npm test` and `npm run lint:md` to confirm the branch is still clean. <!-- CL-§11.17 -->
+- Commit any fixups made during conflict resolution before continuing.
+
+**Pull request:**
+
+- Create the PR with `gh pr create`. <!-- CL-§11.18 -->
+- Title: short imperative phrase, under 70 characters.
+- Body: summary bullets, test plan checklist, Claude Code footer.
+- No commit is needed for this phase — the PR itself is the deliverable.
+
 ---
 
 # Final Rule


### PR DESCRIPTION
…fecycle

Adds CL-§11.15–11.18 covering the rebase-before-PR step and the gh pr create convention. This formalises the workflow we already practice in parallel-development sessions.