### PR TITLE
fix: apply midnight-crossing validation to PHP API

### DIFF
--- a/api/src/Validate.php
+++ b/api/src/Validate.php
@@ -116,8 +116,17 @@ final class Validate
         if (!preg_match(self::TIME_RE, $end)) {
             return self::fail('end måste vara HH:MM');
         }
-        if ($end <= $start) {
+        if ($end === $start) {
             return self::fail('end måste vara efter start');
+        }
+        if ($end < $start) {
+            // Midnight crossing: allow if duration ≤ 17 h (1020 min), reject otherwise.
+            $sMins = (int) substr($start, 0, 2) * 60 + (int) substr($start, 3, 2);
+            $eMins = (int) substr($end, 0, 2) * 60 + (int) substr($end, 3, 2);
+            $dur   = (1440 - $sMins) + $eMins;
+            if ($dur > 1020) {
+                return self::fail('end måste vara efter start');
+            }
         }
         if ($location === '') {
             return self::fail('location är obligatoriskt');


### PR DESCRIPTION
## Summary
- PHP `Validate.php` was not updated in the original midnight-crossing PR (#178)
- Events crossing midnight were accepted client-side but rejected by the production PHP API with "end måste vara efter start"
- Applied the same 17-hour threshold logic to `Validate.php` line 119

## Test plan
- [ ] `npm test` passes (968 tests, 0 failures)
- [ ] Submit an event with start=23:00, end=00:30 via the live form — accepted by server

🤖 Generated with [Claude Code](https://claude.com/claude-code)