### PR TITLE
fix: rename qa-node environment to qanode

### DIFF
--- a/.github/workflows/deploy-qa-node.yml
+++ b/.github/workflows/deploy-qa-node.yml
@@ -7,13 +7,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-qa-node
+  group: deploy-qanode
   cancel-in-progress: true
 
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-reusable.yml
     with:
-      environment: qa-node
+      environment: qanode
       build_env: qa
     secrets: inherit

--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -1949,6 +1949,6 @@ that supports Node.js.
   configuration, and how to set it up on a new host. <!-- 02-§44.37 -->
 - `docs/08-ENVIRONMENTS.md` must document the `qa` GitHub Environment
   (PHP on Loopia) and its secrets. The previous Node.js QA setup is
-  preserved as the `qa-node` environment. <!-- 02-§44.38 -->
+  preserved as the `qanode` environment. <!-- 02-§44.38 -->
 - `docs/03-ARCHITECTURE.md` must note the dual API architecture (Node.js
   for local dev and Node.js hosts, PHP for shared hosting). <!-- 02-§44.39 -->

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -1340,7 +1340,7 @@ backend is determined solely by the `API_URL` environment variable set in each
 GitHub Environment:
 
 - Local development: `npm start` → Node.js API at `http://localhost:3000`
-- `qa-node` environment: Node.js API on a Node.js-capable host
+- `qanode` environment: Node.js API on a Node.js-capable host
 - `qa` environment: PHP API on Loopia (`https://qa.sbsommar.se/api/add-event`)
 - `production` environment: PHP API on Loopia (`https://sbsommar.se/api/add-event`)
 

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -13,7 +13,7 @@ For CI/CD workflow details, see [04-OPERATIONS.md](04-OPERATIONS.md).
 | -------------- | ----------- | --------- | ---------------------------- | ---------------------- | ------------------------------- |
 | **Local**      | localhost   | Node.js   | `npm start`                  | N/A                    | `.env` file                     |
 | **QA**         | Loopia      | PHP       | Auto on push to `main`       | Auto on event PR merge | GitHub Environment `qa`         |
-| **QA-Node**    | Node.js VPS | Node.js   | Auto on push to `main`       | Auto on event PR merge | GitHub Environment `qa-node`    |
+| **QA-Node**    | Node.js VPS | Node.js   | Auto on push to `main`       | Auto on event PR merge | GitHub Environment `qanode`     |
 | **Production** | Loopia      | PHP       | Manual (`workflow_dispatch`) | Auto on event PR merge | GitHub Environment `production` |
 
 **Key rule:** code changes reach Production only when manually triggered.
@@ -91,7 +91,7 @@ file on the server is managed manually and contains the `GITHUB_*`,
 `ALLOWED_ORIGIN`, `QA_ORIGIN`, `COOKIE_DOMAIN`, and `BUILD_ENV` variables
 needed by the PHP API at runtime.
 
-### GitHub Environment: `qa-node` (Node.js host — preserved)
+### GitHub Environment: `qanode` (Node.js host — preserved)
 
 | Secret            | Purpose                                          |
 | ----------------- | ------------------------------------------------ |

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -825,7 +825,7 @@ Audit date: 2026-02-24. Last updated: 2026-02-25 (240 new tests — 75 requireme
 | `02-§44.30` | composer install --no-dev runs in CI or vendor/ included in archive | 04-OPERATIONS.md | manual: inspect workflow | deploy workflow | gap |
 | `02-§44.31` | .env on server managed manually, not in deploy archive | 04-OPERATIONS.md | manual: verify | — | implemented |
 | `02-§44.32` | API_URL points to PHP API path for PHP environments | 08-ENVIRONMENTS.md | manual: check GitHub Environment | GitHub Environment secrets | gap |
-| `02-§44.33` | Node.js API_URL format remains valid for Node.js environments | 08-ENVIRONMENTS.md | manual: check | GitHub Environment `qa-node` | implemented |
+| `02-§44.33` | Node.js API_URL format remains valid for Node.js environments | 08-ENVIRONMENTS.md | manual: check | GitHub Environment `qanode` | implemented |
 | `02-§44.34` | Node.js API unchanged | 03-ARCHITECTURE.md §21 | existing Node.js tests | `app.js`, `source/api/` | implemented |
 | `02-§44.35` | Local dev continues to use npm start | 04-OPERATIONS.md | manual: run locally | `app.js` | implemented |
 | `02-§44.36` | API backend choice determined by API_URL only | 03-ARCHITECTURE.md §21 | manual: inspect build | `source/build/render-add.js` | implemented |


### PR DESCRIPTION
## Summary
- Renames GitHub Environment reference from `qa-node` to `qanode` across workflow and all docs
- Aligns with the actual environment name configured in GitHub

## Test plan
- [x] All tests pass
- [x] Lint passes
- [ ] Trigger deploy-qa-node workflow after merge to verify secrets resolve from `qanode` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)