### PR TITLE
fix: auto-deploy to qanode on push to main

### DIFF
--- a/.github/workflows/deploy-qa-node.yml
+++ b/.github/workflows/deploy-qa-node.yml
@@ -1,6 +1,11 @@
 name: Deploy to QA (Node.js)
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'source/data/**.yaml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Adds `push` trigger (matching `deploy-qa.yml`) to `deploy-qa-node.yml`
- Both QA environments now deploy automatically on push to `main`
- Manual `workflow_dispatch` still available

## Test plan
- [ ] Push to main triggers both deploy-qa and deploy-qa-node workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)