### PR TITLE
Add RSS link on schedule page and fix mobile overflow

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -40,6 +40,7 @@ body {
   background: var(--color-cream);
   font-size: 16px;
   line-height: 1.65;
+  overflow-wrap: break-word;
 }
 
 h1 {
@@ -47,6 +48,21 @@ h1 {
   font-weight: 700;
   color: var(--color-sage);
   margin: 0 0 var(--space-xs);
+}
+
+.schedule-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.rss-link {
+  line-height: 0;
+}
+
+.rss-icon {
+  height: 38px;
+  width: auto;
 }
 
 h2 {

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -102,7 +102,10 @@ function renderSchedulePage(camp, events, footerHtml = '', navSections = []) {
 </head>
 <body>
 ${pageNav('schema.html', navSections)}
-  <h1>Schema – ${campName}</h1>
+  <div class="schedule-header">
+    <h1>Schema – ${campName}</h1>
+    <a href="schema.rss" class="rss-link" title="RSS-feed"><img src="images/RSS-logo.webp" alt="RSS" class="rss-icon"></a>
+  </div>
   <p class="intro">Om du klickar på en aktivitets rubrik så finns det ofta lite mer detaljerad information. När plats säger [annat], då ska platsen stå i den detaljerade informationen.</p>
   <p class="intro">Lägret blir vad vi gör det till tillsammans, alla aktiviteter är deltagararrangerade. Känner man att det är någon aktivitet som man vill arrangera och behöver material till den, det kan vara allt ifrån bakingredienser till microbitar att programmera, kort sagt vad behöver ni som aktivitetsarrangör för att kunna hålla eran aktivitet? Kolla under <a href="lagg-till.html">Lägg till aktivitet</a>.</p>
 

--- a/source/content/discord-guide.md
+++ b/source/content/discord-guide.md
@@ -29,4 +29,4 @@ Vår RFSB server är indelad i kategorier och beroende på roll så kommer man �
   * Ändra ditt namn till ditt riktiga
   * Tack så mycket!
 * Lite saker att tänka på står i detta meddelande på servern.
-  *[https://discord.com/channels/992817044527534181/993132173156683786/993167168982237294](https://discord.com/channels/992817044527534181/993132173156683786/993167168982237294)
+  * [https://discord.com/channels/992817044527534181/993132173156683786/993167168982237294](https://discord.com/channels/992817044527534181/993132173156683786/993167168982237294)

--- a/source/content/images/RSS-logo.webp
+++ b/source/content/images/RSS-logo.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d5d01622744827faf89305b7344ed04a874ba7936433e6c515583ef6a238f1b
+size 4108

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -24,7 +24,10 @@
       </div>
     </div>
   </nav>
-  <h1>Schema – Test Camp 2025</h1>
+  <div class="schedule-header">
+    <h1>Schema – Test Camp 2025</h1>
+    <a href="schema.rss" class="rss-link" title="RSS-feed"><img src="images/RSS-logo.webp" alt="RSS" class="rss-icon"></a>
+  </div>
   <p class="intro">Om du klickar på en aktivitets rubrik så finns det ofta lite mer detaljerad information. När plats säger [annat], då ska platsen stå i den detaljerade informationen.</p>
   <p class="intro">Lägret blir vad vi gör det till tillsammans, alla aktiviteter är deltagararrangerade. Känner man att det är någon aktivitet som man vill arrangera och behöver material till den, det kan vara allt ifrån bakingredienser till microbitar att programmera, kort sagt vad behöver ni som aktivitetsarrangör för att kunna hålla eran aktivitet? Kolla under <a href="lagg-till.html">Lägg till aktivitet</a>.</p>
 


### PR DESCRIPTION
## Summary
- Add clickable RSS logo next to the "Schema" heading, linking to `schema.rss`
- Add `overflow-wrap: break-word` on `body` to prevent horizontal scroll from long URLs (e.g. Discord links on mobile)
- Fix bullet formatting in discord-guide.md
- Update snapshot for new schedule header structure

## Test plan
- [ ] Open schema.html — RSS icon visible to the right of the heading
- [ ] Click RSS icon — opens schema.rss
- [ ] Open discord-guide.md on mobile — long URL wraps instead of causing horizontal scroll
- [ ] All 785 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)