### PR TITLE
fix: tighten form field spacing on mobile

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1172,6 +1172,11 @@ body.modal-open {
   .event-row { padding: 5px var(--space-sm); }
   .event-extra { padding: 5px var(--space-sm) 8px; }
   .field-row { flex-direction: column; gap: 0; }
+
+  /* Tighter form spacing on mobile */
+  .intro { margin-bottom: var(--space-xs); }
+  .intro:last-of-type { margin-bottom: var(--space-md); }
+  .field { margin-bottom: var(--space-xs); }
 }
 
 /* ── Upcoming camps ── */


### PR DESCRIPTION
## Summary
- Reduce vertical whitespace between intro paragraphs and form fields on mobile (≤690px)
- `.intro` margin: 16px → 8px, `.intro:last-of-type`: 40px → 24px, `.field`: 16px → 8px
- Desktop layout unchanged

## Test plan
- [ ] Open /lagg-till.html on a mobile phone and verify less whitespace between fields
- [ ] Verify desktop form spacing is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)