### PR TITLE
fix: skip production deploy for QA camp event data

### DIFF
--- a/.github/workflows/event-data-deploy.yml
+++ b/.github/workflows/event-data-deploy.yml
@@ -5,10 +5,12 @@ name: Event Data Deploy
 #
 # Jobs:
 #   1. lint-yaml      – structural validation of the changed YAML file
-#   2. security-check – injection scan and link protocol validation
+#   2. security-check – injection scan, link protocol validation, QA-camp detection
 #   3. deploy-qa      – build with QA secrets + SCP upload to QA
-#   4. deploy-prod    – build with production secrets + FTP upload to production
-#   (3 and 4 run in parallel after 2 passes)
+#   4. deploy-qa-node – build with QA secrets + SCP upload to QA Node
+#   5. deploy-prod    – build with production secrets + FTP upload to production
+#                       (skipped when the changed file belongs to a QA camp)
+#   (3, 4, and 5 run in parallel after 2 passes)
 
 permissions:
   contents: read
@@ -63,6 +65,8 @@ jobs:
     name: Security scan
     runs-on: ubuntu-latest
     needs: lint-yaml
+    outputs:
+      is_qa: ${{ steps.qa-check.outputs.is_qa }}
 
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +91,20 @@ jobs:
 
       - name: Security scan
         run: node source/scripts/check-yaml-security.js "${{ steps.changed.outputs.yaml_file }}"
+
+      - name: Check if changed file belongs to a QA camp
+        id: qa-check
+        run: |
+          BASENAME=$(basename "${{ steps.changed.outputs.yaml_file }}")
+          IS_QA=$(node -e "
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+            const camps = yaml.load(fs.readFileSync('source/data/camps.yaml','utf8'));
+            const match = camps.camps.find(c => c.file === '$BASENAME');
+            console.log(match && match.qa === true ? 'true' : 'false');
+          ")
+          echo "is_qa=$IS_QA" >> $GITHUB_OUTPUT
+          echo "File $BASENAME is QA camp: $IS_QA"
 
   # Build with QA secrets and deploy event data pages to QA via SCP.
   deploy-qa:
@@ -143,11 +161,69 @@ jobs:
           target: ${{ secrets.DEPLOY_DIR }}/public_html
           strip_components: 1
 
+  # Build with QA secrets and deploy event data pages to QA Node via SCP.
+  deploy-qa-node:
+    name: Build & deploy to QA Node
+    runs-on: ubuntu-latest
+    needs: security-check
+    environment: qa-node
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          SITE_URL: ${{ secrets.SITE_URL }}
+          BUILD_ENV: qa
+
+      # Stage only event-data-derived files for upload.
+      - name: Stage event data pages
+        run: |
+          mkdir -p staging
+          for FILE in schema.html idag.html dagens-schema.html events.json schema.rss; do
+            if [ -f "public/$FILE" ]; then
+              cp "public/$FILE" "staging/$FILE"
+              echo "Staged: $FILE"
+            fi
+          done
+          if [ -d "public/schema" ]; then
+            find public/schema -name 'index.html' | while read -r PAGE; do
+              REL="${PAGE#public/}"
+              mkdir -p "staging/$(dirname "$REL")"
+              cp "$PAGE" "staging/$REL"
+              echo "Staged: $REL"
+            done
+          fi
+
+      - name: Upload event data pages via SCP
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          source: staging/*
+          target: ${{ secrets.DEPLOY_DIR }}/public_html
+          strip_components: 1
+
   # Build with production secrets and deploy event data pages to production.
+  # Skipped when the changed file belongs to a QA camp — prevents overwriting
+  # production schedule pages with an empty build.
   deploy-prod:
     name: Build & deploy to Production
     runs-on: ubuntu-latest
     needs: security-check
+    if: needs.security-check.outputs.is_qa != 'true'
     environment: production
 
     steps:


### PR DESCRIPTION
## Summary
- **Bug:** When an event was added to a QA camp (e.g. via the form on qa-node), the `event-data-deploy` workflow ran a production build. Since `BUILD_ENV=production` excludes QA camps, the build resolved to an empty production camp and overwrote the live schedule pages with zero events.
- **Fix:** The `security-check` job now detects whether the changed YAML file belongs to a `qa: true` camp. The `deploy-prod` job is skipped when it does.
- **New:** Added `deploy-qa-node` job so event data pages also get deployed to the QA Node environment via SCP.

## Test plan
- [ ] Submit an event to the QA camp via the form — verify `deploy-prod` is skipped, `deploy-qa` and `deploy-qa-node` both run
- [ ] Submit an event to a production camp — verify all three deploy jobs run
- [ ] Verify production site schedule pages are not overwritten by QA-only event changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)