### PR TITLE
fix: deploy PHP API in reusable workflow, isolate qanode

### DIFF
--- a/.github/workflows/deploy-qa-node.yml
+++ b/.github/workflows/deploy-qa-node.yml
@@ -17,8 +17,86 @@ concurrency:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/deploy-reusable.yml
-    with:
-      environment: qanode
-      build_env: qa
-    secrets: inherit
+    name: Build & Deploy to qanode
+    runs-on: ubuntu-latest
+    environment: qanode
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          SITE_URL: ${{ secrets.SITE_URL }}
+          BUILD_ENV: qa
+
+      - name: Package site for upload
+        run: tar -czf site.tar.gz -C public .
+
+      - name: Upload site archive via SCP
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          source: site.tar.gz
+          target: ${{ secrets.DEPLOY_DIR }}
+
+      - name: Deploy static site
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          script: |
+            set -e
+            DEPLOY_DIR="${{ secrets.DEPLOY_DIR }}"
+            RELEASE_DIR="$DEPLOY_DIR/release_new"
+            PUBLIC_DIR="$DEPLOY_DIR/public_html"
+
+            # Clean up any previous failed deploy
+            rm -rf "$RELEASE_DIR" "$DEPLOY_DIR/public_html_old"
+
+            # Extract new release
+            mkdir -p "$RELEASE_DIR"
+            tar -xzf "$DEPLOY_DIR/site.tar.gz" -C "$RELEASE_DIR"
+            rm "$DEPLOY_DIR/site.tar.gz"
+
+            # Preserve hosting infrastructure
+            if [ -d "$PUBLIC_DIR/domains" ]; then
+              mv "$PUBLIC_DIR/domains" "$RELEASE_DIR/domains"
+            fi
+
+            # Swap (millisecond downtime)
+            mv "$PUBLIC_DIR" "$DEPLOY_DIR/public_html_old"
+            mv "$RELEASE_DIR" "$PUBLIC_DIR"
+
+            # Cleanup
+            rm -rf "$DEPLOY_DIR/public_html_old"
+
+      - name: Deploy Node.js API
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          script: |
+            cd /home/${{ secrets.SERVER_USER }}/nodeapps/sbsommar
+            git pull
+            npm install --production
+            mkdir -p tmp
+            touch tmp/restart.txt

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -53,8 +53,8 @@ jobs:
           source: site.tar.gz
           target: ${{ secrets.DEPLOY_DIR }}
 
-      # Zero-downtime swap: extract into staging dir, move hosting
-      # infrastructure (domains/) into it, then swap with two mv ops.
+      # Zero-downtime swap: extract into staging dir, back up the PHP API
+      # .env, then swap with two mv ops.
       # Stale dirs from previous failed deploys are cleaned first.
       - name: Deploy with zero-downtime swap
         uses: appleboy/ssh-action@v1.0.3
@@ -77,9 +77,9 @@ jobs:
             tar -xzf "$DEPLOY_DIR/site.tar.gz" -C "$RELEASE_DIR"
             rm "$DEPLOY_DIR/site.tar.gz"
 
-            # Preserve hosting infrastructure
-            if [ -d "$PUBLIC_DIR/domains" ]; then
-              mv "$PUBLIC_DIR/domains" "$RELEASE_DIR/domains"
+            # Preserve PHP API .env (server-managed, not in repo)
+            if [ -f "$PUBLIC_DIR/api/.env" ]; then
+              cp "$PUBLIC_DIR/api/.env" "$DEPLOY_DIR/.env.api.bak"
             fi
 
             # Swap (millisecond downtime)
@@ -89,7 +89,20 @@ jobs:
             # Cleanup
             rm -rf "$DEPLOY_DIR/public_html_old"
 
-      - name: Deploy API via SSH
+      - name: Package PHP API for upload
+        run: tar -czf api.tar.gz --exclude='.env' --exclude='.env.example' --exclude='vendor' -C api .
+
+      - name: Upload API archive via SCP
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          source: api.tar.gz
+          target: ${{ secrets.DEPLOY_DIR }}
+
+      - name: Deploy PHP API
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -97,8 +110,34 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.SERVER_SSH_PORT }}
           script: |
-            cd /home/${{ secrets.SERVER_USER }}/nodeapps/sbsommar
-            git pull
-            npm install --production
-            mkdir -p tmp
-            touch tmp/restart.txt
+            set -e
+            DEPLOY_DIR="${{ secrets.DEPLOY_DIR }}"
+            PUBLIC_DIR="$DEPLOY_DIR/public_html"
+            API_STAGING="$DEPLOY_DIR/api_new"
+
+            # Clean up any previous failed deploy
+            rm -rf "$API_STAGING"
+
+            # Extract new API files
+            mkdir -p "$API_STAGING"
+            tar -xzf "$DEPLOY_DIR/api.tar.gz" -C "$API_STAGING"
+            rm "$DEPLOY_DIR/api.tar.gz"
+
+            # Restore server-managed .env (backed up during static site swap)
+            if [ -f "$DEPLOY_DIR/.env.api.bak" ]; then
+              mv "$DEPLOY_DIR/.env.api.bak" "$API_STAGING/.env"
+            fi
+
+            # Install PHP dependencies
+            cd "$API_STAGING"
+            composer install --no-dev --no-interaction --optimize-autoloader
+
+            # Swap
+            rm -rf "$PUBLIC_DIR/api_old"
+            if [ -d "$PUBLIC_DIR/api" ]; then
+              mv "$PUBLIC_DIR/api" "$PUBLIC_DIR/api_old"
+            fi
+            mv "$API_STAGING" "$PUBLIC_DIR/api"
+
+            # Cleanup
+            rm -rf "$PUBLIC_DIR/api_old"

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -54,12 +54,18 @@ Production receives event data within minutes of the PR merging — no manual st
 | `ci.yml`                  | Every push and PR                                      | — (repo-level)       |
 | `deploy-qa.yml`           | Push to `main` (paths-ignore data YAMLs)               | `qa`                 |
 | `deploy-prod.yml`         | `workflow_dispatch` (manual)                            | `production`         |
+| `deploy-qa-node.yml`      | Push to `main` (paths-ignore data YAMLs)               | `qanode`             |
 | `event-data-deploy.yml`   | PR from `event/` or `event-edit/` changing data YAMLs  | `qa` + `production`  |
 
 `deploy-qa.yml` and `deploy-prod.yml` both call the shared reusable workflow
-`deploy-reusable.yml`, which contains the full build-and-deploy logic.
+`deploy-reusable.yml`, which builds the static site, deploys it via SCP,
+and deploys the PHP API (with `composer install` on the server).
 The only difference is the trigger and the GitHub Environment that provides
 the secrets.
+
+`deploy-qa-node.yml` is self-contained and does not use the reusable workflow.
+It builds and deploys the static site via SCP, then deploys the Node.js API
+separately (`git pull` + `npm install` + restart).
 
 ---
 
@@ -103,8 +109,8 @@ needed by the PHP API at runtime.
 | `SERVER_SSH_PORT` | QA SSH port                                      |
 | `DEPLOY_DIR`      | QA deploy directory                              |
 
-This environment preserves the original Node.js QA setup. It is not
-actively deployed but kept as a fallback.
+This environment powers the Node.js QA host. It auto-deploys on push
+to `main` via `deploy-qa-node.yml`.
 
 ### GitHub Environment: `production`
 


### PR DESCRIPTION
## Summary

- **deploy-reusable.yml** (QA + Prod): Replace Node.js API deploy with PHP API deployment — backs up `api/.env`, packages `api/` as tar, deploys via SCP with `composer install`, zero-downtime swap. Removes `domains/` preservation (Node.js concept, not relevant for Loopia).
- **deploy-qa-node.yml** (Node.js VPS): Inlines full pipeline instead of calling the reusable workflow — builds with `BUILD_ENV: qa`, deploys static site (preserving `domains/`), deploys Node.js API via `git pull` + `npm install` + restart.
- **docs/08-ENVIRONMENTS.md**: Adds `deploy-qa-node.yml` to workflows table, explains the reusable vs self-contained split, updates qanode description.

## Context

The reusable workflow was deploying a Node.js API step to PHP/Loopia environments (no-op at best, error at worst), while the PHP `api/` directory was never deployed — causing `POST /api/add-event` to 404 on QA.

## Test plan

- [ ] Merge and verify QA deploy succeeds (check GitHub Actions logs)
- [ ] Confirm `POST /api/add-event` returns 200 on QA (not 404)
- [ ] Confirm qanode auto-deploys independently on push to main
- [ ] First deploy requires manually creating `public_html/api/.env` on QA server

🤖 Generated with [Claude Code](https://claude.com/claude-code)