### PR TITLE
fix: compact inline camp list layout

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1054,20 +1054,11 @@ body.modal-open {
 .upcoming-camps {
   list-style: none;
   padding: 0;
-  margin: var(--space-sm) 0 0;
+  margin: var(--space-xs) 0 0;
 }
 
 .camp-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-xs) 0;
-}
-
-.camp-icon {
-  flex-shrink: 0;
-  font-size: 1.25em;
-  line-height: 1;
+  line-height: var(--line-height-body);
 }
 
 .camp-icon::after {
@@ -1076,15 +1067,6 @@ body.modal-open {
 
 .camp-past .camp-icon::after {
   content: '✅';
-}
-
-.camp-body {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-xs);
-  flex-wrap: wrap;
 }
 
 .camp-name {

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -272,10 +272,8 @@ function renderUpcomingCampsHtml(allCamps, currentYear) {
 
     return `    <li class="camp-item" data-end="${endDate}">
       <span class="camp-icon" aria-hidden="true"></span>
-      <div class="camp-body">
-        <span class="camp-name">${nameHtml}</span>
-        <span class="camp-meta">${location} · ${dateRange}</span>
-      </div>
+      <span class="camp-name">${nameHtml}</span>
+      <span class="camp-meta">${location} · ${dateRange}</span>
     </li>`;
   }).join('\n');
 

--- a/tests/upcoming-camps.test.js
+++ b/tests/upcoming-camps.test.js
@@ -179,10 +179,12 @@ describe('renderUpcomingCampsHtml – empty list', () => {
 // ── Compact one-liner layout (02-§3.5) ──────────────────────────────────────
 
 describe('Camp list CSS – compact one-liner layout (02-§3.5)', () => {
-  it('CL-01: .camp-body uses display: flex for inline layout', () => {
+  it('CL-01: .camp-item uses inline flow (no flexbox)', () => {
+    const match = CSS.match(/\.camp-item\s*\{([^}]*)\}/);
+    assert.ok(match, '.camp-item rule should exist');
     assert.ok(
-      /\.camp-body\s*\{[^}]*display:\s*flex/s.test(CSS),
-      '.camp-body should have display: flex',
+      !match[1].includes('display: flex') && !match[1].includes('display:flex'),
+      '.camp-item should not have display: flex',
     );
   });
 


### PR DESCRIPTION
## Summary
- Remove flexbox layout from camp items — icon, name, and meta now flow inline like regular text
- Remove the `<div class="camp-body">` wrapper; spans are direct children of `<li>`
- Normal line-height between camps instead of extra padding/gap
- Update CSS test to match new inline layout

## Test plan
- [x] `npm test` — 478 tests pass
- [x] `npm run lint` — clean
- [x] Site builds successfully
- [ ] Visual check in browser: camps display as compact inline text lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)