### PR TITLE
fix: remove WORKDIR from Dockerfile to fix container job git commands

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,14 +1,12 @@
 FROM node:20
 
-WORKDIR /deps
-
 # Copy only package files to leverage Docker layer caching.
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json /deps/
 
 # Install production dependencies only (js-yaml, marked, qrcode).
-RUN npm ci --omit=dev
+RUN cd /deps && npm ci --omit=dev
 
 # Make installed modules visible from any working directory.
-# actions/checkout places the repo in /github/workspace (container default),
+# GitHub Actions container jobs run steps in the workspace directory,
 # so node_modules must be reachable via NODE_PATH.
 ENV NODE_PATH=/deps/node_modules


### PR DESCRIPTION
## Summary
- The `WORKDIR /deps` directive in the Dockerfile caused GitHub Actions container jobs to run all `run` steps from `/deps` instead of the checkout directory
- `git diff` in the detect job failed with "Not a git repository", causing `has_event_data=false` and all deploy jobs to be skipped
- Fix: remove `WORKDIR`, use absolute paths for build-time `COPY` and `npm ci` instead

## Root cause
PR #156 and #157 merged but did not deploy because the detect job's `git diff HEAD~1..HEAD` ran from `/deps` (not a git repo), so no YAML changes were detected and all three deploy jobs were skipped.

## Test plan
- [ ] CI passes
- [ ] Docker image rebuilds (triggered by Dockerfile change)
- [ ] Next event PR merge triggers post-merge deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)