### PR TITLE
Fix 7th CodeQL alert in RSS test assertion

### DIFF
--- a/tests/render-rss.test.js
+++ b/tests/render-rss.test.js
@@ -116,7 +116,7 @@ describe('renderRssFeed (02-§15)', () => {
     // Line 3: description text
     assert.ok(xml.includes('Alla är välkomna!'), 'line 3 should have description');
     // Line 4: link
-    assert.ok(xml.includes('https://example.com/fotboll'), 'line 4 should have link');
+    assert.ok(xml.includes('Alla är välkomna!\nhttps://example.com/fotboll'), 'line 4 should have link after description');
 
     // Event without description or link (Frukost)
     assert.ok(xml.includes('måndag 29 juni 2026, 08:00–09:00'), 'should have date+time for Frukost');


### PR DESCRIPTION
## Summary

- Fix remaining CodeQL `js/incomplete-url-substring-sanitization` false positive in `tests/render-rss.test.js:119`
- Makes the assertion more specific by including surrounding context (`description\nurl` instead of bare URL)
- Discovered during verification of PR #109

## Test plan

- [x] All 788 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)