### PR TITLE
fix: use qanode environment in event-data-deploy

### DIFF
--- a/.github/workflows/event-data-deploy.yml
+++ b/.github/workflows/event-data-deploy.yml
@@ -166,7 +166,7 @@ jobs:
     name: Build & deploy to QA Node
     runs-on: ubuntu-latest
     needs: security-check
-    environment: qa-node
+    environment: qanode
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fixes `environment: qa-node` → `environment: qanode` in the event-data-deploy workflow
- This was missed in #126 — the full deploy workflow was updated but not the event data deploy

## Test plan
- [ ] Add or edit an event via the form and confirm the event-data-deploy workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)