### PR TITLE
fix: add git safe.directory for container detect job

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Detect changed event YAML file
         id: changed
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           CHANGED=$(git diff --name-only HEAD~1..HEAD \
             | grep '^source/data/' | grep '\.yaml$' \
             | grep -v 'camps\.yaml' | grep -v 'local\.yaml' | head -1)


### PR DESCRIPTION
## Summary
- In container jobs, `actions/checkout` sets `safe.directory` in a temporary HOME dir
- Subsequent `run` steps use the container's actual HOME (`/github/home`), which lacks the safe.directory config
- `git diff` fails with "Not a git repository" (misleading error for safe.directory ownership check)
- Fix: explicitly set `safe.directory` before running `git diff`

## Root cause
PR #158 fixed the WORKDIR issue but the real problem was git's safe.directory check. The checkout action writes to a temp gitconfig that run steps cannot see.

## Test plan
- [ ] CI passes
- [ ] Re-run post-merge workflow detects YAML changes correctly
- [ ] Deploy jobs run instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)