### PR TITLE
fix: update anchor links and food order deadline

### DIFF
--- a/source/content/food.md
+++ b/source/content/food.md
@@ -26,14 +26,14 @@ Alla dagar går det att beställa utöver menyn nedan:
 * Vissa kör på restauranger och takeaway runtom.
 * Vissa gör lite av varje.
 
-Man får utgå från sin egen situation och planera vad som fungerar bäst. Bor man på området? Är man två föräldrar med? Har man bil tillgänglig? Har barnen specifika behov? Har man tillgång till kök? Mataffären är några kilometer bort och de flesta tar något slags fordon dit(går ofta att samåka med någon till affären), ska alla laga mat i servicehuset blir det trångt och man behöver då ha med sig egna köksprylar som kastrull, stekpanna och tallrikar. Är man en stor familj kostar det en slant att köpa mat till varje måltid, men det är bekvämt. Se även under “[Hur är det med service runtom Sysslebäck?](#hur-ar-det-med-service-runtom-syssleback)“
+Man får utgå från sin egen situation och planera vad som fungerar bäst. Bor man på området? Är man två föräldrar med? Har man bil tillgänglig? Har barnen specifika behov? Har man tillgång till kök? Mataffären är några kilometer bort och de flesta tar något slags fordon dit(går ofta att samåka med någon till affären), ska alla laga mat i servicehuset blir det trångt och man behöver då ha med sig egna köksprylar som kastrull, stekpanna och tallrikar. Är man en stor familj kostar det en slant att köpa mat till varje måltid, men det är bekvämt. Se även under “[Hur är det med service runtom Sysslebäck?](#service)“
 
 ## Information om att beställa mat
 
 Lunch levereras till campingen i värmeskåp runt kl 12.00 dagligen.
 Middag levereras runt 16.30.
 
-Det kommer även gå att beställa Thaimat från samma leverantör. Priser på Thaimat som beställs direkt från Thai-vagnen kommer att stå i menyn på deras hemsida. Mer information under “[Restaurang och take away](https://sbsommar.se/#hur-ar-det-med-service-runtom-syssleback)“.
+Det kommer även gå att beställa Thaimat från samma leverantör. Priser på Thaimat som beställs direkt från Thai-vagnen kommer att stå i menyn på deras hemsida. Mer information under “[Restaurang och take away](https://sbsommar.se/#service)“.
 
 #### Födoämnesintolleranser / allergier
 
@@ -46,7 +46,7 @@ Det står angivet i menyn vilka rätter som innehåller **gluten**.
 Det kommer att vara stora portioner så räkna en portion till två yngre barn.
 Ange antal portioner per rätt och måltid i formuläret. (Om man vill ha mer än 6 portioner av ett mål en eller flera dagar så gör man en ytterligare beställning.)
 
-[Beställ mat (senast 30 juli)](https://docs.google.com/forms/d/e/1FAIpQLSf_7qvDSueq_QaJcSPfeNN-5a61FBWchCdzxJp1Z3q3PVnu0Q/viewform)
+[Beställ mat (senast 30 juli 2025)](https://docs.google.com/forms/d/e/1FAIpQLSf_7qvDSueq_QaJcSPfeNN-5a61FBWchCdzxJp1Z3q3PVnu0Q/viewform)
 
 #### Betalning
 

--- a/source/content/registration.md
+++ b/source/content/registration.md
@@ -2,7 +2,7 @@
 
 Självklart är hela familjen välkommen. Och alla räknas som deltagare. Barn i alla åldrar finns på lägret, från de minsta bebisar (oftast då medföljande) till barn som vuxit upp och är 20 år.
 
-Före anmälan, läs [regler och villkor](#lagerregler). För att delta i fördelning av boende, behövsa anmälan senast i regel på specifik datum i maj, detaljer om dag kommer när anmälan öppnas. För övriga så är sista dagen ungefär en vecka innan lägret börjar.
+Före anmälan, läs [regler och villkor](#regler). För att delta i fördelning av boende, behövsa anmälan senast i regel på specifik datum i maj, detaljer om dag kommer när anmälan öppnas. För övriga så är sista dagen ungefär en vecka innan lägret börjar.
 
 **Efterfrågad information vid anmälan för 2025**
 


### PR DESCRIPTION
## Summary
- Update anchor targets in food.md (`#service` instead of old long anchors)
- Update anchor target in registration.md (`#regler` instead of `#lagerregler`)
- Add year (2025) to food order deadline link text

## Test plan
- [x] Build passes locally
- [x] Markdown lint passes
- [ ] Verify anchor links resolve correctly on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)