### PR TITLE
content: merge image webp conversions and content update

### DIFF
--- a/source/content/activities.md
+++ b/source/content/activities.md
@@ -54,7 +54,7 @@ Bassängen är 20*8m och 29 grader varm. Se länken ovan för detaljerad informa
 
 ![Bubbelpool](images/bubbelpool.webp)
 
-![Simhall](images/simhall.png)
+![Simhall](images/simhall.webp)
 
 ### Gym
 

--- a/source/content/discord-guide.md
+++ b/source/content/discord-guide.md
@@ -1,6 +1,6 @@
 # Discord guide
 
-![Discord](images/Discord-Logo-Blurple.png)
+![Discord](images/Discord-Logo-Blurple.webp)
 
 Vi kommer använda Discord som en kommunikationskanal, för diskussioner, dialoger och interaktioner.
 Facebook kommer finnas kvar, givetvis kommer det märkas genom att mer kommunikation kommer finnas i Discord också. Facebook används av några vuxna och väldigt få barn. Discord är mer fokuserat på vår kommunikation och störs inte av allt runtom som i Facebook. Välkommen.
@@ -19,8 +19,7 @@ Vår RFSB server är indelad i kategorier och beroende på roll så kommer man �
 
 * Det första vi vill att du gör är att gå till denna kanal
   * Discord-kanal: Läs detta först
-  * När du är där, se detta meddelandet
-    ![Discord](images/Discord-Logo-Blurple.png)
+  * När du är där, se detta meddelandet ![Discord](images/discord_group.png)
   * Klicka på den cirkeln som du är. Du blir nu tilldelad korrekt roll. Var ärlig.
 * På just denna server är det tacksamt om ni har era vanliga namn.
   * Gå till din profil

--- a/source/content/images/20240623_115220-scaled-1.jpg
+++ b/source/content/images/20240623_115220-scaled-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:269f9f4a8be645574d88bfa084d242d535fcc886d476af158ad11e424c1ecc81
-size 640109

--- a/source/content/images/20240623_120058-scaled-1.jpg
+++ b/source/content/images/20240623_120058-scaled-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f9b1fc23ef757c8db19c634aba1e6b12d8b37aa9c87d15fbf14b81dbf8d6270
-size 706504

--- a/source/content/images/20240623_120106-scaled-1.jpg
+++ b/source/content/images/20240623_120106-scaled-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff501927196d1a2b632fc9c3a01a49744b755b8cad975cd334d3bc923cd4a8c8
-size 648797

--- a/source/content/images/Discord-Logo-Blurple.png
+++ b/source/content/images/Discord-Logo-Blurple.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5402ce4d7f01153a205ccb09689fb1a94b7880fd1fcffb9f1189d8d513d6474b
-size 49424

--- a/source/content/images/Discord-Logo-Blurple.webp
+++ b/source/content/images/Discord-Logo-Blurple.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e9d73c84183bdecb593f80e2d11d756a2f351ce12e03e3d4861c738238eda08
+size 11860

--- a/source/content/images/Discord-New-2021-Icon.png
+++ b/source/content/images/Discord-New-2021-Icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bd56daaebcbfc3d3d0e64488240c74ef21939f04274847da6ea33175009265d
-size 68596

--- a/source/content/images/GA-kreativ-scaled-1.jpg
+++ b/source/content/images/GA-kreativ-scaled-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef919461ba3f15204eeef3ea4078fd524ea6f818c60ee9571a6ba4b08ead441e
-size 762310

--- a/source/content/images/GA-kreativ.webp
+++ b/source/content/images/GA-kreativ.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e879d8c04fbfd5a6f47d5226b341cdd9fec7999e861b5a97beee5c1cef4d92db
+size 109656

--- a/source/content/images/GA-lego-scaled-1.jpg
+++ b/source/content/images/GA-lego-scaled-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97ec46a049023da46652305ef96bb9dba4734706610d7b22395f2f4c4ac1e604
-size 631741

--- a/source/content/images/GA-lego.webp
+++ b/source/content/images/GA-lego.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39e39df2c657ba42f0b492a42f9b37e9edf39a1f80ca51577a30f67afe1e8ec9
+size 90012

--- a/source/content/images/branas_sommar-2.webp
+++ b/source/content/images/branas_sommar-2.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2dea9c34944e2f318debfbeae63fd1aad4d54daa3767046a1f60a03e113da97
-size 62442

--- a/source/content/images/campingkarta-1.webp
+++ b/source/content/images/campingkarta-1.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb7f5b3f591c6b5122ed0d69a5ea0b93e3dbad437e29529241d4b9d69b9aa94
-size 24148

--- a/source/content/images/campingkarta-2.webp
+++ b/source/content/images/campingkarta-2.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb7f5b3f591c6b5122ed0d69a5ea0b93e3dbad437e29529241d4b9d69b9aa94
-size 24148

--- a/source/content/images/campingkarta-3.webp
+++ b/source/content/images/campingkarta-3.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93a98b40f3c7b44b74ce24814892d3d5eef5e5025a484fc267c3d6766bb0840c
-size 68904

--- a/source/content/images/campingkarta.webp
+++ b/source/content/images/campingkarta.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4e950ceaba9fb3fef759aa866666616bf112d638c7ec300783520008517ad39
-size 281384
+oid sha256:c91f4b8d60c89aea02bb78334dc65f8a14713fc8dca8ccd1367e1ac3e4818cb2
+size 104506

--- a/source/content/images/discord_group.png
+++ b/source/content/images/discord_group.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceb40fff7f1e8b7d212bb1b5637d4f61c4a50f4a7307deff748519a6a2a71f6c
+size 12237

--- a/source/content/images/lekplats-1.png
+++ b/source/content/images/lekplats-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e618faaf5897b5d7d201361d8d01a06c5005afe8ef9c9f9bb7b2e4e4265404ca
-size 279417

--- a/source/content/images/lekplats.webp
+++ b/source/content/images/lekplats.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e30080e7c3a8172cff2d9ad5d4118b3f456f47f8f210eb81b07ef1a9c305524b
+size 33028

--- a/source/content/images/simhall.png
+++ b/source/content/images/simhall.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9756c8387974f11da0ac74d6d5981e83dbe1403b923a1a0e1b62d96d5fab326
-size 3299866

--- a/source/content/images/simhall.webp
+++ b/source/content/images/simhall.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76704e2754c3b3431148c725edc73a18175615c0d550dc12a189fb0911c7b0af
+size 44502

--- a/source/content/images/sysslebacks-stugby-fiskecamping-map.jpg
+++ b/source/content/images/sysslebacks-stugby-fiskecamping-map.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df3640ad291c43ad4c27b8a1ccfbea7a3075236299e87a0dd587340ea5262076
-size 3325808

--- a/source/content/images/uppehallsrum.png
+++ b/source/content/images/uppehallsrum.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf7e37a4f94adc894d6312ad4d33063f61e9ed094116df3da00075746f9ae224
-size 1826638

--- a/source/data/local.yaml
+++ b/source/data/local.yaml
@@ -2,7 +2,7 @@ locations:
   - id: andreas-taltet
     name: AndreasTältet
     information: ""
-    image_path: "images/andreas-taltet.webp"
+    image_path: ""
   - id: annat
     name: Annat
     information: >
@@ -53,24 +53,34 @@ locations:
     information: >
       En del av GA hallen brukar användas för att spela spel, pussla, pyssla,
       bygga lego, med mera.
-    image_path: "images/GA-kreativ-scaled-1.jpg"
+    image_path: "images/GA-kreativ.webp"
+  - id: ga-lego
+    name: GA Lego
+    information: >
+      En del av GA hallen brukar användas för att spela spel, pussla, pyssla,
+      bygga lego, med mera.
+    image_path: "images/GA-lego.webp"
   - id: ga-stilla-hyllan
     name: GA Stilla hyllan
     information: >
       Uppe på hyllan finns det lite små bord, där kan det göras lugnare och
       mer fokuserade aktiviteter.
-    image_path: "images/GA_stilla_hyllan.webp"
+    image_path:
+      - "images/GA_stilla_hyllan.webp"
+      - "images/GA_laktare.webp"
   - id: grillplats
     name: Grillplats
     information: >
       Grillplatsen ligger vid älven. Badet brukar vara lite varmare på
       eftermiddagen då solen värmt upp “dagens” vatten. Ingen simmar i älven,
       det är sedan gammalt.
-    image_path: "images/grillplatsen.webp"
+    image_path:
+      - "images/grillplatsen.webp"
+      - "images/camping_badplats.webp"
   - id: kaffe-paviljongen
     name: KaffePaviljongen
-    information: ""
-    image_path: "images/kaffetalt.webp"
+    information: "Placerat framför stuga 6, där kaffe och te finns dygnet runt."
+    image_path: ""
   - id: kaffetalt
     name: Kaffetält
     information: >
@@ -138,5 +148,5 @@ locations:
     image_path: "images/talt1_talt2-1.webp"
   - id: tonarsstugan
     name: Tonårsstugan
-    information: ""
-    image_path: "images/tonarsstugan.webp"
+    information: "Endast tillträde för ungdomar som har är 13år fyllda."
+    image_path: ""


### PR DESCRIPTION
## Summary
- Converts several images from png/jpg to webp format (simhall, GA-kreativ, GA-lego, lekplats, Discord-Logo-Blurple)
- Removes unused old-format images (20240623_*.jpg, sysslebacks map, uppehallsrum)
- Updates markdown references to use the new webp filenames
- Adds discord_group.png for Discord guide

This branch was created earlier but never merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)