### PR TITLE
fix: support asterisk list markers in markdown converter

### DIFF
--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -91,10 +91,10 @@ function convertMarkdown(md, headingOffset = 0, collapsible = false) {
     } else if (line.trim() === '---') {
       flushPara();
       blocks.push({ type: 'hr' });
-    } else if (line.startsWith('- ')) {
+    } else if (line.startsWith('- ') || line.startsWith('* ')) {
       flushPara();
       const items = [];
-      while (i < lines.length && lines[i].startsWith('- ')) {
+      while (i < lines.length && (lines[i].startsWith('- ') || lines[i].startsWith('* '))) {
         items.push(lines[i].slice(2));
         i++;
       }


### PR DESCRIPTION
## Summary
- The custom markdown converter only recognized `-` as a list marker, ignoring `*`
- Lines starting with `* ` were treated as paragraph text, collapsing all list items into one block
- Affected files: rules.md, food.md, activities.md, registration.md, discord-guide.md

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] Lint passes
- [x] Verified `<ul>/<li>` tags appear in built HTML for affected sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)