### PR TITLE
fix: move health check from / to /api/health

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,8 +43,8 @@ app.use((req, res, next) => {
 
 // ── Routes ───────────────────────────────────────────────────────────────────
 
-// Health check
-app.get('/', (req, res) => {
+// Health check (on /api/health so that / serves index.html via express.static)
+app.get('/api/health', (req, res) => {
   res.json({ status: 'API running' });
 });
 


### PR DESCRIPTION
## Summary
- `GET /` returned `{"status":"API running"}` instead of serving `public/index.html`
- Move health check to `GET /api/health` so `express.static` handles `/` correctly
- `npm start` → `http://localhost:3000` now shows the site

## Test plan
- [ ] `npm start` → open `http://localhost:3000` → see index.html
- [ ] `curl http://localhost:3000/api/health` → `{"status":"API running"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)