### PR TITLE
Compact upcoming camps list and enable local build

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1058,7 +1058,9 @@ body.modal-open {
 }
 
 .camp-item {
-  line-height: var(--line-height-body);
+  margin: 0;
+  padding: 0;
+  line-height: 1.3;
 }
 
 .camp-icon::after {
@@ -1093,6 +1095,7 @@ body.modal-open {
 }
 
 .camp-item .camp-meta {
+  display: inline;
   font-size: var(--font-size-small);
   color: var(--color-charcoal);
 }

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -15,6 +15,15 @@ const { renderRssFeed } = require('./render-rss');
 const { renderEventPage } = require('./render-event');
 const { resolveActiveCamp } = require('../scripts/resolve-active-camp');
 
+// ── Load .env if present (local dev) ─────────────────────────────────────────
+const envPath = path.join(__dirname, '../..', '.env');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+  }
+}
+
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const CONTENT_DIR = path.join(__dirname, '..', 'content');
 const ASSETS_DIR = path.join(__dirname, '..', 'assets');

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -1,14 +1,14 @@
 camps:
   - id: 2026-08-syssleback
-    name: SB sommar 2026 augusti
-    start_date: '2026-08-02'
-    end_date: '2026-08-09'
-    opens_for_editing: '2026-07-25'
+    name: SB sommar 2026 juli
+    start_date: '2026-07-26'
+    end_date: '2026-08-02'
+    opens_for_editing: '2026-07-18'
     location: Sysslebäck
     link: "https://www.facebook.com/groups/syssleback2026"
     information: |
       Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
-    file: 2026-08-syssleback.yaml
+    file: 2026-07-syssleback.yaml
     archived: false
   - id: 2026-06-syssleback
     name: SB sommar 2026 juni


### PR DESCRIPTION
## Summary
- Make upcoming camps display compact: icon, name, and meta on one row per camp with tighter spacing
- Add minimal .env file loader in build.js so local builds work without manually exporting SITE_URL
- Update july camp dates in camps.yaml (was august, now 26 jul – 2 aug)

## Test plan
- [ ] Open index.html locally and verify upcoming camps show compact (one row each)
- [ ] Verify `npm run build` works without manually setting SITE_URL (with .env present)
- [ ] Verify camp dates are correct in the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)