### PR TITLE
fix: remove --delete from rsync QA deploy

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           install -m 600 /dev/null deploy_key
           echo "${{ secrets.SERVER_SSH_KEY }}" > deploy_key
-          rsync -avz --delete \
+          rsync -avz \
             -e "ssh -p ${{ secrets.SERVER_SSH_PORT }} -o StrictHostKeyChecking=no -i deploy_key" \
             staging/ \
             ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:${{ secrets.DEPLOY_DIR }}/public_html/


### PR DESCRIPTION
## Summary
- Remove `--delete` flag from rsync in QA deploy job
- The staging directory only contains event data pages — `--delete` wipes the rest of `public_html/`

## Test plan
- [ ] Trigger test event via API after merge
- [ ] Verify all site files remain intact on QA server

🤖 Generated with [Claude Code](https://claude.com/claude-code)