### PR TITLE
feat: style event detail page with card layout

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -447,10 +447,95 @@ details.event-row[open] > summary .ev-title {
 
 .event-desc { margin: 0 0 4px; }
 
+/* ── Per-event detail page ── */
+
+.back-link {
+  margin: 0 0 var(--space-sm);
+}
+
+.back-link a {
+  font-size: var(--font-size-small);
+  color: var(--color-terracotta);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.back-link a:hover {
+  text-decoration: underline;
+}
+
+.back-link a:focus-visible {
+  outline: 2px solid var(--color-terracotta);
+  outline-offset: 2px;
+}
+
+.event-detail {
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-md);
+  max-width: var(--container-narrow);
+  margin: 0 0 var(--space-md);
+  border-left: 4px solid var(--color-sage);
+}
+
+.event-detail p {
+  margin: 0 0 var(--space-xs);
+  line-height: var(--line-height-body);
+}
+
+.event-detail p:first-child {
+  font-weight: 700;
+  color: var(--color-navy);
+}
+
+.event-detail p:last-child {
+  margin-bottom: 0;
+  font-size: var(--font-size-small);
+  color: var(--color-charcoal);
+}
+
+.event-description {
+  margin: var(--space-sm) 0 0;
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+  color: var(--color-charcoal);
+}
+
+.event-section-label {
+  font-size: var(--font-size-small);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-charcoal);
+  opacity: 0.5;
+  margin: 0 0 var(--space-xs);
+}
+
+.event-description p {
+  margin: 0 0 var(--space-xs);
+  font-style: italic;
+}
+
+.event-description p:last-child {
+  margin-bottom: 0;
+}
+
+.event-link-row {
+  margin: var(--space-sm) 0 0;
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+}
+
 .event-ext-link {
   color: var(--color-terracotta);
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--font-size-small);
+  text-decoration: none;
+}
+
+.event-ext-link:hover {
+  text-decoration: underline;
 }
 
 .event-ext-link:focus-visible {

--- a/source/build/render-event.js
+++ b/source/build/render-event.js
@@ -24,14 +24,14 @@ function renderEventPage(event, camp, siteUrl, footerHtml = '', navSections = []
   let descriptionHtml = '';
   if (event.description) {
     const paragraphs = event.description.trim().split(/\n\n+/)
-      .map((p) => `    <p>${escapeHtml(p.trim())}</p>`)
+      .map((p) => `      <p>${escapeHtml(p.trim())}</p>`)
       .join('\n');
-    descriptionHtml = `  <div class="event-description">\n${paragraphs}\n  </div>\n`;
+    descriptionHtml = `    <div class="event-description">\n      <p class="event-section-label">Beskrivning</p>\n${paragraphs}\n    </div>\n`;
   }
 
   let linkHtml = '';
   if (event.link) {
-    linkHtml = `  <a class="event-ext-link" href="${escapeHtml(String(event.link))}" target="_blank" rel="noopener noreferrer">Extern länk →</a>\n`;
+    linkHtml = `    <p class="event-link-row"><a class="event-ext-link" href="${escapeHtml(String(event.link))}" target="_blank" rel="noopener noreferrer">Extern länk (för diskussion etc) →</a></p>\n`;
   }
 
   return `<!DOCTYPE html>
@@ -49,10 +49,10 @@ ${pageNav('schema.html', navSections)}
   <p class="back-link"><a href="schema.html">← Tillbaka till schemat</a></p>
   <h1>${title}</h1>
   <div class="event-detail">
-    <p>${date}, ${timeStr}</p>
-    <p>Plats: ${escapeHtml(event.location)} · Ansvarig: ${escapeHtml(event.responsible)}</p>
-  </div>
-${descriptionHtml}${linkHtml}  <script src="nav.js" defer></script>
+    <p>📅 ${date} 🕐 ${timeStr}</p>
+    <p>📍 <strong>Plats:</strong> ${escapeHtml(event.location)} · 👤 <strong>Ansvarig:</strong> ${escapeHtml(event.responsible)}</p>
+${descriptionHtml}${linkHtml}  </div>
+  <script src="nav.js" defer></script>
 ${pageFooter(footerHtml)}
 </body>
 </html>

--- a/source/data/2026-02-testar.yaml
+++ b/source/data/2026-02-testar.yaml
@@ -45,7 +45,7 @@ events:
     description: |
       En massa kul att göra.
       och inget annat heller.
-    link: null
+    link: https://www.facebook.com/share/p/14TCPJYFynM/?
     owner:
       name: ''
       email: ''

--- a/tests/render-event.test.js
+++ b/tests/render-event.test.js
@@ -148,14 +148,18 @@ describe('renderEventPage (02-§36)', () => {
   it('EVT-19 (02-§36.11): uses structured layout with date+time line and plats+ansvarig line', () => {
     const html = renderEventPage(fullEvent, camp, siteUrl);
     assert.ok(!html.includes('<dl'), 'should not use definition list');
-    assert.ok(html.includes('måndag 29 juni 2026, 10:00–12:00'), 'line 1 should have date and time range');
-    assert.ok(html.includes('Plats: Planen · Ansvarig: Erik'), 'line 2 should have labelled plats and ansvarig');
+    assert.ok(html.includes('måndag 29 juni 2026'), 'line 1 should have formatted date');
+    assert.ok(html.includes('10:00–12:00'), 'line 1 should have time range');
+    assert.ok(html.includes('<strong>Plats:</strong> Planen'), 'line 2 should have bold Plats label');
+    assert.ok(html.includes('<strong>Ansvarig:</strong> Erik'), 'line 2 should have bold Ansvarig label');
   });
 
   it('EVT-20 (02-§36.11): structured layout omits description and link lines when absent', () => {
     const html = renderEventPage(minimalEvent, camp, siteUrl);
-    assert.ok(html.includes('måndag 29 juni 2026, 08:00–09:00'), 'line 1 should have date and time range');
-    assert.ok(html.includes('Plats: Matsalen · Ansvarig: Kocken'), 'line 2 should have labelled plats and ansvarig');
+    assert.ok(html.includes('måndag 29 juni 2026'), 'line 1 should have formatted date');
+    assert.ok(html.includes('08:00–09:00'), 'line 1 should have time range');
+    assert.ok(html.includes('<strong>Plats:</strong> Matsalen'), 'line 2 should have bold Plats label');
+    assert.ok(html.includes('<strong>Ansvarig:</strong> Kocken'), 'line 2 should have bold Ansvarig label');
     assert.ok(!html.includes('class="event-description"'), 'should not render description section');
     assert.ok(!html.includes('class="event-ext-link"'), 'should not render external link');
   });


### PR DESCRIPTION
## Summary
- White card with sage-green left border, shadow, and proper spacing
- Emojis for date (📅), time (🕐), location (📍), and responsible (👤)
- Bold labels for Plats and Ansvarig
- Description and external link moved inside the card with separator lines
- Small uppercase "BESKRIVNING" section label
- Link text updated to "Extern länk (för diskussion etc) →"
- Back link styled in terracotta
- Test data: added link to Brädspel event

## Test plan
- [x] All 790 tests pass
- [x] Lint and markdown lint pass
- [ ] Visual check: open event detail page and verify card layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)