### PR TITLE
fix: reset flex-basis on mobile form fields

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1172,6 +1172,7 @@ body.modal-open {
   .event-row { padding: 5px var(--space-sm); }
   .event-extra { padding: 5px var(--space-sm) 8px; }
   .field-row { flex-direction: column; gap: 0; }
+  .field-row .field { flex-basis: auto; }
 
   /* Tighter form spacing on mobile */
   .intro { margin-bottom: var(--space-xs); }


### PR DESCRIPTION
## Summary
- `.field-row .field` had `flex: 1 1 140px` — in mobile column layout this gave each field a 140px min-height, causing the large gaps visible between Datum/Starttid/Sluttid and Plats/Ansvarig
- Add `flex-basis: auto` override in the mobile media query

## Test plan
- [ ] Open /lagg-till.html on a phone — gaps between fields should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)