### PR TITLE
docs: add Decided Against section to architecture doc

### DIFF
--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -715,7 +715,17 @@ The `.section-nav` CSS rule is also removed.
 
 ---
 
-## 10. Design Philosophy
+## 10. Decided Against
+
+Decisions evaluated and deliberately rejected. Kept here so they are not re-proposed.
+
+| Decision | Reason | Date |
+| --- | --- | --- |
+| CSS/JS minification | Total CSS+JS is ~22 KB; server gzips text assets, so actual transfer savings would be ~3–5 KB. Images (~1.7 MB) are the real payload. Build complexity not justified. | 2026-02 |
+
+---
+
+## 11. Design Philosophy
 
 - YAML is the database
 - Git is the archive


### PR DESCRIPTION
## Summary
- Adds a "Decided Against" table to `docs/03-ARCHITECTURE.md` (new §10)
- Records the decision not to add CSS/JS minification, with rationale: total CSS+JS is ~22 KB, server gzips text assets, so actual transfer savings would be ~3-5 KB — not worth the build complexity

## Test plan
- [x] All 335 existing tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] Doc-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)