### PR TITLE
ci: replace SCP with rsync in QA deploy job

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -7,7 +7,7 @@ name: Event Data Deploy (Post-Merge)
 # Each job performs its own inline detection of changed event data files.
 #
 # Jobs:
-#   1. deploy-qa      – detect inline + build + SCP to QA
+#   1. deploy-qa      – detect inline + build + rsync to QA
 #   2. deploy-qa-node – detect inline + build + SCP to QA Node
 #   3. deploy-prod    – detect inline + QA check + build + SCP to Production
 
@@ -83,17 +83,16 @@ jobs:
             done
           fi
 
-      - name: Upload event data pages via SCP
+      - name: Upload event data pages via rsync
         if: steps.gate.outputs.skip != 'true'
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.SERVER_SSH_KEY }}
-          port: ${{ secrets.SERVER_SSH_PORT }}
-          source: staging/*
-          target: ${{ secrets.DEPLOY_DIR }}/public_html
-          strip_components: 1
+        run: |
+          install -m 600 /dev/null deploy_key
+          echo "${{ secrets.SERVER_SSH_KEY }}" > deploy_key
+          rsync -avz --delete \
+            -e "ssh -p ${{ secrets.SERVER_SSH_PORT }} -o StrictHostKeyChecking=no -i deploy_key" \
+            staging/ \
+            ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:${{ secrets.DEPLOY_DIR }}/public_html/
+          rm -f deploy_key
 
   deploy-qa-node:
     name: Build & deploy to QA Node


### PR DESCRIPTION
## Summary
- Replace `appleboy/scp-action@v1` with an inline `rsync -avz --delete` step in the QA deploy job
- SSH key written to file with `install -m 600`, removed after rsync completes
- QA Node and Production jobs unchanged — testing rsync on QA first

## Context
QA deploy currently takes ~17s total, ~10s of which is the SCP step. rsync should be faster for incremental deploys since it only transfers changed files.

## Test plan
- [ ] Trigger a test event via API after merge
- [ ] Compare total workflow time and deploy step time against PR #166 baseline (QA: 17s, SCP: 10s)
- [ ] Verify deployed files are correct on QA server

🤖 Generated with [Claude Code](https://claude.com/claude-code)