### PR TITLE
Add event data, favicon, and terracotta event times

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -485,7 +485,7 @@ details.event-row > summary:focus-visible {
 .ev-time {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-  color: var(--color-navy);
+  color: var(--color-terracotta);
   font-weight: 700;
   flex-shrink: 0;
 }

--- a/source/build/render-add.js
+++ b/source/build/render-add.js
@@ -31,6 +31,7 @@ function renderAddPage(camp, locations, apiUrl, footerHtml = '', navSections = [
   <meta name="robots" content="noindex, nofollow">
   <title>Lägg till aktivitet – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('lagg-till.html', navSections)}

--- a/source/build/render-arkiv.js
+++ b/source/build/render-arkiv.js
@@ -144,6 +144,7 @@ function renderArkivPage(allCamps, footerHtml = '', navSections = [], campEvents
   <meta name="robots" content="noindex, nofollow">
   <title>Arkiv – SB Sommar</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('arkiv.html', navSections)}

--- a/source/build/render-edit.js
+++ b/source/build/render-edit.js
@@ -39,6 +39,7 @@ function renderEditPage(camp, locations, apiUrl, footerHtml = '', navSections = 
   <meta name="robots" content="noindex, nofollow">
   <title>Redigera aktivitet – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('redigera.html', navSections)}

--- a/source/build/render-event.js
+++ b/source/build/render-event.js
@@ -43,6 +43,7 @@ function renderEventPage(event, camp, siteUrl, footerHtml = '', navSections = []
   <base href="../../">
   <title>${title} – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('schema.html', navSections)}

--- a/source/build/render-idag.js
+++ b/source/build/render-idag.js
@@ -32,6 +32,7 @@ function renderIdagPage(camp, events, footerHtml = '', navSections = []) {
   <meta name="robots" content="noindex, nofollow">
   <title>Idag – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('idag.html', navSections)}

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -168,6 +168,7 @@ function renderIndexPage({ heroSrc, heroAlt, sections, discordUrl, facebookUrl, 
   <meta name="robots" content="noindex, nofollow">
   <title>SB Sommar</title>
   <link rel="stylesheet" href="style.css">${preloadHtml}
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('index.html', navSections)}${heroHtml}

--- a/source/build/render-kalender.js
+++ b/source/build/render-kalender.js
@@ -25,6 +25,7 @@ function renderKalenderPage(camp, siteUrl, footerHtml = '', navSections = []) {
   <meta name="robots" content="noindex, nofollow">
   <title>Kalendersynk – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('kalender.html', navSections)}

--- a/source/build/render-today.js
+++ b/source/build/render-today.js
@@ -38,6 +38,7 @@ function renderTodayPage(camp, events, qrSvg, siteUrl = '', buildTime = '') {
   <meta name="robots" content="noindex, nofollow">
   <title>Dagens schema – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body class="display-mode">
 

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -119,6 +119,7 @@ function renderSchedulePage(camp, events, footerHtml = '', navSections = [], sit
   <meta name="robots" content="noindex, nofollow">
   <title>Schema – ${campName}</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
 ${pageNav('schema.html', navSections)}

--- a/source/data/2026-06-syssleback.yaml
+++ b/source/data/2026-06-syssleback.yaml
@@ -4,4 +4,289 @@ camp:
   location: Sysslebäck
   start_date: '2026-06-21'
   end_date: '2026-06-28'
-events: []
+events:
+- id: lunch-2026-06-22-1200
+  title: Lunch
+  date: '2026-06-22'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-23-1200
+  title: Lunch
+  date: '2026-06-23'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-24-1200
+  title: Lunch
+  date: '2026-06-24'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-25-1200
+  title: Lunch
+  date: '2026-06-25'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-26-1200
+  title: Lunch
+  date: '2026-06-26'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-27-1200
+  title: Lunch
+  date: '2026-06-27'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-22-1700
+  title: Middag
+  date: '2026-06-22'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-23-1700
+  title: Middag
+  date: '2026-06-23'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-24-1700
+  title: Middag
+  date: '2026-06-24'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-25-1700
+  title: Middag
+  date: '2026-06-25'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-26-1700
+  title: Middag
+  date: '2026-06-26'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-27-1700
+  title: Middag
+  date: '2026-06-27'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: valkommen-2026-06-21-1200
+  title: Välkommen
+  date: '2026-06-21'
+  start: '12:00'
+  end: '23:30'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: glass-pa-chokladfabriken-2026-06-28-1200
+  title: Glass på chokladfabriken
+  date: '2026-06-28'
+  start: '12:00'
+  end: '15:00'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: valkomstmote-2026-06-22-1000
+  title: Välkomstmöte
+  date: '2026-06-22'
+  start: '10:00'
+  end: '10:30'
+  location: GA Idrott
+  responsible: Andreas (Lägernissen)
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: avslutningsmote-alla-deltar-2026-06-27-1800
+  title: Avslutningsmöte (alla deltar)
+  date: '2026-06-27'
+  start: '18:00'
+  end: '20:00'
+  location: Annat
+  responsible: Andreas (Lägernissen)
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: obs-alla-deltar-nya-lite-extra-rigga-talt-och-stalla-i-ordning-ga-hall-2026-06-21-1800
+  title: (OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall
+  date: '2026-06-21'
+  start: '18:00'
+  end: '20:30'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: middag-2026-06-21-1700
+  title: Middag
+  date: '2026-06-21'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'
+- id: lunch-2026-06-28-1200
+  title: Lunch
+  date: '2026-06-28'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:12:59'
+    updated_at: '2026-02-27 09:12:59'

--- a/source/data/2026-07-syssleback.yaml
+++ b/source/data/2026-07-syssleback.yaml
@@ -1,7 +1,292 @@
 camp:
-  id: 2026-08-syssleback
+  id: 2026-07-syssleback
   name: SB sommar 2026 juli
   location: Sysslebäck
   start_date: '2026-07-26'
   end_date: '2026-08-02'
-events: []
+events:
+- id: lunch-2026-07-27-1200
+  title: Lunch
+  date: '2026-07-27'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-07-28-1200
+  title: Lunch
+  date: '2026-07-28'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-07-29-1200
+  title: Lunch
+  date: '2026-07-29'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-07-30-1200
+  title: Lunch
+  date: '2026-07-30'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-07-31-1200
+  title: Lunch
+  date: '2026-07-31'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-08-01-1200
+  title: Lunch
+  date: '2026-08-01'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-27-1700
+  title: Middag
+  date: '2026-07-27'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-28-1700
+  title: Middag
+  date: '2026-07-28'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-29-1700
+  title: Middag
+  date: '2026-07-29'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-30-1700
+  title: Middag
+  date: '2026-07-30'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-31-1700
+  title: Middag
+  date: '2026-07-31'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-08-01-1700
+  title: Middag
+  date: '2026-08-01'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: välkommen-2026-07-26-1200
+  title: Välkommen
+  date: '2026-07-26'
+  start: '12:00'
+  end: '23:30'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: glass-på-chokladfabriken-2026-08-02-1200
+  title: Glass på chokladfabriken
+  date: '2026-08-02'
+  start: '12:00'
+  end: '15:00'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: välkomstmöte-2026-07-27-1000
+  title: Välkomstmöte
+  date: '2026-07-27'
+  start: '10:00'
+  end: '10:30'
+  location: GA Idrott
+  responsible: Andreas (Lägernissen)
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: avslutningsmöte-alla-deltar-2026-08-01-1800
+  title: Avslutningsmöte (alla deltar)
+  date: '2026-08-01'
+  start: '18:00'
+  end: '20:00'
+  location: Annat
+  responsible: Andreas (Lägernissen)
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2026-07-26-1800
+  title: (OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall
+  date: '2026-07-26'
+  start: '18:00'
+  end: '20:30'
+  location: Annat
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: middag-2026-07-26-1700
+  title: Middag
+  date: '2026-07-26'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'
+- id: lunch-2026-08-02-1200
+  title: Lunch
+  date: '2026-08-02'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: null
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: '2026-02-27 09:16:57'
+    updated_at: '2026-02-27 09:16:57'

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex, nofollow">
   <title>Schema – Test Camp 2025</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/webp" href="images/RFSBsommarLogo.webp">
 </head>
 <body>
   <nav class="page-nav" aria-label="Sidnavigation">


### PR DESCRIPTION
## Summary
- Add events for June and July 2026 camps (lunch, middag, välkomstmöte, avslutningsmöte, etc.)
- Add RFSBsommarLogo.webp as site favicon (browser tab icon) across all pages
- Change schedule event times (.ev-time) to terracotta color
- Update test snapshots to match

## Test plan
- [x] All 878 tests pass
- [x] Lint passes
- [ ] Verify favicon appears in browser tabs
- [ ] Verify event times display in terracotta on schema/idag pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)