### PR TITLE
data: backfill descriptions and links from legacy CSV

### DIFF
--- a/source/data/2022-06-syssleback.yaml
+++ b/source/data/2022-06-syssleback.yaml
@@ -12,7 +12,10 @@ events:
     end: '23:30'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+
+      Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt.
     link: null
     owner:
       name: ''
@@ -27,7 +30,11 @@ events:
     end: '11:15'
     location: Annat
     responsible: Andreas
-    description: null
+    description: |-
+      Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
+
+      Gräsytan mellan tälten och lekplatsen.
+      Vid dåligt väder, GA-hallen.
     link: null
     owner:
       name: ''
@@ -42,7 +49,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -57,7 +69,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -72,7 +89,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -87,7 +109,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -102,7 +129,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -117,7 +149,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -132,7 +169,12 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -147,7 +189,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -162,7 +209,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -177,7 +229,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -192,7 +249,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -207,7 +269,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -222,7 +289,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -237,7 +309,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -252,7 +324,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -267,7 +339,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -282,7 +354,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -297,7 +369,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -312,7 +384,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -327,7 +399,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -342,7 +414,24 @@ events:
     end: '20:00'
     location: Annat
     responsible: Andreas
-    description: null
+    description: |-
+      <strong>Möte:
+      </strong>Vi börjar med avetablering, alla hjälps åt!
+      När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.
+      Ofta en gemensam bild på alla deltagare.
+      <strong>
+      Avetablering:
+      </strong>Gemensam översyn på området med iordningställande och städ.
+      Alla tält packas ner.
+      All utrustning tas om hand.
+      Alla gemensamma ytor sopas.
+      Gräsytor utomhus gås igenom och skräp plockas upp.
+
+      Lost and found, vid ingång till GA-hallen.
+
+      Plats:
+      Gräsytan mellan tälten och lekplatsen.
+      Vid dåligt väder, GA-hallen.
     link: null
     owner:
       name: ''
@@ -357,7 +446,12 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: |-
+      Beställd mat hämtas vid servicehuset. Lunch och middagslådor levereras samtidigt till värmeskåpen. Maten levereras inför lunchen. Familjer väljer själva när dessa hämtas och äts.
+
+      Övriga fixar mat på egen hand.
+
+      Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -372,7 +466,11 @@ events:
     end: '15:45'
     location: Skolsal
     responsible: 'Lisa Lautrup '
-    description: null
+    description: |-
+      <p>Vi bakar Mochi Mochi donuts och lagar bobs-te efter Ai Venturas bok ”Baka Kawaii”. Barn under 10 år i vuxens sällskap. Max 9 st deltagare. Anmälan endast i Fb-gruppen.</p>
+      <p>OBS! Just nu är kursen fullbokad men om intresset är stort kan vi säkert köra fler tillfällen.</p>
+      <p>&nbsp;</p>
+      Kommer vara i hemkunskapssalen i skolan.
     link: null
     owner:
       name: ''
@@ -387,7 +485,9 @@ events:
     end: '15:00'
     location: Annat
     responsible: Birgitta
-    description: null
+    description: |-
+      <p>Studiebesök Höljes.</p>
+      <p>På plats i Höljes 15.00</p>
     link: null
     owner:
       name: ''
@@ -402,7 +502,7 @@ events:
     end: '15:45'
     location: Skolsal
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Vi bakar Mochi Mochi donuts och lagar boba-te efter Ai Venturas bok ”Baka kawaii”. Barn under 10 år i vuxens sällskap. Max 9 deltagare. Anmälan sker i Fb-gruppen.\_<br /><br /></p>\n<p>OBS! Kursen är just nu fullbokad men om intresset är stort kanske vi kan ordna fler tillfällen.</p>\nKommer vara i hemkunskapssal i skolan."
     link: null
     owner:
       name: ''
@@ -417,7 +517,7 @@ events:
     end: '15:00'
     location: Nerf-arena
     responsible: 'Rönnkvist '
-    description: null
+    description: "<p>Välkommen till årets qudditch match för mugglare. Medtag egen kvast (pinne, gren eller dylikt). Regelgenomgång och lagindelning sker på plats.\_</p>\n<p>Tänk på att ha kläder som tål rörelse och en vattenflaska.\_</p>"
     link: null
     owner:
       name: ''
@@ -426,13 +526,13 @@ events:
       created_at: '2022-06-23 21:44:08'
       updated_at: '2022-06-23 21:44:08'
   - id: rollspel-fm-viktor-2022-06-27-0900
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2022-06-27'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: "<p>Fullbokad<br />Deltagare: Ivar, Edgar, Elias, Anton och Simon.\_<br />Första gången kommer främst vara till för att göra karaktärer.<br />Paus för informationsmöte</p>"
     link: null
     owner:
       name: ''
@@ -447,7 +547,7 @@ events:
     end: '17:00'
     location: Nerf-arena
     responsible: 'Christina Johansson '
-    description: null
+    description: "<p>En omgång Bäst i test liknade tv-programmet. Vi samlas utanför GA-hallen och gör lagindelning på plats.\_</p>\n<br>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/735023300875823/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -462,7 +562,10 @@ events:
     end: '17:00'
     location: Annat
     responsible: J Nyh
-    description: null
+    description: |-
+      Årsmöte för RFSB (följt av årsmöte för lokalföreningen i Stockholm/Mälardalen), enligt tidigare utskickad inbjudan (som nytillkomna medlemmar inte fått, men ändå är välkomna till årsmötet).
+
+      I kaffetältet (vid stuga 6).
     link: null
     owner:
       name: ''
@@ -477,7 +580,7 @@ events:
     end: '12:30'
     location: Servicehus
     responsible: 'Jessica Malmberg '
-    description: null
+    description: "<p>Vi pärlar egna läger armband, bokstavspärlor RFSB och andra blandade pärlor.\_</p>\n<ol>\n<li>Ta gärna med eget glas eller tallrik att lägga lite pärlor på så att de i te rullar iväg när ni pärlar.\_</li>\n</ol>"
     link: null
     owner:
       name: ''
@@ -492,8 +595,17 @@ events:
     end: '10:15'
     location: Servicehus
     responsible: Cecilia Löfgreen
-    description: null
-    link: null
+    description: |-
+      <p><strong>Uppgifts-runda - Lära känna aktivitet kl 09:30-10:15</strong></p>
+      <p>&nbsp;</p>
+      <p>09:30-10:15 på måndag så kan alla barn gå en uppgifts-runda, mindre barn kan behöva vuxenstöd. Vi möts vid sittplatserna vid servicehusets kortsida.</p>
+      <p>&nbsp;</p>
+      <p>Det är drop-in och målsättningen är att alla som deltar ska få chansen att lära känna andra barn på lägret. Därför vill vi gärna blanda grupperna med barn som är på lägret första gången och barn som varit med förut. Ålder är bara en siffra, men vi kommer ändå försöka hålla vissa åldersspann på grupperna.</p>
+      <p>&nbsp;</p>
+      <p>Grupperna kommer vara 4-6 barn och man får vänta vid servicehuset tills man har hittat en grupp att gå med – oroa er inte, vi kommer hjälpa till och se till att alla som vill har en grupp att gå med.</p>
+      <p>&nbsp;</p>
+      <p>Alla som deltar får glass efter genomförd uppgiftsrunda.</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/739949180383235/
     owner:
       name: ''
       email: ''
@@ -507,7 +619,10 @@ events:
     end: '12:00'
     location: Rollspelstält2
     responsible: Hedda
-    description: null
+    description: |-
+      <blockquote>
+      <p>Aktiviteten är fullbokad. Deltagare på denna gång är Ines, Hulda, Albin, Alvin och Ludvig.</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -516,13 +631,15 @@ events:
       created_at: '2022-06-25 11:05:24'
       updated_at: '2022-06-25 11:05:24'
   - id: rollspel-minikampanj-2022-06-30-0900
-    title: 'Rollspel, minikampanj'
+    title: Rollspel, minikampanj
     date: '2022-06-30'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält2
     responsible: Hedda
-    description: null
+    description: |-
+      <p>Aktiviteten är fullbokad. Deltagare på denna gång är Xander, Louis, Tom, Thor och Sam.</p>
+      <p>Detta är första delen av kampanjen och det förväntas att deltagarna är med även på andra delen, som är dagen efter.</p>
     link: null
     owner:
       name: ''
@@ -531,13 +648,15 @@ events:
       created_at: '2022-06-25 11:13:27'
       updated_at: '2022-06-25 11:13:27'
   - id: rollspel-minikampanj-2022-07-01-0900
-    title: 'Rollspel, minikampanj'
+    title: Rollspel, minikampanj
     date: '2022-07-01'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält2
     responsible: Hedda
-    description: null
+    description: |-
+      <p>Aktiviteten är fullbokad. Deltagare på denna gång är Xander, Louis, Tom, Thor och Sam.</p>
+      <p>Detta är andra delen av kampanjen och det förväntas att deltagarna är med även på första delen, som är dagen före.</p>
     link: null
     owner:
       name: ''
@@ -546,13 +665,13 @@ events:
       created_at: '2022-06-25 11:16:24'
       updated_at: '2022-06-25 11:16:24'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-06-27-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-06-27'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad\_</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar Samuel, Jonathan, Salt och Emilia.</p>\n<p>Under första omgången kommer det finnas tid till att göra karaktärer.</p>\n<p>Lokal: Rollspelstält 1 och 2</p>"
     link: null
     owner:
       name: ''
@@ -561,13 +680,16 @@ events:
       created_at: '2022-06-25 15:48:52'
       updated_at: '2022-06-25 15:48:52'
   - id: rollspel-kvall-viktor-2022-06-27-1830
-    title: 'Rollspel kväll, Viktor'
+    title: Rollspel kväll, Viktor
     date: '2022-06-27'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Johan, Astor, Gabriel, Ebbe och Harry.</p>
+      <p>Under första omgången kommer det finnas tid till att göra karaktärer.</p>
     link: null
     owner:
       name: ''
@@ -582,7 +704,7 @@ events:
     end: '20:45'
     location: Annat
     responsible: Jenny och Viktor
-    description: null
+    description: "<p>Resa två partytält samt hämta alla bänkar och bord till dem.<strong>\_</strong>Plats: Mellan GA-hallen och lekplatsen.\_</p>"
     link: null
     owner:
       name: ''
@@ -591,13 +713,16 @@ events:
       created_at: '2022-06-25 16:10:27'
       updated_at: '2022-06-25 16:10:27'
   - id: rollspel-kvall-harald-2022-06-27-1830
-    title: 'Rollspel kväll, Harald'
+    title: Rollspel kväll, Harald
     date: '2022-06-27'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Harald
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Lo, Selma, Tova, Molle och Mida.</p>
+      <p>Under första omgången kommer det finnas tid för att göra karaktärer.</p>
     link: null
     owner:
       name: ''
@@ -612,7 +737,11 @@ events:
     end: '18:30'
     location: Annat
     responsible: Birgitta
-    description: null
+    description: |-
+      <p>För de som var med på måndagens studiebesök.</p>
+      Mer information kommer.
+      <br>
+      <a href="https://m.facebook.com/groups/639094320468722/permalink/734177770960376/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -627,7 +756,7 @@ events:
     end: '11:30'
     location: Tält1
     responsible: Malin Isenfors
-    description: null
+    description: "<p>Jag heter Malin och har en son som flyttat upp 3 år. Jag har också en dotter som sedan flyttat upp 2 år. Med den erfarenheten i bagaget har jag varit med vid flera skolmöten och hjälpt andra familjer få till uppflytt.</p>\n<ol>\n<li>Jag berättar och svarar på frågor, men hoppas framförallt att det ska bli en allmän diskussion.\_</li>\n</ol>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -642,7 +771,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Malin
-    description: null
+    description: "<p>Sugen på att piffa till dig lite extra? Kom och måla dina naglar vid servicehuset. Eller varför inte bli överraska dig själv genom att låta någon annan måla dina naglar? Alla hjälps åt.\_</p>"
     link: null
     owner:
       name: ''
@@ -657,7 +786,10 @@ events:
     end: '12:00'
     location: Skolsal
     responsible: Ivar Ängquist
-    description: null
+    description: |-
+      <p>Något av det roligaste jag vet är att lösa matematiska problem. För att dela denna gädje har jag sammanställt drygt ett dussin kluriga geometriproblem med en stor variation av olika svårhetsgrader. Jag har noggrant valt ut de problem jag tror är utmanande på ett rättvist sätt och ger de bästa "aha"-upplevelserna. Problemlösning innebär att det inte handlar om att kunna en specifik formel eller metod. Istället gäller det att hitta på en egen metod för varje problem. Jag rekommenderar workshopen för alla matteintresserade som går på eller har gått ut högstadiet. Även vuxna är varmt välkomna.</p>
+      <br>
+      <a href="https://www.facebook.com/groups/639094320468722/permalink/740051673706319/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -666,13 +798,13 @@ events:
       created_at: '2022-06-25 23:04:53'
       updated_at: '2022-06-25 23:04:53'
   - id: rollspel-kvall-viktor-2022-06-28-1830
-    title: 'Rollspel kväll, Viktor'
+    title: Rollspel kväll, Viktor
     date: '2022-06-28'
     start: '18:30'
     end: '21:00'
     location: Rollspelstält1
     responsible: 'Viktor '
-    description: null
+    description: "<p>Fullbokad\_</p>\n<p>Deltagare: Astor, Johan, Harry, Gabriel och Ebbe.</p>"
     link: null
     owner:
       name: ''
@@ -681,13 +813,13 @@ events:
       created_at: '2022-06-26 10:38:17'
       updated_at: '2022-06-26 10:38:17'
   - id: rollspel-kvall-harald-2022-06-28-1830
-    title: 'Rollspel kväll, Harald'
+    title: Rollspel kväll, Harald
     date: '2022-06-28'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Harald
-    description: null
+    description: "<p>Fullbokad\_</p>\n<p>Deltagare: Lo, Selma, Tova, Molle och Mida</p>"
     link: null
     owner:
       name: ''
@@ -702,7 +834,7 @@ events:
     end: '16:45'
     location: GA-hall
     responsible: 'Kalle Kalle@sandzen.se '
-    description: null
+    description: "<p>Prova stop motion i programmet Dragonframe. Jag (Kalle Sandzen, lektor i animation på Stockholms Konstnärliga Högskola) ställer upp en station för att animera teckningar eller modelllera. Kom och prova! Kommer bara använda ett hörn inomhus om någon vill ha andra aktiviteter samtidigt i skolsalen.\_</p>"
     link: null
     owner:
       name: ''
@@ -717,7 +849,7 @@ events:
     end: '19:30'
     location: Fotbollsplan
     responsible: 'Dillner '
-    description: null
+    description: <p>Fotboll för alla åldrar.</p>
     link: null
     owner:
       name: ''
@@ -732,7 +864,7 @@ events:
     end: '20:45'
     location: Annat
     responsible: Andreas
-    description: null
+    description: <p>Vi samlas utanför GA-hallen för att rigga lägret!</p>
     link: null
     owner:
       name: ''
@@ -747,8 +879,8 @@ events:
     end: '16:30'
     location: Tält1
     responsible: Ivar Ängquist
-    description: null
-    link: null
+    description: '<p class="p1" style="text-align: left"><span class="s1">När man räknar med modulo ligger talen på en cirkel istället för på en tallinje. Jag tänker gå igenom hur addition subtraktion, multiplikation, division och potenser fungerar på denna cirkel och visa hur man kan lösa några problem med detta matematiska verktyg. Lektionen kommer ha ett högt tempo, men kräver inga särskilda förkunskaper. Beroende på vilken tid och energi som finns kvar kan vi dyka ännu djupare i ämnet.</span></p>'
+    link: https://m.facebook.com/groups/639094320468722/permalink/740969193614567/?fs=0&amp;focus_composer=0&amp;m_entstream_source=group
     owner:
       name: ''
       email: ''
@@ -762,7 +894,14 @@ events:
     end: '11:45'
     location: Datorsal
     responsible: Niclas Nilsson och Johan Sommerfeld
-    description: null
+    description: |-
+      <p class="p1">Spelarna:<br /><br />Under uppstartsmötet kommer spelarna att få bestämma:</p>
+      <ul class="ul1">
+      <li class="li1">Om ni skall köra en ny värld eller bygga vidare i förra årets värld.</li>
+      <li class="li1">Vilka inställningar som skall gälla på servern.</li>
+      </ul>
+      <p class="p1">Er uppgift är att tänka på att så många som möjligt skall trivas. En del är hardcore minecrafters, andra är casual players. En del kanske kommer sitta många timmar varje dag, andra kommer spela när de har en lucka mellan andra aktiviteter. Det är viktigt att ni ser till helheten och inte bara till personliga preferenser. Ha också tekniskt strul för andra i åtanke om det blir tal om mods. Vi vill att det skall flyta på så bra som möjligt och att alla skall ha kul.</p>
+      <p class="p1">Föräldrarna:<br /><br />Föräldrarna kommer i sin tur att få komma överens om vuxenschemat i datasalen. Datasalen kommer bara vara öppen när det finns en vuxen där och ni bestämmer tillsammans öppettider. Den vuxnes uppgift är inte att vara teknisk support (om den inte råkar vilja/kunna), utan att ha koll på om något barn verkar bli plötsligt ledsen eller upprörd och då ta reda på vad som hänt, och eventuellt hjälpa till att reda ut problemet med de andra spelarna. Man kan som vuxen inte sitta och slösurfa utan ens jobb är att ha koll på barnens välmående, då detta är mycket viktiga och känslomässiga saker för många.</p>
     link: null
     owner:
       name: ''
@@ -793,7 +932,7 @@ events:
     location: Tält2
     responsible: 'Christina '
     description: null
-    link: null
+    link: https://m.facebook.com/groups/639094320468722/permalink/735023300875823/
     owner:
       name: ''
       email: ''
@@ -807,8 +946,8 @@ events:
     end: '15:00'
     location: GA-hall
     responsible: 'Lotta Jonsson '
-    description: null
-    link: null
+    description: "<p class=\"p1\">\_</p>\n<p class=\"p1\">Hej!\_</p>\n<p>Från 13:30 finns det möjlighet att bygga med Lego o GA hallen. Möjlighet finns att prova Lego stop motion för den som vill. Lasse visar gärna lite grunder. \_</p>\n<p class=\"p1\">Det finns Lego satser (Classic, City och Friends) att använda.\_</p>\n<p class=\"p1\"><span class=\"s1\">Bygget man gör kan bli en scen till en stopmotion film eller vad som helst. </span></p>\n<p class=\"p1\"><span class=\"s1\">Det går bra att ta med sitt eget Lego om man vill.</span></p>\n<p class=\"p1\"><span class=\"s1\">Det kommer finnas snickrade ställ för mobilen att använda vid filmning. Lasse kan visa grunderna hur man gör. </span></p>\n<p class=\"p1\"><span class=\"s1\">Appen Stop Motion studios (den blå gratis versionen funkar) är att rekommendera att man laddar ner.</span></p>\n<p class=\"p1\"><span class=\"s1\">Regler:<br /></span></p>\n<ul>\n<li class=\"p1\"><span class=\"s1\">Öppna lådor försiktigt. Vi förvarar i dessa så länge det går. <br /></span></li>\n<li class=\"p1\"><span class=\"s1\">Blanda inte bitar förutom Classic som är till för att blanda. (Får se hur det blir om denna regel ändras men kul att hålla satserna intakta ett tag). </span></li>\n<li class=\"p1\"><span class=\"s1\">Bygg själv eller tillsammans. Bjud gärna in varandra.</span></li>\n<li><span class=\"s1\"><span class=\"s1\">Lägg lapp med namnet på om du vill komma tillbaka senare.\_<br /></span></span>Håll inte Legot längre än du behöver så fler kan bygga samma legosats.</li>\n</ul>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741321473579339/
     owner:
       name: ''
       email: ''
@@ -822,7 +961,7 @@ events:
     end: '16:30'
     location: Skolsal
     responsible: 'Leigh Jamison, psykolog '
-    description: null
+    description: <p>Översikt över särskild begåvning i Sverige - praxis, forskning, vården, skola</p>
     link: null
     owner:
       name: ''
@@ -837,7 +976,7 @@ events:
     end: '16:30'
     location: Skolsal
     responsible: Leigh Jamison
-    description: null
+    description: <p>Föreläsning, tema bestäms vid onsdagsföreläsningen!</p>
     link: null
     owner:
       name: ''
@@ -852,7 +991,12 @@ events:
     end: '13:00'
     location: Annat
     responsible: Pia Olsson
-    description: null
+    description: |-
+      <p>Discgolf i Branäs.</p>
+      <p>Kommer att tillbringa heldag där men börjar med discgolf. Enligt Branäs-hemsidan och appen UDisc så är det en 9-hålsbana. Spelade 2 rundor där förra året.</p>
+      <p>Stannar kvar och grillar efteråt och cyklar MTB.</p>
+      <p>Det går att hyra frisbees i Branäs enligt hemsidan om man inte har egna själv.</p>
+      <p>Har frisbees i min bil och visar gärna grunderna om någon är intresserad att testa innan.</p>
     link: null
     owner:
       name: ''
@@ -866,8 +1010,11 @@ events:
     start: '13:00'
     end: '15:00'
     location: Datorsal
-    responsible: 'Christoffer Modée, Gustav Kalander'
-    description: null
+    responsible: Christoffer Modée, Gustav Kalander
+    description: |-
+      <p>Introduktionskurs i programmering med Python. Rekommenderas till dig som provat lite programmering tidigare, dig som är lite rostig eller dig som bara är nyfiken och vill prova på. Den passar också utmärkt för dig som vill förbereda dig för den AI-workshop som kommer anordnas senare under veckan.</p>
+      <br>
+      <a href="https://www.facebook.com/groups/639094320468722/permalink/740192703692216">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -882,7 +1029,19 @@ events:
     end: '20:30'
     location: Tält1
     responsible: Jenny vB
-    description: null
+    description: |-
+      <p>Gruppdiskussion där vi delar med oss av tips och erfarenheter kring särbegåvning och högskolestudier. Frågor att diskutera:</p>
+      <p>- Läsa i snabbare tempo på högskolan, kan man tenta av hela kurser, läsa dubbelt osv?</p>
+      <p>- Komma in på olika högskoleutbildningar på högskolan i Sverige och utomlands (tex USA)</p>
+      <p>- Bästa högskolestudierna för särbegåvade (upplägg, tempo)?</p>
+      <p>- Distansstudier, online studier. Bästa valen och hur gör man?</p>
+      <p>- Publicera egna papers. Hur gör man? Vad krävs?</p>
+      <p>- Börja högskolestudier parallellt med gymnasiet. Hur gör man?</p>
+      <p>- Finns det fallgropar att undvika?</p>
+      <p>- Andra frågeställningar som har med särbegåvning och högskolestudier att göra.</p>
+      <p>Särskilt välkomnas alla äldre ungdomar, föräldrar till äldre ungdomar samt personer som har koll på högskolan av andra skäl.</p>
+      <br>
+      <a href="https://www.facebook.com/groups/639094320468722/permalink/741470240231129/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -897,7 +1056,7 @@ events:
     end: '20:00'
     location: Skolsal
     responsible: Cecilia Pakravan
-    description: null
+    description: <a href="https://www.facebook.com/groups/639094320468722/permalink/741480866896733/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -912,7 +1071,7 @@ events:
     end: '20:00'
     location: Skolsal
     responsible: Cecilia Pakravan
-    description: null
+    description: <a href="https://www.facebook.com/groups/639094320468722/permalink/741480866896733/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -927,8 +1086,8 @@ events:
     end: '11:00'
     location: Skolsal
     responsible: 'Leija /Charlotte Anderberg '
-    description: null
-    link: null
+    description: "<p>Hej!\_</p>\n<p>Älskar du liksom jag musik och att sjunga? Med inspiration från filmen Pitch perfect och de låtarna undrar jag om det finns några som skulle tycka att det var roligt att under lägret tillsammans öva in fyra låtar från filmen? Målet är en mini-konsert i slutet av veckan.\_</p>\n<p>Från ca. 8 år.</p>\n<p>Jag har med mig låttexter.\_</p>\n<p>Vi började öva lite under måndagen men det är inte för sent om fler vill hänga på.\_</p>\n<p>Vi sjunger 10-11 varje dag, med reservation för justeringar.\_</p>\n<p>/Leija 10 år</p>\n<p>&nbsp;</p>"
+    link: https://m.facebook.com/groups/639094320468722/permalink/738396160538537/
     owner:
       name: ''
       email: ''
@@ -942,7 +1101,7 @@ events:
     end: '11:00'
     location: Skolsal
     responsible: 'Leija/ Lotta Anderberg '
-    description: null
+    description: "<p>Hej!\_</p>\n<p>Älskar du liksom jag musik och att sjunga? Med inspiration från filmen Pitch perfect och de låtarna undrar jag om det finns några som skulle tycka att det var roligt att under lägret tillsammans öva in fyra låtar från filmen? Målet är en mini-konsert i slutet av veckan.\_</p>\n<p>Från ca. 8 år.</p>\n<p>Jag har med mig låttexter.\_</p>\n<p>Vi började öva lite under måndagen men det är inte för sent om fler vill hänga på.\_</p>\n<p>Vi sjunger 10-11 varje dag, med reservation för justeringar.\_</p>\n<p>/Leija 10 år</p>\n<br>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/738396160538537/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -957,7 +1116,7 @@ events:
     end: '11:00'
     location: Skolsal
     responsible: 'Leija, Lotta Anderberg '
-    description: null
+    description: "<p>Hej!\_</p>\n<p>&nbsp;</p>\n<p>Älskar du liksom jag musik och att sjunga? Med inspiration från filmen Pitch perfect och de låtarna undrar jag om det finns några som skulle tycka att det var roligt att under lägret tillsammans öva in fyra låtar från filmen? Målet är en mini-konsert i slutet av veckan.\_</p>\n<p>&nbsp;</p>\n<p>Från ca. 8 år.</p>\n<p>Jag har med mig låttexter.\_</p>\n<p>Vi sjunger 10-11 varje dag, med reservation för justeringar.\_</p>\n<p>/Leija 10 år</p>\n<br>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/738396160538537/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -972,7 +1131,7 @@ events:
     end: '11:00'
     location: Skolsal
     responsible: 'Leija, Lotta Anderberg '
-    description: null
+    description: "<p>Hej!\_</p>\n<p>Älskar du liksom jag musik och att sjunga? Med inspiration från filmen Pitch perfect och de låtarna undrar jag om det finns några som skulle tycka att det var roligt att under lägret tillsammans öva in fyra låtar från filmen? Målet är en mini-konsert i slutet av veckan.\_</p>\n<p>Från ca. 8 år.</p>\n<p>Jag har med mig låttexter.</p>\n<p>Vi sjunger 10-11 varje dag, med reservation för justeringar.\_</p>\n<p>/Leija 10 år</p>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/738396160538537/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -987,7 +1146,10 @@ events:
     end: '15:00'
     location: Tält1
     responsible: 'Mohammed '
-    description: null
+    description: |-
+      <p>Teckenspråk enkla tecken</p>
+      <br>
+      <a href="https://www.facebook.com/groups/639094320468722/permalink/741558740222279/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -1002,8 +1164,8 @@ events:
     end: '10:30'
     location: Tält1
     responsible: 'Malin Isenfors '
-    description: null
-    link: null
+    description: "<p>Liten träff för alla oss som spelar Pokemon Go, så vi får se varandra och kan bli vänner i spelet.\_</p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/740821633629323/
     owner:
       name: ''
       email: ''
@@ -1017,7 +1179,11 @@ events:
     end: '15:00'
     location: Annat
     responsible: Eget ansvar
-    description: null
+    description: |-
+      Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.<br>
+      Det finns parkering för de som vill vara redo för "hemfärd".<br>
+      Annars är det en lagom promenad på vägen bakom receptionen.<br>
+      Tiden är för det brukar vara lite "drop-in".
     link: null
     owner:
       name: ''
@@ -1032,7 +1198,7 @@ events:
     end: '16:30'
     location: Fritidsgård
     responsible: Daniel och Björn
-    description: null
+    description: "<p>Prova på att klättra på klättervägg. Lilla gympahallen som är uppe på skolan Kvistbergsvägen 30.\_ Alla åldrar välkomna.</p>"
     link: null
     owner:
       name: ''
@@ -1041,13 +1207,13 @@ events:
       created_at: '2022-06-27 22:44:27'
       updated_at: '2022-06-27 22:44:27'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-06-28-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-06-28'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar, Samuel, Jonathan, Salt och Emilia.\_</p>"
     link: null
     owner:
       name: ''
@@ -1056,13 +1222,13 @@ events:
       created_at: '2022-06-28 00:18:28'
       updated_at: '2022-06-28 00:18:28'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-06-29-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-06-29'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar, Samuel, Jonathan, Salt och Emilia.\_</p>"
     link: null
     owner:
       name: ''
@@ -1071,13 +1237,13 @@ events:
       created_at: '2022-06-28 00:18:28'
       updated_at: '2022-06-28 00:18:28'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-06-30-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-06-30'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar, Samuel, Jonathan, Salt och Emilia.\_</p>"
     link: null
     owner:
       name: ''
@@ -1086,13 +1252,13 @@ events:
       created_at: '2022-06-28 00:18:28'
       updated_at: '2022-06-28 00:18:28'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-07-01-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-07-01'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar, Samuel, Jonathan, Salt och Emilia.\_</p>"
     link: null
     owner:
       name: ''
@@ -1101,13 +1267,13 @@ events:
       created_at: '2022-06-28 00:18:28'
       updated_at: '2022-06-28 00:18:28'
   - id: rollspel-stor-grupp-viktor-och-harald-2022-07-02-1330
-    title: 'Rollspel, stor grupp, Viktor och Harald'
+    title: Rollspel, stor grupp, Viktor och Harald
     date: '2022-07-02'
     start: '13:30'
     end: '17:00'
     location: Rollspelstält1
     responsible: Viktor och Harald
-    description: null
+    description: "<p>Fullbokad</p>\n<p>Deltagare: Tekla, Nemi, Wille, Hedda, Vidar, Samuel, Jonathan, Salt och Emilia.\_</p>"
     link: null
     owner:
       name: ''
@@ -1116,13 +1282,13 @@ events:
       created_at: '2022-06-28 00:18:28'
       updated_at: '2022-06-28 00:18:28'
   - id: rollspel-kvall-harald-2022-06-30-1830
-    title: 'Rollspel kväll, Harald'
+    title: Rollspel kväll, Harald
     date: '2022-06-30'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Harald
-    description: null
+    description: "<p>Fullbokad\_</p>\n<p>Deltagare: Lo, Selma, Tova, Molle och Mida</p>"
     link: null
     owner:
       name: ''
@@ -1131,13 +1297,13 @@ events:
       created_at: '2022-06-28 00:21:15'
       updated_at: '2022-06-28 00:21:15'
   - id: rollspel-kvall-harald-2022-07-01-1830
-    title: 'Rollspel kväll, Harald'
+    title: Rollspel kväll, Harald
     date: '2022-07-01'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Harald
-    description: null
+    description: "<p>Fullbokad\_</p>\n<p>Deltagare: Lo, Selma, Tova, Molle och Mida</p>"
     link: null
     owner:
       name: ''
@@ -1146,13 +1312,15 @@ events:
       created_at: '2022-06-28 00:21:15'
       updated_at: '2022-06-28 00:21:15'
   - id: rollspel-fm-viktor-2022-06-28-0900
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2022-06-28'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Ivar, Edgar, Elias, Anton och Simon.<!--more--></p>
     link: null
     owner:
       name: ''
@@ -1161,13 +1329,15 @@ events:
       created_at: '2022-06-28 00:21:54'
       updated_at: '2022-06-28 00:21:54'
   - id: rollspel-fm-viktor-2022-06-29-0900
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2022-06-29'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Ivar, Edgar, Elias, Anton och Simon.<!--more--></p>
     link: null
     owner:
       name: ''
@@ -1176,13 +1346,13 @@ events:
       created_at: '2022-06-28 00:21:54'
       updated_at: '2022-06-28 00:21:54'
   - id: rollspel-kvall-viktor-2022-06-30-1830
-    title: 'Rollspel kväll, Viktor'
+    title: Rollspel kväll, Viktor
     date: '2022-06-30'
     start: '18:30'
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: "<p>&nbsp;</p>\n<p>Fullbokad\_</p>\n<p>Deltagare: Astor, Johan, Harry, Gabriel och Ebbe.</p>"
     link: null
     owner:
       name: ''
@@ -1191,13 +1361,13 @@ events:
       created_at: '2022-06-28 00:22:27'
       updated_at: '2022-06-28 00:22:27'
   - id: rollspel-kvall-viktor-2022-07-01-1830
-    title: 'Rollspel kväll, Viktor'
+    title: Rollspel kväll, Viktor
     date: '2022-07-01'
     start: '18:30'
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: "<p>&nbsp;</p>\n<p>Fullbokad\_</p>\n<p>Deltagare: Astor, Johan, Harry, Gabriel och Ebbe.</p>"
     link: null
     owner:
       name: ''
@@ -1206,13 +1376,15 @@ events:
       created_at: '2022-06-28 00:22:27'
       updated_at: '2022-06-28 00:22:27'
   - id: rollspel-fm-viktor-2022-07-01-0900
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2022-07-01'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Ivar, Edgar, Elias, Anton och Simon.</p>
     link: null
     owner:
       name: ''
@@ -1221,13 +1393,15 @@ events:
       created_at: '2022-06-28 00:22:56'
       updated_at: '2022-06-28 00:22:56'
   - id: rollspel-fm-viktor-2022-07-02-0900
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2022-07-02'
     start: '09:00'
     end: '12:00'
     location: Rollspelstält1
     responsible: Viktor
-    description: null
+    description: |-
+      <p>Fullbokad</p>
+      <p>Deltagare: Ivar, Edgar, Elias, Anton och Simon.</p>
     link: null
     owner:
       name: ''
@@ -1242,7 +1416,10 @@ events:
     end: '17:00'
     location: GA-hall
     responsible: 'Petra Hultman '
-    description: null
+    description: |-
+      <p>Vi har med oss papper och pennor som vi placerar i sporthallen för alla. För de som vill kan jag hålla i lite kollektiva ritaktiviteter för alla åldrar. I morgon Tisdag vid 16 finns jag på plats med lite övningar. Om ni vill vara med så ta med ett föremål som ryms i handflatan!</p>
+      <br>
+      <a href="https://www.facebook.com/groups/639094320468722/permalink/741584896886330/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -1257,7 +1434,7 @@ events:
     end: '20:30'
     location: GA-hall
     responsible: Christina Falk
-    description: null
+    description: "<p>Schackintresserade träffas och spelar. Ta gärna med schackbräden, de som har.\_<br />Om fler vill kan vi planera in en schackturnering.\_</p>\n<br>\n<a href=\"https://www.facebook.com/groups/639094320468722/permalink/741514133560073/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -1272,7 +1449,7 @@ events:
     end: '11:00'
     location: Annat
     responsible: Cecilia P och Cecilia L
-    description: null
+    description: <a href="https://www.facebook.com/groups/639094320468722/permalink/741849993526487/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -1281,14 +1458,14 @@ events:
       created_at: '2022-06-28 09:06:03'
       updated_at: '2022-06-28 09:06:03'
   - id: foraldrafika-hemmasittare-livspusslet-och-vagen-tillbaka-kaffetaltet-bredvid-stuga-6-2022-07-01-1000
-    title: 'Föräldrafika – Hemmasittare, livspusslet och vägen tillbaka (Kaffetältet, bredvid stuga 6)'
+    title: Föräldrafika – Hemmasittare, livspusslet och vägen tillbaka (Kaffetältet, bredvid stuga 6)
     date: '2022-07-01'
     start: '10:00'
     end: '11:00'
     location: Annat
     responsible: Cecilia och Cecilia
     description: null
-    link: null
+    link: https://Skicka%20i%20Messenger%20https://www.facebook.com/groups/639094320468722/permalink/741849656859854/
     owner:
       name: ''
       email: ''
@@ -1302,7 +1479,7 @@ events:
     end: '11:00'
     location: Tält1
     responsible: Cecilia och Cecilia
-    description: null
+    description: <a href="https://www.facebook.com/groups/639094320468722/permalink/741849196859900/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -1317,7 +1494,7 @@ events:
     end: '11:00'
     location: Annat
     responsible: Cecilia och Cecilia mfl
-    description: null
+    description: <a href="https://www.facebook.com/groups/639094320468722/permalink/741846076860212/">FB-tråd</a>
     link: null
     owner:
       name: ''
@@ -1332,7 +1509,7 @@ events:
     end: '21:30'
     location: Fritidsgård
     responsible: Tilde ( Karin )
-    description: null
+    description: "<p><strong>En lugn stund att teckna tillsammans.\_</strong></p>\n<p dir=\"ltr\">✏️📋 anmälan behövs. (Vet hur många när jag vet lokal).</p>\n<p dir=\"ltr\">Vi har olika papper, blyerts i olika mjukhet, lite kol, stompf, akvarellfärg och några penslar, färgpennor av olika slag (ej alkoholiserade men ta gärna med om du har)</p>\n<p dir=\"ltr\">Om du har egna saker du vill använda så ta med dem. <br />Tecknat du digitalt på platta så ta med det.</p>\n<p dir=\"ltr\">Lillasyster Linn 13 år är också med.</p>\n<br>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/741895436855276/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -1347,7 +1524,7 @@ events:
     end: '12:00'
     location: Tält1
     responsible: 'Linda Backman '
-    description: null
+    description: "<p>Föreläsning/diskussion/seminarium. Stort fokus på era funderingar.\_</p>\n<br>\n<a href=\"https://m.facebook.com/groups/639094320468722/permalink/741870253524461/\">FB-tråd</a>"
     link: null
     owner:
       name: ''
@@ -1362,7 +1539,7 @@ events:
     end: '19:00'
     location: Annat
     responsible: Niclas Nilsson
-    description: null
+    description: "<p class=\"p1\">Alla musikintresserade som gillar och vill spela/sjunga tillsammans kan ta med sig instrument/röst så spelar vi ihop, lär varandra saker, testar lite låtar tillsammans och helt enkelt jammar och har kul.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\">Samling <strong>under björkarna vid lekplatsen</strong> vid bra väder, och längs bort i korridoren i GA-hallen om det är mindre bra väder.</p>\n<p class=\"p1\">Repeteras varje eftermiddag 16:00-17:00 (förutom idag tisdag då vi kör 18:00-19:00 då många av oss säkert vill lära oss Beatboxa).<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\"><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741917626853057/\">https://www.facebook.com/groups/639094320468722/permalink/741917626853057/</a></p>"
     link: null
     owner:
       name: ''
@@ -1377,8 +1554,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p class=\"p1\">Alla musikintresserade som gillar och vill spela/sjunga tillsammans kan ta med sig instrument/röst så spelar vi ihop, lär varandra saker, testar lite låtar tillsammans och helt enkelt jammar och har kul.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\">Samling <strong>under björkarna vid lekplatsen</strong> vid bra väder, och längs bort i korridoren i GA-hallen om det är mindre bra väder.</p>\n<p class=\"p1\">Repeteras varje eftermiddag 16:00-17:00.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\"><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741917626853057/\">https://www.facebook.com/groups/639094320468722/permalink/741917626853057/</a></p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741917626853057/
     owner:
       name: ''
       email: ''
@@ -1392,8 +1569,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p class=\"p1\">Alla musikintresserade som gillar och vill spela/sjunga tillsammans kan ta med sig instrument/röst så spelar vi ihop, lär varandra saker, testar lite låtar tillsammans och helt enkelt jammar och har kul.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\">Samling <strong>under björkarna vid lekplatsen</strong> vid bra väder, och längs bort i korridoren i GA-hallen om det är mindre bra väder.</p>\n<p class=\"p1\">Repeteras varje eftermiddag 16:00-17:00.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\"><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741917626853057/\">https://www.facebook.com/groups/639094320468722/permalink/741917626853057/</a></p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741917626853057/
     owner:
       name: ''
       email: ''
@@ -1407,8 +1584,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p class=\"p1\">Alla musikintresserade som gillar och vill spela/sjunga tillsammans kan ta med sig instrument/röst så spelar vi ihop, lär varandra saker, testar lite låtar tillsammans och helt enkelt jammar och har kul.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\">Samling <strong>under björkarna vid lekplatsen</strong> vid bra väder, och längs bort i korridoren i GA-hallen om det är mindre bra väder.</p>\n<p class=\"p1\">Repeteras varje eftermiddag 16:00-17:00.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\"><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741917626853057/\">https://www.facebook.com/groups/639094320468722/permalink/741917626853057/</a></p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741917626853057/
     owner:
       name: ''
       email: ''
@@ -1422,8 +1599,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p class=\"p1\">Alla musikintresserade som gillar och vill spela/sjunga tillsammans kan ta med sig instrument/röst så spelar vi ihop, lär varandra saker, testar lite låtar tillsammans och helt enkelt jammar och har kul.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\">Samling <strong>under björkarna vid lekplatsen</strong> vid bra väder, och längs bort i korridoren i GA-hallen om det är mindre bra väder.</p>\n<p class=\"p1\">Repeteras varje eftermiddag 16:00-17:00.<span class=\"Apple-converted-space\">\_</span></p>\n<p class=\"p1\"><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741917626853057/\">https://www.facebook.com/groups/639094320468722/permalink/741917626853057/</a></p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741917626853057/
     owner:
       name: ''
       email: ''
@@ -1437,7 +1614,7 @@ events:
     end: '12:00'
     location: Fotbollsplan
     responsible: Sara v K
-    description: null
+    description: "<p>Ett enkelt träningspass till musik där en kortlek avgör vilka övningar och hur många repetitioner man gör! Passar alla åldrar men under 8 behöver förälder/vuxen med sig.\_</p>\n<p>https://www.facebook.com/groups/639094320468722/permalink/741986896846130/</p>"
     link: null
     owner:
       name: ''
@@ -1452,7 +1629,7 @@ events:
     end: '09:50'
     location: Grillplatsen
     responsible: Ulrica Liavor
-    description: null
+    description: "<p>Jag tänker lära ut en 17 minuters flödessekvens som inte kräver vana. Den stretchar ut kroppen ffa delar som öppnar andning och lymfa och ger energi. Den innehåller inga traditionella yogaasanas, men bygger på samma system. Vem som helst kan vara med. Mest tänker jag en liten oas för vuxna, men alla är välkomna.</p>\n<p>\_FLÖDESSEKVENS <br />10 min förklaring och genomgång <br />17 min själva flödessekvensen <br />10 min vila <br /><br />Efteråt pratar jag gärna och svarar på frågor, men avslutar så att alla hinner till föräldramötet med ny energi eller funnen trötthet;)\_</p>\n<p>Ca 45-50 min\_</p>\n<p>Vi ses vid älven nedanför grillplatsen.\_<br />Ta med en handduk, filt eller något annat att kunna ligga på under vilan.\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1467,7 +1644,9 @@ events:
     end: '17:00'
     location: Tält1
     responsible: Maria Alfredsson
-    description: null
+    description: |-
+      <p>Jag hemundervisar mina två barn på Åland sedan fyra år tillbaka. Jag har massor av erfarenheter av vad som fungerar väl och vad som inte fungerar alls. Kanske någon av er som kommer på lägret funderar över att hemundervisa utomlands? I så fall kan jag gärna bidra med att berätta om våra erfarenheter från hur det går till på lilla Åland.</p>
+      <p><br />https://www.facebook.com/groups/639094320468722/permalink/739538220424331/</p>
     link: null
     owner:
       name: ''
@@ -1482,7 +1661,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -1497,7 +1676,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -1512,7 +1691,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -1527,7 +1706,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -1542,7 +1721,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -1557,8 +1736,8 @@ events:
     end: '20:30'
     location: Skolsal
     responsible: Amanda Gruneau
-    description: null
-    link: null
+    description: <p>Vi kollar på genrepet inför fotbolls-EM tillsammans. Sverige möter Brasilien på Friends arena. Vi är i ett klassrum i skolan. Ring Amanda om ni inte hittar oss 0733661233</p>
+    link: https://facebook.com/events/s/fotboll-sverige-brasilien/544869620456242/
     owner:
       name: ''
       email: ''
@@ -1566,12 +1745,12 @@ events:
       created_at: '2022-06-28 18:06:12'
       updated_at: '2022-06-28 18:06:12'
   - id: filmkvall-familjen-mitchell-mot-maskinerna-2022-06-28-2000
-    title: 'Filmkväll, familjen Mitchell mot maskinerna'
+    title: Filmkväll, familjen Mitchell mot maskinerna
     date: '2022-06-28'
     start: '20:00'
     end: '22:00'
     location: GA-hall
-    responsible: 'Andreas? :)'
+    responsible: Andreas? :)
     description: null
     link: null
     owner:
@@ -1587,7 +1766,7 @@ events:
     end: '12:00'
     location: Nerf-arena
     responsible: 'Rönnkvist '
-    description: null
+    description: "<p>Vi bjuder upp till ny match i Quidditch för mugglare. Ta med vattenflaska för påfyllnad och gärna egen kvast.\_</p>\n<p>Lagindelning och regler på plats.\_</p>\n<p>Välkomna\_</p>"
     link: null
     owner:
       name: ''
@@ -1602,8 +1781,8 @@ events:
     end: '12:00'
     location: Tält1
     responsible: 'Alexandra och Rebecca Isenfors '
-    description: null
-    link: null
+    description: "<p>Kom och prova på att spela blockflöjt.\_</p>"
+    link: https://m.facebook.com/groups/639094320468722/permalink/742262996818520/
     owner:
       name: ''
       email: ''
@@ -1617,7 +1796,7 @@ events:
     end: '14:00'
     location: GA-hall
     responsible: Lova Gruneau och Amanda Johansson
-    description: null
+    description: <p>Här kan barn 3-8 år komma och leka olika lekar och köra hinderbana.</p>
     link: null
     owner:
       name: ''
@@ -1632,8 +1811,8 @@ events:
     end: '09:50'
     location: Kaffetältet
     responsible: Lotta Jonsson
-    description: null
-    link: null
+    description: "<p>09:00 - 10:00</p>\n<p>Rakt upp och ner berättelse i dialog om hur vi kom igång, hur vi organiserar oss, hur vi löste vatten, grävning, gödsel, \_och förhåller oss till familjeliv, egen ork och miljö … och hur det gått med skörden trots diverse odlardilemmor. \_Väl mött\_Lotta\_</p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/731080067936813/
     owner:
       name: ''
       email: ''
@@ -1647,8 +1826,8 @@ events:
     end: '03:00'
     location: Grillplatsen
     responsible: 'Malin Isenfors '
-    description: null
-    link: null
+    description: "<p>Vi står för eld och bjuder barnen på popcorn och marshmellows.\_</p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/742447090133444/
     owner:
       name: ''
       email: ''
@@ -1662,8 +1841,21 @@ events:
     end: '11:00'
     location: Annat
     responsible: Samuel Modée
-    description: null
-    link: null
+    description: |-
+      <p>Samuel har varit instruktör i ju-jutsu i många år och håller en introduktionskurs i praktiskt självförsvar. Om vädret tillåter håller vi till utomhus på gräsplanen nedanför gympasalen: https://goo.gl/maps/SmFuCcmLcfEcnqF56</p>
+      <ul>
+      <li>
+      <div class="bi6gxh9e"><span class="d2edcug0 hpfvmrgz qv66sw1b c1et5uql lr9zc1uh jq4qci2q a3bd9o3v b1v8xokw oo9gr5id">Alla är välkomna oavsett ålder, färg eller form</span></div>
+      </li>
+      <li>
+      <div class="bi6gxh9e"><span class="d2edcug0 hpfvmrgz qv66sw1b c1et5uql lr9zc1uh jq4qci2q a3bd9o3v b1v8xokw oo9gr5id">Ha kläder ni är bekväma att röra er (och kanske svettas) i</span></div>
+      </li>
+      <li>
+      <div class="bi6gxh9e"><span class="d2edcug0 hpfvmrgz qv66sw1b c1et5uql lr9zc1uh jq4qci2q a3bd9o3v b1v8xokw oo9gr5id">Då vi kommer ha kroppskontakt får man avstå om man känner sjukdomssymptom</span></div>
+      </li>
+      </ul>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/741423583569128
     owner:
       name: ''
       email: ''
@@ -1677,8 +1869,10 @@ events:
     end: '12:00'
     location: GA-hall
     responsible: Björn Maude
-    description: null
-    link: null
+    description: |-
+      <p>Jag har ett förflutet som basketspelare och tio års erfarenhet som ungdoms- och damlagstränare, så det är med viss basket-koppling och handhållen bollkontroll.</p>
+      <p>Inga förkunskaper behövs.. Det finns 20-nånting basketbollar, så det borde räcka.</p>
+    link: https://m.facebook.com/groups/639094320468722/permalink/742696900108463/
     owner:
       name: ''
       email: ''
@@ -1692,8 +1886,10 @@ events:
     end: '12:00'
     location: GA-hall
     responsible: Björn Maude
-    description: null
-    link: null
+    description: |-
+      <p>Jag har ett förflutet som basketspelare och tio års erfarenhet som ungdoms- och damlagstränare, så det är med viss basket-koppling och handhållen bollkontroll.</p>
+      <p>Inga förkunskaper behövs. Det finns 20-nånting basketbollar, så det borde räcka.</p>
+    link: https://m.facebook.com/groups/639094320468722/permalink/742696900108463/
     owner:
       name: ''
       email: ''
@@ -1707,8 +1903,8 @@ events:
     end: '14:30'
     location: Kaffetältet
     responsible: Anna B
-    description: null
-    link: null
+    description: "<p>Vi pratar om dyslexi hos särskilt begåvade barn.\_</p>"
+    link: https://m.facebook.com/groups/639094320468722/permalink/741865913524895/?m_entstream_source=group&amp;anchor_composer=false&amp;mds=%2Fedit%2Fpost%2Fdialog%2F%3Fcid%3DS%253A_I100000502885401%253AVK%253A741865913524895%26ct%3D2%26nodeID%3Dm_story_permalink_view%26redir%3D%252Fstory_chevron_menu%252F%253Fis_menu_registered%253Dfalse%26perm%26loc%3Dpermalink&amp;mdf=1
     owner:
       name: ''
       email: ''
@@ -1722,8 +1918,10 @@ events:
     end: '19:00'
     location: Tält1
     responsible: 'Mohammed '
-    description: null
-    link: null
+    description: |-
+      <p>Teckenspråk flyttat till Torsdag pga Grillkväll onsdag.</p>
+      <p>Ni är välkomna!</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/741558740222279/
     owner:
       name: ''
       email: ''
@@ -1738,7 +1936,7 @@ events:
     location: Nerf-arena
     responsible: Annie
     description: null
-    link: null
+    link: https://www.facebook.com/groups/639094320468722/permalink/742699333441553/
     owner:
       name: ''
       email: ''
@@ -1752,8 +1950,8 @@ events:
     end: '12:00'
     location: Annat
     responsible: Sara v K
-    description: null
-    link: null
+    description: "<p>Enkelt träningspass för alla åldrar!(under 8 med förälder)\_</p>\n<p><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741986896846130/\">Läs mer i tråden </a></p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/741986896846130/
     owner:
       name: ''
       email: ''
@@ -1766,9 +1964,12 @@ events:
     start: '13:00'
     end: '16:00'
     location: Skolsal
-    responsible: 'Samuel Modée, Christoffer Modée, Gustav Kalander'
-    description: null
-    link: null
+    responsible: Samuel Modée, Christoffer Modée, Gustav Kalander
+    description: |-
+      <p>På fredag kl 13-16 håller vi (Christoffer Modée, Gustav Kalander och jag) en workshop i datorhörnan där vi bygger AI och låter dem tävla mot varandra. Det kommer vara tillgängligt för alla från nybörjare till experter och alla kommer kunna utmana sig själva på sin nivå.</p>
+      <p><br />Varje lag som deltar behöver ha med sig en dator. Vi rekommenderar att man är 2-3 personer i ett lag. Har du möjlighet att se till att Python (åtminstone version 3.8) redan är installerat på datorn så är det jättebra. Annars fixar vi det i början av workshopen.</p>
+      <p><br />Pris kommer finnas åt alla AI som deltar. Men eftersom AI inte uppskattar materiella saker så delas priserna ut till er konstruktörer istället 🙂</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/742859533425533
     owner:
       name: ''
       email: ''
@@ -1782,7 +1983,7 @@ events:
     end: '20:30'
     location: Tält2
     responsible: Ines och Katharina Bjerke
-    description: null
+    description: "<p>Vi börjar kl 18.30 och håller på så länge någon har lust.\_</p>\n<p>Kom och virka en amigurumi-nyckelring eller vad du har lust med. Vi har garn och virknålar. Vi ses i tält 1, om det blåser mycket flyttar vi in i GA-hallen.</p>\n<p>&nbsp;</p>\n<p><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741517190226434/\">Facebooklänk</a></p>"
     link: null
     owner:
       name: ''
@@ -1797,8 +1998,11 @@ events:
     end: '16:00'
     location: Grillplatsen
     responsible: Ulrica Liavor
-    description: null
-    link: null
+    description: |-
+      <p>Torsdag kl 15 - ANDNING - MANETERNA - pass/workshop som går igenom hur vi med enkla medel kan få en fördjupad andning, vilket kan förändra andningsmönster som belastar de sekundära andningsmusklerna, vilket skapar spänning i bröst, nacke, axlar och även påverkar hjärtat då diafragman inte får vara dynamisk osv väldigt kort förklarat.</p>
+      <p>Ca 45 m-60 min med frågor och samtal för den som vill.</p>
+      <p>Vi ses vid älven. Medtag handduk, liggunderlag eller stol (eg det allra bästa).</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/743027133408773/
     owner:
       name: ''
       email: ''
@@ -1812,7 +2016,7 @@ events:
     end: '19:30'
     location: Fotbollsplan
     responsible: 'Dillner '
-    description: null
+    description: <p>Fotboll för alla</p>
     link: null
     owner:
       name: ''
@@ -1827,8 +2031,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: 'Tilde '
-    description: null
-    link: null
+    description: "<p>Tilde har Tecknarstudio för tonåringar torsdag kl 14.00 i bildsalen i skolan. Bredvid entrén.\_</p>\n<p>✏️📋Anmälan behövs då det inte får plats hur många som helst.</p>\n<p>Petra kommer och köra lite kreativa teckningsövningar och visa lite saker för de som är intresserade.</p>\n<p>Det kommer finnas olika blyerts, färgpennor, tuschpennor, akvarell och kol. <br />Olika typer av papper m.m.</p>\n<p>Har du eget som du vill använda så ta med det. 😀</p>"
+    link: https://m.facebook.com/groups/639094320468722/permalink/741895436855276/
     owner:
       name: ''
       email: ''
@@ -1836,14 +2040,17 @@ events:
       created_at: '2022-06-29 23:45:35'
       updated_at: '2022-06-29 23:45:35'
   - id: minecraft-mods-demos-och-annat-2022-06-30-1300
-    title: 'Minecraft - mods, demos och annat'
+    title: Minecraft - mods, demos och annat
     date: '2022-06-30'
     start: '13:00'
     end: '14:00'
     location: Datorsal
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Minecraft, mods, tips/tricks m.m.</p>
+      <p>Har du mods du vill visa? Har du några coola Minecraft tricks som kanske inte alla kan? Eller något annat du skulle vilja visa?</p>
+      <p>Vi tar en timme 13:00 idag och tar en paus ifrån det vanliga Minecraftandet och visar varandra lite saker.</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/743337766711043/
     owner:
       name: ''
       email: ''
@@ -1857,7 +2064,7 @@ events:
     end: '12:00'
     location: Annat
     responsible: Sara v K
-    description: null
+    description: "<p>Enkelt och roligt träningspass för alla åldrar! (under 8 med förälder)\_</p>\n<p><a href=\"https://www.facebook.com/groups/639094320468722/permalink/741986896846130/\">Läs mer i tråden </a></p>"
     link: null
     owner:
       name: ''
@@ -1872,8 +2079,12 @@ events:
     end: '20:00'
     location: Skolsal
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Vi kör en session med köra en funktionell programmering i Clojure (en Lisp som kompilerar ned till Java/Javascript/.NET).</p>
+      <p>Det är definitivt inte tänkt som en nybörjarsession utan målgruppen är ungdomar och vuxna som programmerat ett tag, men som kanske ännu inte stött på en Lisp och/eller är nyfikna på hur ett dynamiskt funktionellt språk ser ut och fungerar.</p>
+      <p>”Lisp is worth learning for the profound enlightenment experience you will have when you finally get it; that experience will make you a better programmer for the rest of your days, even if you never actually use Lisp itself a lot.” - Eric Raymond</p>
+      <p>Förberedelser: Installera VS Code och https://calva.io</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/743177456727074/
     owner:
       name: ''
       email: ''
@@ -1887,7 +2098,7 @@ events:
     end: '15:00'
     location: Annat
     responsible: 'Ida (elin) Sommerfeld '
-    description: null
+    description: "<p class=\"p1\"><span class=\"s1\">Prova på disco (nivå 8-11 år)<br /></span>Uppvärmning, discosteg och en liten koreografi.</p>\n<p>utomhus om vädret tillåter annars i GA-hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -1902,7 +2113,7 @@ events:
     end: '21:00'
     location: Tält1
     responsible: Tekla och Nemi Nilede
-    description: null
+    description: <p>Komplicerad varulv klockan 19 på torsdag och fredag, om fler än 13 kommer så lottar vi vem som får vara med de som eventuellt inte får vara med på torsdagen har förtur på fredagen. Från 10 år.</p>
     link: null
     owner:
       name: ''
@@ -1917,7 +2128,7 @@ events:
     end: '21:00'
     location: Tält1
     responsible: Tekla och Nemi
-    description: null
+    description: <p>Komplicerad varulv med Tekla och Nemi klockan 19 på fredag. Max 13 deltagare. Tältet utanför GA-hallen. Från 13 år.</p>
     link: null
     owner:
       name: ''
@@ -1932,7 +2143,7 @@ events:
     end: '11:00'
     location: Skolsal
     responsible: 'Charlotta Savander '
-    description: null
+    description: <p>Prova att dirigera? Vad och hur gör en dirigent? Kom och prova, vi turas om att bli dirigerade och att dirigera. Kan du röra på armarna kan du dirigera. Nivå efter deltagarna men kanske helst från skolåldern.</p>
     link: null
     owner:
       name: ''
@@ -1947,7 +2158,7 @@ events:
     end: '19:30'
     location: Servicehus
     responsible: 'Malin Isenfors '
-    description: null
+    description: "<p>Kom och fixa dina naglar!\_</p>"
     link: null
     owner:
       name: ''
@@ -1961,9 +2172,9 @@ events:
     start: '16:45'
     end: '17:30'
     location: Tält1
-    responsible: 'RFSB Stockholm (Cecilia, Sara och Jesscia)'
+    responsible: RFSB Stockholm (Cecilia, Sara och Jesscia)
     description: null
-    link: null
+    link: https://www.facebook.com/groups/639094320468722/permalink/743679183343568/
     owner:
       name: ''
       email: ''
@@ -1977,8 +2188,8 @@ events:
     end: '18:00'
     location: Tält2
     responsible: Christina Falk
-    description: null
-    link: null
+    description: "<p>Den som vill bli målad får en ansiktsmålning.\_<br />se facebook-tråden för anmälan att få vara med och måla. Jag behöver några hjälpredor.\_</p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/743303006714519/
     owner:
       name: ''
       email: ''
@@ -1992,8 +2203,8 @@ events:
     end: '23:45'
     location: GA-hall
     responsible: 'Gabriel Olsson '
-    description: null
-    link: null
+    description: <p>Brädspelsafton i GA-HALLEN från kl.20 fram tills alla vännerna gått hem.</p>
+    link: https://m.facebook.com/groups/639094320468722/permalink/744101359968017/
     owner:
       name: ''
       email: ''
@@ -2007,8 +2218,10 @@ events:
     end: '12:00'
     location: Tält1
     responsible: Tobias Ander
-    description: null
-    link: null
+    description: |-
+      <p>Att leva med särbegåvning. (För föräldrar och unga vuxna).<br />Tobias (Ander) har vetat om min begåvning i 28 år och det har på många olika sätt påverkat vardagen, arbetslivet och livet i stort. (Jag har även 3 särskilt begåvade barn vilket i sig blir intresant).</p>
+      <p>Har du frågor och funderingar du skulle vilja fråga en särbegåvad som du inte törs fråga annars, ställ dem här under denna aktivitet, eller om du är bara allmänt nyfiken så välkommen att delta.</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/743634950014658/
     owner:
       name: ''
       email: ''
@@ -2022,8 +2235,8 @@ events:
     end: '15:00'
     location: Tält1
     responsible: Martin Jacobson
-    description: null
-    link: null
+    description: "<p>Undervisningskoncept Pullout\_</p>\n<p>Hej! Jag skulle vilja hålla prat om Pull Out undervisning. Dvs att köra separat undervisning för SB tvärs åldrar och skolor en gång i veckan. Vi tittar på att dra igång en pilot i Stockholm med dröm om att göra det för hela landet.</p>\n<p>Jag skulle vilja få input - innehåll, ideer, farhågor, kanske ide om vem som kan hjälpa till vara pedagog eller familjer som skulle vilja vara med. Målgruppen är barn i åldrarna 7 till 15.</p>\n<p>Fokuset jag tänker mig är Lusten till lärande och Att bygga en självkänsla / identitet.</p>"
+    link: https://m.facebook.com/groups/639094320468722/permalink/744286516616168/
     owner:
       name: ''
       email: ''
@@ -2031,14 +2244,16 @@ events:
       created_at: '2022-07-01 18:59:44'
       updated_at: '2022-07-01 18:59:44'
   - id: vattenkrig-2022-07-02-1300
-    title: 'Vattenkrig!'
+    title: Vattenkrig!
     date: '2022-07-02'
     start: '13:00'
     end: '14:00'
     location: Annat
     responsible: Maria Gröndahl
-    description: null
-    link: null
+    description: |-
+      <p>Traditionsenligt vattenkrig! Vuxna mot barn. Vi samlas vid uteduscharna lördag kl. 13.</p>
+      <p>https://www.facebook.com/groups/639094320468722/permalink/744377203273766/</p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/744377203273766/
     owner:
       name: ''
       email: ''
@@ -2052,8 +2267,8 @@ events:
     end: '15:00'
     location: Tält1
     responsible: Charlotte Tyldhed
-    description: null
-    link: null
+    description: "<p>Hampus och Vera bjuder in till en introduktion i japanska. Lär dig räkna, säga vad klockan är och vad du heter. Inga förkunskaper krävs.\_</p>"
+    link: https://www.facebook.com/groups/639094320468722/permalink/743426573368829
     owner:
       name: ''
       email: ''
@@ -2067,8 +2282,8 @@ events:
     end: '12:00'
     location: Annat
     responsible: Amanda G
-    description: null
-    link: null
+    description: <p><a href="https://www.facebook.com/groups/639094320468722/permalink/744363199941833/">Läs mer i tråden</a></p>
+    link: https://www.facebook.com/groups/639094320468722/permalink/744363199941833/
     owner:
       name: ''
       email: ''
@@ -2082,7 +2297,7 @@ events:
     end: '16:00'
     location: Rollspelstält1
     responsible: Christina Ebeling
-    description: null
+    description: <p>Mera vattenkrig, barn vs vuxna :-)!</p>
     link: null
     owner:
       name: ''
@@ -2097,7 +2312,7 @@ events:
     end: '22:15'
     location: Grillplatsen
     responsible: Ivar Ängquist
-    description: null
+    description: "<p class=\"p1\" style=\"text-align: center\"><span class=\"s1\">Efter den gemensamma städningen tycker jag att vi som inte har bråttom med ännu mer städning kan\_delta i en filosofidiskussion. Jag har förberett gott med tankeväckande frågor varav hälften handlar om rättvisa och hälften om känslor. Så länge vi blir tillräckligt många borde vi kunna dela in oss grupper så att både barn och vuxna kan diskutera med andra som har samma ålder och filosofisk erfarenhet. Vi ses nere vid bänkarna vid vattnet.</span></p>"
     link: null
     owner:
       name: ''

--- a/source/data/2023-06-syssleback.yaml
+++ b/source/data/2023-06-syssleback.yaml
@@ -12,7 +12,10 @@ events:
     end: '23:30'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+
+      Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt
     link: null
     owner:
       name: ''
@@ -27,8 +30,12 @@ events:
     end: '15:00'
     location: Annat
     responsible: Eget ansvar
-    description: null
-    link: null
+    description: |-
+      Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.
+      Det finns parkering för de som vill vara redo för “hemfärd”.
+      Annars är det en lagom promenad på vägen bakom receptionen.
+      Tiden är för det brukar vara lite “drop-in”.
+    link: http://www.naturpralinen.se
     owner:
       name: ''
       email: ''
@@ -42,7 +49,7 @@ events:
     end: '20:00'
     location: Annat
     responsible: Andreas
-    description: null
+    description: "<strong>Möte:</strong>\nVi börjar med avetablering, alla hjälps åt!\nNär vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.\nOfta en gemensam bild på alla deltagare.\n\n<strong>Avetablering:</strong>\n<ul>\n\t<li>Gemensam översyn på området med iordningställande och städ.</li>\n\t<li>Alla tält packas ner.</li>\n\t<li>All utrustning tas om hand.</li>\n\t<li>Alla gemensamma ytor sopas.</li>\n\t<li>Gräsytor utomhus gås igenom och skräp plockas upp.</li>\n</ul>\n\nLost and found, vid ingång till GA-hallen.\n\n<strong>Plats:</strong>\nGräsytan mellan tälten och lekplatsen.\nVid dåligt väder, GA-hallen."
     link: null
     owner:
       name: ''
@@ -147,7 +154,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -162,7 +169,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -177,7 +184,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -192,7 +199,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -207,7 +214,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -222,7 +229,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -237,7 +244,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: En chans att titta på sommarlovsmorgon i TV-rummet (i serviceshuset) med andra på lägret. Först dit startar TV:n.
     link: null
     owner:
       name: ''
@@ -246,13 +253,13 @@ events:
       created_at: '2022-11-29 22:10:06'
       updated_at: '2022-11-29 22:10:06'
   - id: vattenkrig-2023-07-01-1300
-    title: 'Vattenkrig!'
+    title: Vattenkrig!
     date: '2023-07-01'
     start: '13:00'
     end: '14:00'
     location: Annat
     responsible: Vattnet
-    description: null
+    description: Traditionsenligt vattenkrig! Vuxna mot barn. Vi samlas vid uteduscharna, gräsytan mellan simhall och lekplats.
     link: null
     owner:
       name: ''
@@ -267,7 +274,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -282,7 +289,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -297,7 +304,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -312,7 +319,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -327,7 +334,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -342,7 +349,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -357,7 +364,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -372,7 +379,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -387,7 +394,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -402,7 +409,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -417,7 +424,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -432,7 +439,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -447,7 +454,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -462,8 +469,10 @@ events:
     end: '16:00'
     location: Skolsal
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: |-
+      <pre>Vi bakar Mochi Mochi donuts och testar Kakigori shaved ice baserat på Ai Venturas bok Baka Kawaii. </pre>
+      <pre>Alla åldrar är välkomna men vissa moment kräver stöd av en vuxen. Anmälan sker i Fb-evenemanget. <br />Ange gärna eventuell allergi eller intolerans så anpassar vi.<br />Max antal deltagare: 16 st</pre>
+    link: https://facebook.com/events/s/japansk-bakkurs-1/793094462393414/
     owner:
       name: ''
       email: ''
@@ -477,8 +486,10 @@ events:
     end: '16:00'
     location: Skolsal
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: |-
+      <pre>Vi bakar Mochi Mochi donuts och testar Kakigori shaved ice baserat på Ai Venturas bok Baka Kawaii. </pre>
+      <pre>Alla åldrar är välkomna men vissa moment kräver stöd av en vuxen. Anmälan sker i Fb-evenemanget. <br />Ange gärna eventuell allergi eller intolerans så anpassar vi.<br />Max antal deltagare: 16 st</pre>
+    link: https://facebook.com/events/s/japansk-bakkurs-2/279590051288868/
     owner:
       name: ''
       email: ''
@@ -486,13 +497,13 @@ events:
       created_at: '2023-06-24 10:26:11'
       updated_at: '2023-06-24 10:26:11'
   - id: rollspel-fm-viktor-2023-06-27-0930
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2023-06-27'
     start: '09:30'
     end: '12:00'
     location: Rollspelstält1
     responsible: 'Viktor Ängquist '
-    description: null
+    description: '<p>Anmälda: Laura, Kim, Elias Karlin, Ludvig och Xander.</p>'
     link: null
     owner:
       name: ''
@@ -501,13 +512,13 @@ events:
       created_at: '2023-06-24 19:57:39'
       updated_at: '2023-06-24 19:57:39'
   - id: rollspel-fm-viktor-2023-06-30-0930
-    title: 'Rollspel fm, Viktor'
+    title: Rollspel fm, Viktor
     date: '2023-06-30'
     start: '09:30'
     end: '12:00'
     location: Rollspelstält1
     responsible: 'Viktor '
-    description: null
+    description: '<p>Anmälda: Laura, Kim, Elias Karlin, Ludvig och Xander.</p>'
     link: null
     owner:
       name: ''
@@ -522,8 +533,8 @@ events:
     end: '16:45'
     location: GA Idrott
     responsible: Isabella Hägermark
-    description: null
-    link: null
+    description: "<p>Pröva på latindanserna Cha-cha-cha och Jive! Danserna är med i programmet Let´s Dance. Inga förkunskaper krävs. Lektionerna är för alla åldrar.\_</p>"
+    link: https://fb.me/e/4tGGlEHBY
     owner:
       name: ''
       email: ''
@@ -537,7 +548,7 @@ events:
     end: '19:00'
     location: Servicehus
     responsible: Emilia Lindh mfl
-    description: null
+    description: "<p>Obs: föranmälan! Finns några platser kvar men inte så många. Åldersgräns: 13 år.</p>\n<p>https://forms.gle/yAVMsjB9AmfY1Gt56\_</p>\n<p>Vi möts utanför servicehuset och går igenom regler och likande, sedan kommer sessionen ta plats på flera olika platser på lägerområdet, främst utomhus.</p>\n<p>Historian utspelar sig i en medeltida fantasymiljö där spelarna är sjömän som lidit skeppsbrott och blivit strandsatta på en avlägsen ö som kontrolleras av ett gäng ondsinta banditer.</p>\n<p>För er som kanske inte vet, så är lajv en form av rollspel där deltagarna fysiskt spelar sina karaktärer, ofta iklädda tex fantasyklädsel. Det är en sorts blandning mellan rollspel och improvisationsteater, som utspelar sig i en fiktiv fantasymiljö, som representeras av de verkliga omgivningarna man befinner sig i.\_</p>"
     link: null
     owner:
       name: ''
@@ -552,7 +563,7 @@ events:
     end: '11:30'
     location: Skolsal
     responsible: Petter Åström
-    description: null
+    description: <p>Vi kör en kurs i webbutveckling med HTML, CSS och JavaScript. Tänker mig att antal träffar där man bygger på kunskaperna men vet inre riktigt hur många eller långa tillfällen som är lagom. Börjar med att boka 2 tillfällen tisdag och onsdag så får vi se hur det går och hur vi går vidare!</p>
     link: null
     owner:
       name: ''
@@ -567,8 +578,11 @@ events:
     end: '15:30'
     location: Skolsal
     responsible: Lisa Lautrup
-    description: null
-    link: null
+    description: |-
+      <p>Vi tillverkar svärd i papper med inspiration av Kyojuro Rengoku i Demon Slayer efter instruktion från Paper Creative MASTER:</p>
+      <p>https://youtu.be/MWFghLF3-pk<br />https://youtu.be/cA0FFkA3ZJQ</p>
+      <p>Anmälan sker i Fb-evenemanget, max 12 deltagare. OBS! Många kluriga moment 🤓</p>
+    link: https://facebook.com/events/s/simons-svardskola/633818948463920/
     owner:
       name: ''
       email: ''
@@ -582,8 +596,8 @@ events:
     end: '17:00'
     location: Nerf-arena
     responsible: 'Christina '
-    description: null
-    link: null
+    description: <p>Bäst i test, som i tv-programmet, men vi kör lagtävling. Lagindelning på plats. Vi träffas utanför GA-hallen</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2230210373838116/
     owner:
       name: ''
       email: ''
@@ -597,7 +611,7 @@ events:
     end: '10:30'
     location: GA Idrott
     responsible: Andreas
-    description: null
+    description: <p>Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.</p>
     link: null
     owner:
       name: ''
@@ -612,7 +626,7 @@ events:
     end: '16:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: <p>Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om <a href="https://www.torsby.se/upplevagora/idrottmotionochfriluftsliv/simhallarbadhus/sysslebacksbadet.4.108f9ad3156b3ea512042593.html">simhallen</a>.</p>
     link: null
     owner:
       name: ''
@@ -627,7 +641,7 @@ events:
     end: '15:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: <p>Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om <a href="https://www.torsby.se/upplevagora/idrottmotionochfriluftsliv/simhallarbadhus/sysslebacksbadet.4.108f9ad3156b3ea512042593.html">simhallen</a>.</p>
     link: null
     owner:
       name: ''
@@ -642,7 +656,7 @@ events:
     end: '16:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: <p>Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om <a href="https://www.torsby.se/upplevagora/idrottmotionochfriluftsliv/simhallarbadhus/sysslebacksbadet.4.108f9ad3156b3ea512042593.html">simhallen</a>.</p>
     link: null
     owner:
       name: ''
@@ -657,7 +671,7 @@ events:
     end: '20:45'
     location: Annat
     responsible: Alla
-    description: null
+    description: <p>Vi samlas utanför GA-hallen för att rigga lägret!</p>
     link: null
     owner:
       name: ''
@@ -672,7 +686,7 @@ events:
     end: '10:40'
     location: GA Kreativ hörna
     responsible: 'Jessica Malmberg '
-    description: null
+    description: "<p>Vi träffas efter välkomstmötet i GA Hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -687,7 +701,7 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: 'RFSB Stockholm '
-    description: null
+    description: "<p>Tipspromenad i min mindre grupper, dax att lära känna nya.\_</p>"
     link: null
     owner:
       name: ''
@@ -702,7 +716,7 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: <p><!--more--></p>
     link: null
     owner:
       name: ''
@@ -717,7 +731,7 @@ events:
     end: '11:30'
     location: Skolsal
     responsible: Petter Åström
-    description: null
+    description: <p>Vi kör en kurs i webbutveckling med HTML, CSS och JavaScript. Tänker mig att antal träffar där man bygger på kunskaperna men vet inre riktigt hur många eller långa tillfällen som är lagom. Börjar med att boka 2 tillfällen tisdag och onsdag så får vi se hur det går och hur vi går vidare!</p>
     link: null
     owner:
       name: ''
@@ -732,8 +746,13 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -747,8 +766,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -762,8 +781,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -777,8 +796,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -792,8 +811,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -807,8 +826,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Vi spelar musik och sjunger ihop varje dag klockan 16. Nybörjare som erfarna, vi lär varandra låtar och bara spelar. Opretentiöst, och alla som spelar något eller sjunger är välkomna att vara med. Ta med instrument eller röst, så kör vi och har kul!</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237534369772383/
     owner:
       name: ''
       email: ''
@@ -822,7 +841,10 @@ events:
     end: '15:00'
     location: GA Kreativ hörna
     responsible: 'Björn Maude '
-    description: null
+    description: |-
+      <p>Introduktion till låsdyrkning. Låssportens hederskodex, beskrivning av hur ett standardlås fungerar och hur det kan användas för att dyrka.</p>
+      <p>Litegrann om säkerhetsfunktioner som gör dyrkningen svårare.</p>
+      <p>Dyrkar och en del hänglås finns på plats. Ta gärna med ett eget lås om du har.</p>
     link: null
     owner:
       name: ''
@@ -837,7 +859,7 @@ events:
     end: '12:00'
     location: Servicehus
     responsible: Christina Falk
-    description: null
+    description: "<p>Vi övar in en dans tillsammans till låten ”Våran sång” (Sveriges officiella VM-låt 2023). Korreografin är gjord av Selma Falk och är street-inspirerad.\_<br />Svårighetsgrad: medel, men alla åldrar och nivåer är välkomna.\_<br /><br /></p>\n<p>Vi samlas vid servicehuset men dansar på en lämplig plats på gräset i närheten.\_</p>"
     link: null
     owner:
       name: ''
@@ -852,7 +874,7 @@ events:
     end: '11:00'
     location: Tält1
     responsible: 'Björn Maude '
-    description: null
+    description: <p>Vi tittar ner i en ryggsäck med ultralätt fjällpackning anpassad för tvådagars fjällorientering.</p>
     link: null
     owner:
       name: ''
@@ -861,13 +883,15 @@ events:
       created_at: '2023-06-26 09:56:08'
       updated_at: '2023-06-26 09:56:08'
   - id: ul-kok-tillverknings-workshop-2023-06-28-1500
-    title: 'UL-kök, tillverknings-workshop'
+    title: UL-kök, tillverknings-workshop
     date: '2023-06-28'
     start: '15:00'
     end: '17:00'
     location: Tält1
     responsible: 'Björn Maude '
-    description: null
+    description: |-
+      <p>Tillverka ditt eget ultralätta friluftskök.</p>
+      <p>Medtag kattmatsburk och fiskbulleburk</p>
     link: null
     owner:
       name: ''
@@ -882,7 +906,7 @@ events:
     end: '16:00'
     location: Tält1
     responsible: 'Jessica Malmberg '
-    description: null
+    description: "<p>Vi diskuterar samtal med skola.</p>\n<p>Jag delat med mig om hur skolans beslutsår ser utifrån, utifrån skolledningsperspektiv då jag arbetar som förvaltningschef på en friskolekoncern.\_</p>\n<p>Tror att många kan komma längre genom strategiskt tänkande ;)\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -897,7 +921,7 @@ events:
     end: '13:55'
     location: Servicehus
     responsible: Robert Sabelstrom
-    description: null
+    description: <p>Vi har med diverse ingredienser till att göra eget slime.</p>
     link: null
     owner:
       name: ''
@@ -927,8 +951,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Petter Åström
-    description: null
-    link: null
+    description: <p>Bokat kanoterna för långa turen nedströms. 5 canadensare och 2 kajaker, 12 pers. Campingen hämtar kanoterna, vi behöver hämta oss själva. Medtag matsäck och badkläder! Anmäl er i FB-eventet.</p>
+    link: https://m.facebook.com/events/591497836184607/?ref_source=GROUP
     owner:
       name: ''
       email: ''
@@ -942,8 +966,10 @@ events:
     end: '01:00'
     location: GA Datorsal
     responsible: Patrik vK 0706019700
-    description: null
-    link: null
+    description: |-
+      <p>Kvällspass i datahallen</p>
+      <p>Regler enl överenskommelse på plats</p>
+    link: https://facebook.com/events/s/sen-kvallspass-datahallen/975354823818137/
     owner:
       name: ''
       email: ''
@@ -957,8 +983,11 @@ events:
     end: '18:30'
     location: Fritidsgård
     responsible: Emilia Lindh och San Georén
-    description: null
-    link: null
+    description: |-
+      <p>Vi tänkte hålla en liten dansworkshop. Vi lär oss lite koreografi och sätter sedan ihop lite ny koreografi tillsammans.</p>
+      <p>För en lite äldre målgrupp, rekommenderas ålder 12 och uppåt, men yngre kan förstås också komma om man känner att man klarar av nivån</p>
+      <p>Lokal: gympasalen i skolan (samma hus som fritidsgården)</p>
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2239151269610693/
     owner:
       name: ''
       email: ''
@@ -972,7 +1001,7 @@ events:
     end: '22:00'
     location: Grillplats
     responsible: Sara Varda St Vincent
-    description: null
+    description: <p><em>Sjung och spela musik vid grillplatsen nedanför tälten! Ta med instrument om du har, annars kom som du är :-)</em></p>
     link: null
     owner:
       name: ''
@@ -987,7 +1016,7 @@ events:
     end: '12:00'
     location: Servicehus
     responsible: Christina Falk
-    description: null
+    description: "<p>Vi övar in en dans tillsammans till låten ”Våran sång” (Sveriges officiella VM-låt 2023). Korreografin är gjord av Selma Falk och är street-inspirerad.\_<br />Svårighetsgrad: medel, men alla åldrar och nivåer är välkomna.\_</p>\n<p>Vi samlas vid servicehuset men dansar på en lämplig plats på gräset i närheten.\_</p>"
     link: null
     owner:
       name: ''
@@ -1002,7 +1031,7 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Anna Björnson/Anne Carlsson
-    description: null
+    description: <p>Föräldrafika där vi delar erfarenheter om npf i kombination med särskild begåvning. (2e)</p>
     link: null
     owner:
       name: ''
@@ -1011,14 +1040,14 @@ events:
       created_at: '2023-06-26 13:54:41'
       updated_at: '2023-06-26 13:54:41'
   - id: flyttad-lokal-foraldrafika-provning-uppflytt-att-ta-studenten-vid-16-2023-06-29-1500
-    title: 'Flyttad lokal, Föräldrafika - prövning, uppflytt, att ta studenten vid 16'
+    title: Flyttad lokal, Föräldrafika - prövning, uppflytt, att ta studenten vid 16
     date: '2023-06-29'
     start: '15:00'
     end: '16:00'
     location: Tält2
     responsible: Anne Carlsson/Anna Björnson
-    description: null
-    link: null
+    description: <p>Föräldrafika där vi delar erfarenheter och tips om prövning, uppflytt och vad man kan göra efter att man tagit studenten som 16-åring.</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2242226099303210/
     owner:
       name: ''
       email: ''
@@ -1032,7 +1061,9 @@ events:
     end: '21:00'
     location: GA Idrott
     responsible: 'Björn Maude '
-    description: null
+    description: |-
+      <p>Stilla lunk och lite fartlek.</p>
+      <p>Samling vid entren till GA-hallen. Till vänster om campingen finns en liten rundslinga på 850m som vi gör valfritt antal varv</p>
     link: null
     owner:
       name: ''
@@ -1041,14 +1072,23 @@ events:
       created_at: '2023-06-26 15:05:06'
       updated_at: '2023-06-26 15:05:06'
   - id: tecknarstudio-besok-av-kalle-2023-06-26-1800
-    title: 'Tecknarstudio (Besök av Kalle!)'
+    title: Tecknarstudio (Besök av Kalle!)
     date: '2023-06-26'
     start: '18:00'
     end: '19:30'
     location: Skolsal
     responsible: Tilde
-    description: null
-    link: null
+    description: |-
+      <p>Första tecknarstudion för 2023 lägret!</p>
+      <p>Vi får besök av Kalle som berättar om varför det är viktigt att kunna teckna när man söker/har jobb inom animation och spel branschen!</p>
+      <p>Det finns mängder av papper av olika slag, färgpennor, blyerts, akvarell färg, kol, tuschpennor, böcker etc att låna/använda. Men man får självklart ta med sig eget</p>
+      <p>&nbsp;</p>
+      <p>Tanken är ungdom och uppåt men är man under 13 och kan vara lugn får man självklart komma om man är i vuxet sällskap (vuxet sällskap definierar vi som föräldrar eller syskon/kompis över 18)</p>
+      <p>&nbsp;</p>
+      <p>Vi har helt enkelt en lugn stund tillsammans där vi ritar, pysslar och hänger.</p>
+      <p>&nbsp;</p>
+      <p>Vi befinner oss i skolans klassrum för 4-5an</p>
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2242181132641040/
     owner:
       name: ''
       email: ''
@@ -1056,13 +1096,13 @@ events:
       created_at: '2023-06-26 15:12:48'
       updated_at: '2023-06-26 15:12:48'
   - id: hur-funkar-chatgpt-egentligen-2023-06-30-1500
-    title: 'Hur funkar ChatGPT egentligen?'
+    title: Hur funkar ChatGPT egentligen?
     date: '2023-06-30'
     start: '15:00'
     end: '16:00'
     location: Tält1
     responsible: Niclas Nilsson
-    description: null
+    description: <p>Hur funkar ChatGPT och andra Large Language Models egentligen? Hur går det till under ytan? När kan man lita på den och när kan man inte? Och - den stora frågan - kan den bli ond och ta över världen?</p>
     link: null
     owner:
       name: ''
@@ -1077,8 +1117,8 @@ events:
     end: '10:45'
     location: Annat
     responsible: 'Ulrica Liavor '
-    description: null
-    link: null
+    description: "<p class=\"p1\"><span class=\"s1\">Rörelserna är enkla och enbart stående och jag börjar med att förklara dem, sedan är passet 17 min och efterföljs av en stund sittande eller liggande till trumma. Allt som allt ca 45 min. Ger energi och avslappning utan att behöva kunna något innan.</span></p>\n<p class=\"p1\"><span class=\"s1\">Yogaflowet passar alla åldrar där man kan delta självständigt. Då får alla ut mest av stunden.\_<br /><br /></span></p>\n<p>Vi ses i närheten av lilla bron längst bort på campingen i skuggan av ett träd.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2241477386044748/
     owner:
       name: ''
       email: ''
@@ -1092,7 +1132,7 @@ events:
     end: '14:15'
     location: GA Idrott
     responsible: 'Björn Maude '
-    description: null
+    description: <p>Studsa boll. Inga förkunskaper krävs. Inga skor behövs.</p>
     link: null
     owner:
       name: ''
@@ -1107,8 +1147,10 @@ events:
     end: '12:00'
     location: Fritidsgård
     responsible: 'Björn Maude '
-    description: null
-    link: null
+    description: |-
+      <p>Topprep i Gymnastiksalen på fritidsgården bredvid skolan.</p>
+      <p>Ett barn kan klättra i taget. Det finns en del annat gympasaligt att använda där. Går bra att komma och gå under tiden.</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2242418595950627/
     owner:
       name: ''
       email: ''
@@ -1122,7 +1164,7 @@ events:
     end: '15:00'
     location: GA Kreativ hörna
     responsible: 'Björn Maude '
-    description: null
+    description: <p>Introduktion till låsdyrkning. För dom som missade passet på måndagen</p>
     link: null
     owner:
       name: ''
@@ -1137,7 +1179,7 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Tomas Hägermark
-    description: null
+    description: För er som vill träna och lära er lite tricks i schack  inför schackturneringen på onsdag kväll. Eller bara träna lite på schack för att det är roligt :)
     link: null
     owner:
       name: ''
@@ -1152,8 +1194,8 @@ events:
     end: '21:00'
     location: Kaffetält
     responsible: 'Tomas Hägermark '
-    description: null
-    link: null
+    description: "<p style=\"text-align: left\">Schackturnering. Om ni har eget schackbräde ta gärna med det så kan vi vara fler.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2241187766073710/
     owner:
       name: ''
       email: ''
@@ -1167,8 +1209,8 @@ events:
     end: '14:55'
     location: Tält1
     responsible: Malin Palmqvist
-    description: null
-    link: null
+    description: "<p class=\"p1\"><span class=\"s1\">Skrivarmaraton går till så att man väljer en slumpvis mening ur en bok och ställer en timer på 3, 5, 10 eller 15 minuter. Sedan skriver alla fritt utifrån den meningen. Om man vill kan man läsa upp texten efteråt, men man kan också låta bli. \_ Vi kommenterar inte varandras texter, syftet är att få igång skrivarflödet. Både barn och vuxna kan delta. Medtag gärna penna och skrivblock eller papper, jag tar också med en del.\_</span></p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2237481743110979/
     owner:
       name: ''
       email: ''
@@ -1182,7 +1224,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: Sara von Knorring
-    description: null
+    description: "<p>Ett kort och enkelt styrkepass (utan vikter). Alla kan vara med!\_</p>\n<p>Vi ses nedanför nerf-arenan så hittar vi en plats i skuggan. Ta gärna med vattenflaska, och en handduk om du inte vill vara direkt på gräset.\_</p>"
     link: null
     owner:
       name: ''
@@ -1197,8 +1239,8 @@ events:
     end: '13:55'
     location: GA Kreativ hörna
     responsible: Daniel Tiger
-    description: null
-    link: null
+    description: "<p>Vi tittar på exempel på tryckning av motiv på tyg, från design genom skärning på vinyl till tryck. Vad blir bra, tankar kring design etc. Gå gärna med i <a href=\"https://www.facebook.com/groups/1970151763177313/chats/6993338974027382\">chattkanalen</a> så kan vi kolla mer på specifika tankar. Själva skärning och tryckning är lättare att göra en åt gången, tider för detta kommer till torsdag, fredag eller haffa mig på plats.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2229461760579644/
     owner:
       name: ''
       email: ''
@@ -1212,8 +1254,12 @@ events:
     end: '12:00'
     location: Skolsal
     responsible: Daniel Nilede
-    description: null
-    link: null
+    description: |-
+      <p>På onsdag 10:00-12:00 i något av klassrummen på skolan så håller jag en kurs i programmering för de som inte programmerat tidigare. Vi kommer att skapa ett enkelt spel i programmeringsspråket Scratch. Alla som deltar behöver en dator. Har ni ingen dator med på lägret så skriv till mig så kanske jag kan fixa en att låna.</p>
+
+      Det går att förbereda genom att ladda ner och installera lokalt på datorn.
+      https://scratch.mit.edu/download/
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2242562882602865/
     owner:
       name: ''
       email: ''
@@ -1227,8 +1273,10 @@ events:
     end: '16:00'
     location: Annat
     responsible: 'Annelie Mattson-Djos '
-    description: null
-    link: null
+    description: |-
+      <p>Barn som gillar att läsa på engelska träffas och pratar och tipsar om böcker de läst, och kanske läser lite ur varandras böcker.</p>
+      <p>Vi sitter i skuggan under något av träden runt lekparken. Ta gärna med böcker.</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2236767766515710/
     owner:
       name: ''
       email: ''
@@ -1242,7 +1290,7 @@ events:
     end: '21:00'
     location: Servicehus
     responsible: Ola Hammar
-    description: null
+    description: <p>Quiz med musik från förr och nu. Frågor med viss spännvidd. Finns ett gäng block och pennor om man vill vara med. Vi håller till vid servicehuset. Välkomna!</p>
     link: null
     owner:
       name: ''
@@ -1257,7 +1305,7 @@ events:
     end: '20:30'
     location: Skolsal
     responsible: 'Mika Holst Norin '
-    description: null
+    description: "<p>Kom o sjung Kareoke med en mikrofon och ta med dina vänner. Välj låt själv.\_</p>"
     link: null
     owner:
       name: ''
@@ -1272,8 +1320,8 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Lotta Tyldhed
-    description: null
-    link: null
+    description: "<p>Vi lär oss vika enklare figurer som hjärtan, hoppande grodor och fjärilar, och får tips hur man viker boxar och ”evighetskuber”. Papper, saxar och lim finns på plats.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2239063512952802/
     owner:
       name: ''
       email: ''
@@ -1287,8 +1335,15 @@ events:
     end: '12:00'
     location: Rollspelstält2
     responsible: Anders Malmberg
-    description: null
-    link: null
+    description: |-
+      Prova att spela rollspel. Inga förkunskaper krävs.
+
+      Ålder 8 till 13
+
+      Vi kommer spela Mutant som utspelar sig i ett framtida Skandinavien efter att den nuvarande civilisationen fallit.
+
+      Max 6 deltagare
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2242923195900167/
     owner:
       name: ''
       email: ''
@@ -1302,7 +1357,7 @@ events:
     end: '14:30'
     location: Skolsal
     responsible: 'Leigh Jamison '
-    description: null
+    description: <p>En orientering inom området Särskild Begåvning. Jag som föreläser är utredningspsykolog på BUP. Frågestund i slutet!</p>
     link: null
     owner:
       name: ''
@@ -1317,8 +1372,8 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Daniel Tiger
-    description: null
-    link: null
+    description: "<p>Vi kör lite drop-in 10-12 typ. Testar att skära, rensa och trycka på tygkassar eller medhavda tyggrejer. Kolla gärna in chatten för att snacka om och förbereda motiv till tryck.\_<br /><br /></p>\n<p>https://m.me/ch/AbaDDV-HFi3BDouu/</p>\n<p>Vi kör ons, tor, fre 10-12 \_i GA-hallen, bredvid datorerna \_</p>\n<p>&nbsp;</p>"
+    link: https://m.me/ch/AbaDDV-HFi3BDouu/
     owner:
       name: ''
       email: ''
@@ -1332,8 +1387,8 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Daniel Tiger
-    description: null
-    link: null
+    description: "<p>Vi kör lite drop-in 10-12 typ. Testar att skära, rensa och trycka på tygkassar eller medhavda tyggrejer. Kolla gärna in chatten för att snacka om och förbereda motiv till tryck.\_<br /><br /></p>\n<p>https://m.me/ch/AbaDDV-HFi3BDouu/</p>\n<p>Vi kör ons, tor, fre 10-12 \_i GA-hallen, bredvid datorerna \_</p>\n<p>&nbsp;</p>"
+    link: https://m.me/ch/AbaDDV-HFi3BDouu/
     owner:
       name: ''
       email: ''
@@ -1347,8 +1402,8 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Daniel Tiger
-    description: null
-    link: null
+    description: "<p>Vi kör lite drop-in 10-12 typ. Testar att skära, rensa och trycka på tygkassar eller medhavda tyggrejer. Kolla gärna in chatten för att snacka om och förbereda motiv till tryck.\_<br /><br /></p>\n<p>https://m.me/ch/AbaDDV-HFi3BDouu/</p>\n<p>Vi kör ons, tor, fre 10-12 \_i GA-hallen, bredvid datorerna \_</p>\n<p>&nbsp;</p>"
+    link: https://m.me/ch/AbaDDV-HFi3BDouu/
     owner:
       name: ''
       email: ''
@@ -1362,7 +1417,7 @@ events:
     end: '18:00'
     location: Kaffetält
     responsible: Vincent Söder Willhans
-    description: null
+    description: <p>Beatbox workshop, BTK, simpel basic grejer</p>
     link: null
     owner:
       name: ''
@@ -1377,7 +1432,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: Sara von Knorring
-    description: null
+    description: "<p>Ett kort och enkelt styrkepass (utan vikter). Alla kan vara med!\_</p>\n<p>Vi ses nedanför nerf-arenan så hittar vi en plats i skuggan. Ta gärna med vattenflaska, och en handduk om du inte vill vara direkt på gräset.\_</p>"
     link: null
     owner:
       name: ''
@@ -1392,7 +1447,9 @@ events:
     end: '14:00'
     location: Fritidsgård
     responsible: Emilia Lindh och San Georén
-    description: null
+    description: |-
+      <p style="text-align: center">Fortsättning på det vi gjorde igår, vi gör koreografi, bro</p>
+      <p style="text-align: left">Lokal: gympasalen (samma som förut)</p>
     link: null
     owner:
       name: ''
@@ -1407,7 +1464,7 @@ events:
     end: '14:00'
     location: GA Idrott
     responsible: Christina Falk
-    description: null
+    description: "<p>Sista tillfället - vi övar inför uppvisning av dansen.</p>\n<p>Information om uppvisningen läggs ut på facebook under dagen.</p>\n<p>OBS! Denna gång i GA-hallen (p.g.a. mycket skalbaggar)</p>\n<p>Vi övar in en dans tillsammans till låten ”Våran sång” (Sveriges officiella VM-låt 2023). Korreografin är gjord av Selma Falk och är street-inspirerad.\_<br />Svårighetsgrad: medel, men alla åldrar och nivåer är välkomna.\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1421,9 +1478,9 @@ events:
     start: '14:00'
     end: '17:00'
     location: Skolsal
-    responsible: 'Tilde, Albin, Moa'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Moa
+    description: "<p>Tecknarstudio!\_</p>\n<p>Idag (onsdag) kl 14 - ca 17!</p>\n<p>Jag, Albin och Moa har Tecknarstudio igen i skolan! Varmt välkomna folk från och med 13 år</p>\n<p>Material finns, men självklart får ni ha med eget\_</p>\n<p>Begränsat antal platser då vi blev lite många sist 😅, så bekräftad anmälan krävs.</p>\n<p>Anmälning sker i Facebook inlägget som är länkat nedan</p>"
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2243301435862343/
     owner:
       name: ''
       email: ''
@@ -1437,7 +1494,7 @@ events:
     end: '16:00'
     location: Annat
     responsible: Andreas
-    description: null
+    description: Andreas har två gäster på besök. Tänk runt GA, tältet, och servicehuset.
     link: null
     owner:
       name: ''
@@ -1452,7 +1509,7 @@ events:
     end: '19:00'
     location: Kaffetält
     responsible: Andreas
-    description: null
+    description: Hemliga gästerna sitter i kaffetältet och spelar Pandemic, fler kan delta.
     link: null
     owner:
       name: ''
@@ -1467,7 +1524,9 @@ events:
     end: '14:00'
     location: Kaffetält
     responsible: Thorunn Widö
-    description: null
+    description: |-
+      <p>En mindfulnessmeditation med inslag av bl.a. kroppsskannings och fokus på andningen. Ca 20-30 minuter.</p>
+      <p>(Ingen tidigare erfarenhet krävs.)</p>
     link: null
     owner:
       name: ''
@@ -1482,7 +1541,7 @@ events:
     end: '12:00'
     location: Kaffetält
     responsible: Lotta Tyldhed
-    description: null
+    description: "<p>Lokalföreningen för Dalarna Gävleborg bjuder in till kaffe och fika. Vi presenterar oss och vilka vi är, berättar om vad vi gjort och planerar att göra i vårt område. Varmt välkomna!\_</p>"
     link: null
     owner:
       name: ''
@@ -1497,7 +1556,7 @@ events:
     end: '14:55'
     location: GA Kreativ hörna
     responsible: 'Robert Sabelstrom '
-    description: null
+    description: "<p>Thyra (10 år) och Lindwen (11 år) \_m.fl. visar varandra \_digitala teckningar på padda/mobil. Prova på. Inspirera varandra.</p>"
     link: null
     owner:
       name: ''
@@ -1512,8 +1571,8 @@ events:
     end: '03:00'
     location: Grillplats
     responsible: 'Jessica/Morgan '
-    description: null
-    link: null
+    description: "<p>Lägereld för alla, ta med er middag och tillaga vid elden.\_</p>\n<p>Plocka fram glatt humör och instrument ni som har.</p>\n<p>Vi äter, sjunger, spelar, och samtalar så länge vi orkar.\_</p>"
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2243637722495381/
     owner:
       name: ''
       email: ''
@@ -1527,7 +1586,7 @@ events:
     end: '23:50'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: "<p>Alternativ lokal; övervåningen i hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -1542,7 +1601,7 @@ events:
     end: '11:30'
     location: Skolsal
     responsible: Petter Åström
-    description: null
+    description: <p>Det var så kul med webbutveckling så vi kör ett pass till för de som vill lära sig ännu mer!</p>
     link: null
     owner:
       name: ''
@@ -1557,7 +1616,7 @@ events:
     end: '20:30'
     location: Tält1
     responsible: 'Rahan Pakravan '
-    description: null
+    description: <p>max 20 pers</p>
     link: null
     owner:
       name: ''
@@ -1572,7 +1631,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: Sara von Knorring
-    description: null
+    description: "<p>Ett kort och enkelt styrkepass (utan vikter). Alla kan vara med!\_</p>\n<p>Vi ses nedanför nerf-arenan så hittar vi en plats i skuggan. Ta gärna med vattenflaska, och en handduk om du inte vill vara direkt på gräset.\_</p>"
     link: null
     owner:
       name: ''
@@ -1587,8 +1646,8 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Erik Tamlin
-    description: null
-    link: null
+    description: <p>Förenklat och avslappnat Drakar och demoner (Dungeons and dragons) för de yngre barnen som vill prova på. Fokus på kul snarare än korrekta regler. Inga förkunskaper krävs. Vi har en kampanj som vi kört ett tag men det går alldeles utmärkt att hoppa in en stund och styra nån karaktär. Vi är flexibla.</p>
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2243791885813298/
     owner:
       name: ''
       email: ''
@@ -1602,7 +1661,7 @@ events:
     end: '11:45'
     location: Annat
     responsible: Christina Falk
-    description: null
+    description: "<p>De som övat på lägerdansen visar upp den på <strong>gräsmattan framför GA-hallen</strong> för alla som vill se.\_</p>"
     link: null
     owner:
       name: ''
@@ -1617,7 +1676,7 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: <p>Ny tid pga grillning</p>
     link: null
     owner:
       name: ''
@@ -1632,7 +1691,7 @@ events:
     end: '15:30'
     location: Fotbollsplan
     responsible: Amanda Gruneau
-    description: null
+    description: "<p>Fotboll för tjejer från 7 år och uppåt. Ingen fotbollsvana krävs.\_</p>"
     link: null
     owner:
       name: ''
@@ -1647,7 +1706,7 @@ events:
     end: '11:00'
     location: Fotbollsplan
     responsible: Amanda Gruneau
-    description: null
+    description: "<p>Kom och ha kul med boll! För barn cirka 4-7 år med eller utan fotbollsvana.\_</p>"
     link: null
     owner:
       name: ''
@@ -1662,7 +1721,7 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Petter Åström
-    description: null
+    description: <p>För elever i alla åldrar samt föräldrar. Vi delar erfarenheter av anpassning av matte i skolan, och löser tillsammans en uppgift eller två, det är kul att tänka tillsammans! Vi tar med extraboken Variabel Matematik C1 som vi använder, för åk 7. Ta med ert ev material!</p>
     link: null
     owner:
       name: ''
@@ -1677,7 +1736,7 @@ events:
     end: '19:00'
     location: Kaffetält
     responsible: Kerstin Eiman
-    description: null
+    description: "<p>Ta med din stickning och kanske en kaffekopp till Kaffetältet.\_</p>"
     link: null
     owner:
       name: ''
@@ -1692,8 +1751,11 @@ events:
     end: '15:00'
     location: Kaffetält
     responsible: 'Malin Lindborg '
-    description: null
-    link: null
+    description: |-
+      <p class="p1"><strong><span class="s1">Blackout poetry</span></strong></p>
+      <p class="p1"><span class="s1">Välkomna att skapa poesi utan att skriva ett enda ord! Istället för att börja med ett vitt papper börjar vi från en redan skriven text. Genom att svärta över ointressanta ord och lämna kvar utvalda ord växer dikter fram. Passar både barn och vuxna.</span></p>
+      <p class="p1"><span class="s1">Jag har med ett gäng mörka tuschpennor (vanliga barntuschpennor) samt utklippta bok- och tidningssidor. Medtag gärna svart tjock penna om du har tillgång till det.</span></p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2244269879098832/
     owner:
       name: ''
       email: ''
@@ -1707,7 +1769,7 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Anne Carlsson/Anna Björnson
-    description: null
+    description: <p>Föräldrar från Värmland. Vi träffas och ser vilka vi är som är här från Värmland.</p>
     link: null
     owner:
       name: ''
@@ -1722,8 +1784,8 @@ events:
     end: '14:45'
     location: Tält1
     responsible: Thorunn Widö
-    description: null
-    link: null
+    description: "<p>Om QuietFrames, hur behovet av visuell brusreducering uppstod och att gå från idé till färdig produkt. Det kommer finnas mycket tid för frågor om t.ex. företagande eller hur man tar fram en fysisk produkt.\_</p>\n<p class=\"p1\"><span class=\"s1\">Den som är nyfiken kommer kunna klämma, känna på &amp; testa QuietFrames.</span></p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2244477429078077/
     owner:
       name: ''
       email: ''
@@ -1737,8 +1799,10 @@ events:
     end: '12:00'
     location: GA Kreativ hörna
     responsible: Erik Tamlin
-    description: null
-    link: null
+    description: |-
+      <p>Ytterligare ett tillfälle då inte alla fick prova på första gången.</p>
+      <p>Förenklat och avslappnat Drakar och demoner (Dungeons and dragons) för de yngre barnen som vill prova på. Fokus på kul snarare än korrekta regler. Inga förkunskaper krävs. Vi har en kampanj som vi kört ett tag men det går alldeles utmärkt att hoppa in en stund och styra nån karaktär. Vi är flexibla.</p>
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2243791885813298/
     owner:
       name: ''
       email: ''
@@ -1752,8 +1816,8 @@ events:
     end: '12:00'
     location: Skolsal
     responsible: 'Ioana Rodhe och Katarina '
-    description: null
-    link: null
+    description: "<p>Tekning upp till 12 år.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2244447495747737/
     owner:
       name: ''
       email: ''
@@ -1767,7 +1831,7 @@ events:
     end: '19:00'
     location: Kaffetält
     responsible: Kerstin Eiman
-    description: null
+    description: "<p>Ta med din stickning och slå dig mer i kaffetältet.\_</p>"
     link: null
     owner:
       name: ''
@@ -1782,7 +1846,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: 'Sara von Knorring '
-    description: null
+    description: "<p>Ett kort och enkelt styrkepass (utan vikter). Alla kan vara med!\_</p>\n<p>Vi ses nedanför nerf-arenan så hittar vi en plats i skuggan. Ta gärna med vattenflaska, och en handduk om du inte vill vara direkt på gräset.\_</p>\n<p>Vid mycket regn hittar vi ett tält alt går in i hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -1797,7 +1861,7 @@ events:
     end: '16:30'
     location: GA Kreativ hörna
     responsible: 'Martin Jacobson '
-    description: null
+    description: "<p>Desarmera bomber i lag.</p>\n<p>Vi spelar \"Keep Talking And Nobody Explodes\" tillsammans ett datorspel, där de flesta spelarna inte får titta på datorn.\_</p>\n<p>Kom i lag eller ensam så får du vara med i något lag. Desarmera bomber med hjälp av knasig manual under tidspress.</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1812,7 +1876,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ✨️San och Emilia✨️
-    description: null
+    description: <p>Välkommen att fira San's och Emilia's väldigt verkliga bröllop!! Tjoho!!! Komsi komsi &lt;3</p>
     link: null
     owner:
       name: ''
@@ -1826,9 +1890,9 @@ events:
     start: '19:00'
     end: '21:00'
     location: Skolsal
-    responsible: 'Tilde, Albin'
-    description: null
-    link: null
+    responsible: Tilde, Albin
+    description: "<p>Tecknarstudio - Tonåring och uppåt kl 19.00</p>\n<p>&nbsp;</p>\n<p>Nu har det blivit dags för mig och Albin att hålla den sista tecknarstudion för oss i år! 13 år och uppåt är välkomna till skolan från kl 19 till ca 21 ikväll.</p>\n<p>Finns förmodligen någon som pratar om något intressant idag, vem det blir vet vi intre än!</p>\n<p>&nbsp;</p>\n<p>Varmt välkomna! Var god säg till i detta Facebook inlägget (länkat nedan) om ni kommer\_</p>\n<p>Och tack för oss! &lt;3</p>"
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2244914295701057/
     owner:
       name: ''
       email: ''
@@ -1842,7 +1906,7 @@ events:
     end: '14:30'
     location: GA Idrott
     responsible: 'Martina Sjöström '
-    description: null
+    description: "<p><span style=\"font-weight: 400\">Vi börjar bygga hinderbanan cirka en halvtimme innan start tar gärna hjälp både innan och efter. Vi visar hinderbanan som vi tänkt och sedan gör man efter bästa förmåga.\_</span></p>"
     link: null
     owner:
       name: ''
@@ -1857,8 +1921,8 @@ events:
     end: '16:00'
     location: Tält2
     responsible: Jenny von Bahr
-    description: null
-    link: null
+    description: "<blockquote>\n<p>Planering av Klurumläger för ungdomar i början på januari 2024. Vi har nu ordnat en lokal och behöver diskutera:</p>\n<p>- Tider, program, marknadsföring, maten, ansvarsfördelning och så vidare. Ungdomar är hemskt välkomna!\_</p>\n</blockquote>"
+    link: https://Ja
     owner:
       name: ''
       email: ''
@@ -1872,8 +1936,8 @@ events:
     end: '12:02'
     location: Kaffetält
     responsible: Anders
-    description: null
-    link: null
+    description: <p>Sista sessionen Muntant</p>
+    link: https://m.facebook.com/groups/syssleback2023/permalink/2242923195900167/
     owner:
       name: ''
       email: ''
@@ -1887,7 +1951,7 @@ events:
     end: '21:30'
     location: Tält2
     responsible: 'Mika '
-    description: null
+    description: "<p>Jag läser högt från min samling av allt den Bamse x Krösus till Jimmi Åkesson x Ulf kristersson\_</p>\n<p>Kom gärna med hela familjen!\_</p>"
     link: null
     owner:
       name: ''
@@ -1902,7 +1966,7 @@ events:
     end: '16:30'
     location: Annat
     responsible: Sara von Knorring
-    description: null
+    description: "<p>Ett kort och enkelt styrkepass (utan vikter). Alla kan vara med!\_</p>\n<p>Vi ses nedanför nerf-arenan. Ta gärna med vattenflaska, och en handduk om du inte vill vara direkt på gräset.\_</p>"
     link: null
     owner:
       name: ''
@@ -1916,8 +1980,12 @@ events:
     start: '20:19'
     end: '21:19'
     location: Servicehus
-    responsible: 'Edvin, Astor och Sam'
-    description: null
+    responsible: Edvin, Astor och Sam
+    description: |-
+      <p><strong>OBS! Kräver telefon eller dator!</strong></p>
+      <blockquote>
+      <p>En bestämd Kahoot! med mystery tema och sedan önskemål för Kahoot!<br />För er som inte vet: Kahoot! är en platform för quiz m.m. där man använder telefoner som kontroller.<br />(Det kommer troligtvis sluta tidigare) .</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -1932,8 +2000,10 @@ events:
     end: '14:00'
     location: GA Datorsal
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>En träff för alla engangerade Minecraftföräldrar och (speciellt lite äldre) spelare. Det är lite svårt att få till det sociala i den större Minecraftgruppen. Det förstörs en del saker och dödas, trots överenskomna regler, och det blir lätt grupperingar.</p>
+      <p>Låt oss slå ihop våra skallar, byta erfarenheter och fundera på vad vi kan förbättra till nästa år och hur vi genomför det.</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2245585752300578/
     owner:
       name: ''
       email: ''
@@ -1947,7 +2017,7 @@ events:
     end: '15:30'
     location: Tält1
     responsible: 'Jessica &amp; Sara '
-    description: null
+    description: "<p>14:00 - 15:00</p>\n<p>Vi som tillhör Stockholm/Mälardalen ses för en träff/fika tillsammans! Vad kan vi göra på hemmaplan? Vad finns för önskemål kring lokala aktiviteter, och hur får vi dem att hända?\_<br />Kom till Tält 1 kl 14:30!\_</p>"
     link: null
     owner:
       name: ''
@@ -1962,7 +2032,7 @@ events:
     end: '14:30'
     location: Kaffetält
     responsible: 'Johan '
-    description: null
+    description: "<p>Årsmöte för riks, därefter Stockholm.\_<br />välkomna!\_</p>"
     link: null
     owner:
       name: ''
@@ -1971,13 +2041,15 @@ events:
       created_at: '2023-07-01 12:07:22'
       updated_at: '2023-07-01 12:07:22'
   - id: arsmote-rfsb-darefter-lokalforening-stockholm-malardalen-2023-07-01-1400
-    title: 'Årsmöte RFSB, därefter lokalförening Stockholm Mälardalen'
+    title: Årsmöte RFSB, därefter lokalförening Stockholm Mälardalen
     date: '2023-07-01'
     start: '14:00'
     end: '14:00'
     location: Kaffetält
     responsible: Johan N
-    description: null
+    description: |-
+      <p>Se även kallelse. Den som inte fått kallelsen (t.ex. p.g.a. ej betald avgift när den skickades ut) kan få den via mail väl på plats.</p>
+      <p>Vi hoppas på snabba möten och det kanske mest "spännande" som ska beslutas är att öka delen av de tvåhundra kronorna som går till lokalföreningen, från 50 till 100kr per medlem samt ett stadgeändringsförslag som gör det möjligt att hålla årsmötet något senare vid behov.<br /><br />Välkomna!</p>
     link: null
     owner:
       name: ''
@@ -1986,13 +2058,15 @@ events:
       created_at: '2023-07-01 12:13:26'
       updated_at: '2023-07-01 12:13:26'
   - id: kahoot-pentesting-2023-07-01-2015
-    title: 'Kahoot! (pentesting)'
+    title: Kahoot! (pentesting)
     date: '2023-07-01'
     start: '20:15'
     end: '21:15'
     location: Servicehus
-    responsible: 'Edvin, Sam och Astor'
-    description: null
+    responsible: Edvin, Sam och Astor
+    description: |-
+      <h2>OBS! Telefen eller dator behövs!</h2>
+      <p>En bestämd Kahoot! med mystery tema och sedan önskemål för Kahoot!<br />För er som inte vet: Kahoot! är en platform för quiz m.m. där man använder telefoner som kontroller.<br />(Det kommer troligtvis sluta tidigare)<a href="https://ntfy.zibberflux.agency" target="_blank" rel="noopener">​</a></p>
     link: null
     owner:
       name: ''
@@ -2001,13 +2075,15 @@ events:
       created_at: '2023-07-01 19:09:57'
       updated_at: '2023-07-01 19:09:57'
   - id: kahoot-pentesting-och-onskemal-2023-07-01-2015
-    title: 'Kahoot! pentesting och önskemål'
+    title: Kahoot! pentesting och önskemål
     date: '2023-07-01'
     start: '20:15'
     end: '21:15'
     location: Servicehus
-    responsible: 'Astor, Sam och Edvin'
-    description: null
+    responsible: Astor, Sam och Edvin
+    description: |-
+      <h2>OBS! Telefen eller dator behövs!</h2>
+      <p>En bestämd Kahoot! med pentesting tema och sedan önskemål för Kahoot! tema.<br />För er som inte vet: Kahoot! är en platform för quiz m.m. där man använder telefoner som kontroller.<br />(Det kommer troligtvis sluta tidigare)<br /><a href="https://ntfy.zibberflux.agency/filur_hemlig" target="_blank" rel="noopener">​</a><br />PSST! SmFnIGhldGVyIFRyb2xsaWxpdXMhIEVuIGxpdGVuIHNwaW9uZsOlZ2VsIHZpc2thZGUgaSBtaXR0IMO2cmEgIk9tIG1hbiBrb2xsYXIgSFRNTCBrb2RlbiBww6UgZGVuIGjDpHIgc2lkYW4gc8OlIHNlciBtYW4gbsOlZ290IGhlbWxpZ3QhIg==</p>
     link: null
     owner:
       name: ''

--- a/source/data/2024-06-syssleback.yaml
+++ b/source/data/2024-06-syssleback.yaml
@@ -12,7 +12,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -27,7 +27,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -42,7 +42,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -57,7 +57,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -72,7 +72,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -87,7 +87,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -102,7 +102,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -117,7 +117,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -132,7 +132,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -147,7 +147,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -162,7 +162,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -177,7 +177,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -192,7 +192,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: ' '
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -207,7 +207,10 @@ events:
     end: '23:30'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+
+      Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt!
     link: null
     owner:
       name: ''
@@ -222,7 +225,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -237,7 +240,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -252,7 +255,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -267,7 +270,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -282,7 +285,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -297,7 +300,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -312,7 +315,7 @@ events:
     end: '20:45'
     location: Annat
     responsible: Alla
-    description: null
+    description: Vi samlas utanför GA-hallen för att rigga lägret!
     link: null
     owner:
       name: ''
@@ -327,7 +330,11 @@ events:
     end: '15:00'
     location: Annat
     responsible: Eget ansvar
-    description: null
+    description: |-
+      Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.
+      Det finns parkering för de som vill vara redo för “hemfärd”.
+      Annars är det en lagom promenad på vägen bakom receptionen.
+      Tiden är för det brukar vara lite “drop-in”.
     link: null
     owner:
       name: ''
@@ -342,7 +349,7 @@ events:
     end: '10:30'
     location: GA Idrott
     responsible: Andreas
-    description: null
+    description: Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
     link: null
     owner:
       name: ''
@@ -357,7 +364,9 @@ events:
     end: '15:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: |-
+      Gratis entré för lägerdeltagare.
+      Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om simhallen.
     link: null
     owner:
       name: ''
@@ -372,7 +381,9 @@ events:
     end: '15:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: |-
+      Gratis entré för lägerdeltagare.
+      Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om simhallen.
     link: null
     owner:
       name: ''
@@ -387,7 +398,9 @@ events:
     end: '15:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: |-
+      Gratis entré för lägerdeltagare.
+      Simhallen är öppen. Vuxna ansvarar för sina barn. För övriga tider se information om simhallen.
     link: null
     owner:
       name: ''
@@ -402,7 +415,11 @@ events:
     end: '15:00'
     location: GA Idrott
     responsible: Föräldrar
-    description: null
+    description: |-
+      RFSB lokalföreningar träffas denna tiden.
+      Inga andra aktiviteter denna tid där föräldrar behövs.
+
+      Det är för alla föräldrar att träffas i respektive förening. Se vilka som finns i sitt geografiska område och prata om vad som är lämpligt för respektive förening.
     link: null
     owner:
       name: ''
@@ -411,14 +428,14 @@ events:
       created_at: '2024-06-17 14:55:06'
       updated_at: '2024-06-17 14:55:06'
   - id: molles-rollspelskampanj-ordna-karaktarer-2024-06-24-1400
-    title: 'Molles rollspelskampanj, ordna karaktärer'
+    title: Molles rollspelskampanj, ordna karaktärer
     date: '2024-06-24'
     start: '14:00'
     end: '15:00'
     location: Rollspelstält2
     responsible: Molle
-    description: null
-    link: null
+    description: '<p>Alla i Molleskampanj tar fram karaktärer. Molle och Viktor hjälper till. Deltagare: Hulda, Astor, Johan R och Frank B.</p>'
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -432,8 +449,8 @@ events:
     end: '15:00'
     location: Rollspelstält1
     responsible: Selma
-    description: null
-    link: null
+    description: "<p>Ordna karaktärer. Selma och Harald finns på plats för att hjälpa till. Deltagare: Isabella F, Zet S, Xander, Wilhelm och Miranda.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -447,8 +464,8 @@ events:
     end: '17:00'
     location: Rollspelstält1
     responsible: 'Viktor Ängquist '
-    description: null
-    link: null
+    description: "<p>Ordna karaktärer inför rollspelet. Harald och Viktor hjälper till. Deltagare: Natan, Elias R, Vidar, Tova, Sofia, Edgar, Elias W, Emil och Ludvig.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -462,8 +479,8 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Molle
-    description: null
-    link: null
+    description: Session 1.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -477,8 +494,8 @@ events:
     end: '13:00'
     location: Rollspelstält1
     responsible: Selma
-    description: null
-    link: null
+    description: Session 1.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -492,7 +509,7 @@ events:
     end: '16:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
+    description: <p>Vi bakar ROLL CAKE inspirerat av recept från Ai Venturas bakbok ”Japansk bakning” och tillverkar egna POPPING BOBAS med hjälp av sfärifiering.</p>
     link: null
     owner:
       name: ''
@@ -507,7 +524,10 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: Birgitta
-    description: null
+    description: |-
+      <p>Diverse kunskapsspel tas med och vi enas om vad vi vill spela</p>
+      <p>TP<br />NE<br />När då då</p>
+      <p>Riket</p>
     link: null
     owner:
       name: ''
@@ -522,7 +542,12 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: Birgitta
-    description: null
+    description: |-
+      <p>Diverse kunskapsspel tas med och vi enas om vad vi vill spela</p>
+      <p>TP<br />NE<br />När då då</p>
+      <p>Riket</p>
+      <p>&nbsp;</p>
+      <p>OBS Utgår om det blir grillkväll vid älven fredag</p>
     link: null
     owner:
       name: ''
@@ -537,7 +562,14 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: Birgitta
-    description: null
+    description: |-
+      Diverse kunskapsspel tas med och vi enas om vad vi vill spela
+
+      TP
+      NE
+      När då då
+
+      Riket
     link: null
     owner:
       name: ''
@@ -552,8 +584,11 @@ events:
     end: '23:00'
     location: Grillplats
     responsible: 'Malin Isenfors '
-    description: null
-    link: null
+    description: |-
+      Vid 18.30 tänder vi eldarna och under kvällen bjuder vi på lite godsaker.
+
+      Ta med mat och dryck, gärna något att sitta på och äta med. Varma kläder och myggmedel är det också bra att ha. Badkläder för de som känner för det. Instrument är alltid trevligt.
+    link: https://www.facebook.com/groups/syssleback2024/posts/3811154542493588/
     owner:
       name: ''
       email: ''
@@ -561,14 +596,14 @@ events:
       created_at: '2024-06-20 16:46:25'
       updated_at: '2024-06-20 16:46:25'
   - id: bokcirkel-fallet-av-albert-camus-2024-06-26-1600
-    title: 'Bokcirkel "Fallet" av Albert Camus'
+    title: Bokcirkel "Fallet" av Albert Camus
     date: '2024-06-26'
     start: '16:00'
     end: '17:00'
     location: Kaffetält
     responsible: 'Christina '
-    description: null
-    link: null
+    description: "Inför bokcirkel, läs boken \"Fallet\" av Albert Camus.\n<ul>\n \t<li><a href=\"https://www.storytel.com/se/books/fallet-1081781\" target=\"_blank\" rel=\"noopener\">Storytel</a></li>\n \t<li><a href=\"https://nextory.com/se/author/albert-camus-13794\" target=\"_blank\" rel=\"noopener\">Nextory</a></li>\n \t<li><a href=\"https://www.bookbeat.com/se/book/fallet-290203\" target=\"_blank\" rel=\"noopener\">Bookbeat</a></li>\n \t<li><a href=\"https://biblioteket.stockholm.se/titel/49712\" target=\"_blank\" rel=\"noopener\">Stockholm stadsbibliotek</a></li>\n \t<li><a href=\"https://gotlib.overdrive.com/media/5950649\" target=\"_blank\" rel=\"noopener\">Göteborgs bibliotek</a></li>\n \t<li>Finns säkerligen på många fler bibliotek, som e-bok och ljudbok.</li>\n</ul>\nVi diskuterar Fallet av Albert Camus utifrån följande diskussionsfrågor:\n\nSkuld och moraliskt ansvar:\n\nHur behandlar Camus temat skuld och moraliskt ansvar i \"Fallet\"? Diskutera huvudkaraktären Jean-Baptiste Clamence's känslor av skuld och hur de påverkar hans handlingar och syn på världen. Hur reflekterar detta över människans natur och vår benägenhet att undvika ansvar?\n\n&nbsp;\n\nBerättarteknik och struktur:\n\n\"Fallet\" är skriven som en monolog där Clamence berättar sin historia för en okänd åhörare. Hur påverkar denna berättarstil din uppfattning av berättelsen och karaktären? Diskutera hur monologformen bidrar till bokens teman och Camus' filosofiska budskap.\n\n&nbsp;\n\nExistentialism och absurditet:\n\nAlbert Camus är känd för sina existentialistiska och absurdistiska teman. Hur manifesterar sig dessa filosofiska idéer i \"Fallet\"? Diskutera Clamence's syn på livet, frihet, och existens. Hur speglar hans resa och förändring Camus' tankar om det absurda?\n\n&nbsp;\n\nMoraliskt förfall och mänskliga relationer:\n\nClamence beskriver sitt eget moraliska förfall och hur han manipulerar och dömer andra människor. Hur ser du på hans relationer med andra och hans försök att konfrontera sin egen hyckleri? Diskutera hur boken utforskar människans komplexa och ofta motsägelsefulla natur."
+    link: https://www.facebook.com/share/p/KK9rK6LCedHrk8Ue/
     owner:
       name: ''
       email: ''
@@ -582,7 +617,7 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: Lisa Lautrup
-    description: null
+    description: Vi bakar ROLL CAKE inspirerat av recept från Ai Venturas bakbok ”Japanska bakverk” och tillverkar egna POPPING BOBAS med hjälp av sfärifiering.
     link: null
     owner:
       name: ''
@@ -597,7 +632,10 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
+    description: |-
+      OBS! Lisa planerar åka hem. Saker finns kvar. Recept finns. Någon som kan tänkas ta ansvar och genomföra aktiviteten?
+
+      Vi bakar ROLL CAKE inspirerat av recept från Ai Venturas bakbok ”Japanska bakverk” och tillverkar egna POPPING BOBAS med hjälp av sfärifiering.
     link: null
     owner:
       name: ''
@@ -612,8 +650,8 @@ events:
     end: '17:00'
     location: Nerf-arena
     responsible: 'Christina '
-    description: null
-    link: null
+    description: <p>Bäst I test som i tv-programmet. Lagindelning på plats. Samling utanför GA-hallen.</p>
+    link: https://www.facebook.com/groups/syssleback2023/permalink/2230210373838116/
     owner:
       name: ''
       email: ''
@@ -627,8 +665,8 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Molle
-    description: null
-    link: null
+    description: <p>Rollspel. Fullbokat.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -643,7 +681,7 @@ events:
     location: Rollspelstält1
     responsible: Selma
     description: null
-    link: null
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -657,8 +695,8 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Viktor och Harald Ängquist
-    description: null
-    link: null
+    description: <p>Rollspel för ungdomar 16-22 år. Fullbokat.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -672,8 +710,8 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Viktor och Harald Ängquist
-    description: null
-    link: null
+    description: <p>Rollspel för ungdomar 16-22 år. Fullbokat.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -687,8 +725,8 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Viktor och Harald Ängquist
-    description: null
-    link: null
+    description: <p>Rollspel för ungdomar 16-22 år. Fullbokat.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -703,7 +741,7 @@ events:
     location: Rollspelstält1
     responsible: Viktor Ängquist
     description: null
-    link: null
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -717,8 +755,8 @@ events:
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: <p>Spelledarkurs – kurskampanj 1 session 2 - Fullbokad</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -732,8 +770,8 @@ events:
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: <p>Spelledarkurs – kurskampanj 2 session 1 - Fullbokad</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -747,8 +785,8 @@ events:
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: <p>Spelledarkurs – kurskampanj 2 session 2 - Fullbokad</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -762,8 +800,8 @@ events:
     end: '12:30'
     location: Rollspelstält2
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: <p><span class="x193iq5w xeuugli x13faqbe x1vvkbs x10flsy6 x1lliihq x1s928wv xhkezso x1gmr53x x1cpjm7i x1fgarty x1943h6x x4zkp8e x41vudc x6prxxf xvq8zen xo1l8bm xzsf02u x1yc453h" dir="auto">Prova-på-kampanj 2</span> - fullbokad</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -777,8 +815,8 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Viktor och Harald Ängquist
-    description: null
-    link: null
+    description: Rollspel för 16-21-åringar. Fullbokat.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -792,8 +830,8 @@ events:
     end: '13:00'
     location: Rollspelstält1
     responsible: Selma
-    description: null
-    link: null
+    description: <p>Rollspel för föranmälda.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -807,8 +845,8 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Viktor och Harald Ängquist
-    description: null
-    link: null
+    description: Rollspel för ungdomar 16-22 år. Fullbokat.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -822,8 +860,8 @@ events:
     end: '21:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: "<p>Spelledarkurs. Viktor håller föredrag om hur man leder rollspel som spelledare. Anmälda: Alexander, Edgar, Hampus, Wilhelm, Xander och Ludvig.\_</p>\n<p>Detta föredrag är öppet även för de som inte går övriga delen av kursen. Kursen är full.</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -837,7 +875,7 @@ events:
     end: '11:55'
     location: GA Stilla hyllan
     responsible: Karin
-    description: null
+    description: Vi testar Diamond painting tillsammans.
     link: null
     owner:
       name: ''
@@ -852,7 +890,9 @@ events:
     end: '14:30'
     location: GA Datorsal
     responsible: Birgitta/Lukas
-    description: null
+    description: |-
+      <p>Lukas förklarar hur 5D schack fungerar.</p>
+      <p>Vid intresse blir det tid bokad för att spela 5D schack på onsdag.</p>
     link: null
     owner:
       name: ''
@@ -867,8 +907,13 @@ events:
     end: '22:30'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>I år kommer vi att sätta upp en scen i GA-hallen under två kvällar för Open Stage. På Open Stage får alla som vill chansen att stå på scen och uppträda inför publik, vare sig det är med sång, dans, musik, poesi, cirkustricks, stand-up comedy, buktaleri, ett kort teaterframträdande, eller något annat ni vill visa upp.</p>
+      <p>Det krävs ingen föranmälan – du kan bestämma på plats om du vill vara med. På många läger där det finns Open Stage händer det också att man övar in något under lägret med några vänner och sedan uppträder tillsammans.</p>
+      <p>Om det är första gången du uppträder är Open Stage på ett läger där du har lärt känna lite folk under veckan, ett utmärkt och tryggt tillfälle att prova dina vingar för första gången.</p>
+      <p>Det kommer att finnas ljud- och ljusanläggning, mikrofoner, en cajón (trumlåda), och några gitarreffekter/förstärkarsimuleringar tillgängliga. Övrig rekvisita (instrument eller liknande) ordnar man själv. Det kommer också finnas möjlighet att ha inspelad bakgrundsmusik till sitt uppträdande.</p>
+      <p>Fundera på vad ni vill uppträda med, både ungdomar och vuxna, och börja eventuella förberedelser! Vi ses på Open Stage i GA-hallen!</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3798501577092218/
     owner:
       name: ''
       email: ''
@@ -882,7 +927,7 @@ events:
     end: '20:00'
     location: GA Idrott
     responsible: Lotta Tyldhed
-    description: null
+    description: "<p>Välkommen till världshistoriens första SyssCon!</p>\n<p>Marknaden öppnar kl 12 och vi håller till i \"gången\" i GA-hallen.\_\_</p>\n<p>För de som vill ställa ut på marknaden öppnar vi kl 11 för att hinna rigga borden. Anmälan om bord sker via sms till Lotta på 0739876617.</p>"
     link: null
     owner:
       name: ''
@@ -897,7 +942,7 @@ events:
     end: '19:30'
     location: GA Idrott
     responsible: Lotta Tyldhed
-    description: null
+    description: "<p>Välkommen till världshistoriens första SyssCon!</p>\n<p>Självklart innehåller SyssCon en Cosplay-parad! Klä upp dig i din favorit-karaktär, låna en kostym eller sätt bara på dig en kul hatt! Kliv utanför din comfort zone eller in i ditt sanna jag och visa upp det för världen och ta emot folkets jubel.\_</p>\n<p>Vi kommer att låna scenen som byggs under veckan och som troligtvis (?) ställs i GA-hallen, och presentera våra alter-egon på scenen.\_\_</p>\n<p>Inget krav på anmälan, men skicka ett sms till mig senast på torsdagen på 0739876617 om du vill låna någon kostym.</p>"
     link: null
     owner:
       name: ''
@@ -912,7 +957,12 @@ events:
     end: '14:00'
     location: Kaffetält
     responsible: Hampus Sommerfeld
-    description: null
+    description: |-
+      Denna aktivitet är ämnad för alla med grundläggande kunskaper i schack som vill prova på spel med klocka.
+
+      Hur en schackklocka fungerar samt etikett inom schack kommer läras ut.
+
+      På plats kommer det finnas tio bräden med klocka.
     link: null
     owner:
       name: ''
@@ -927,8 +977,25 @@ events:
     end: '15:00'
     location: GA Stilla hyllan
     responsible: D Tiger Gruneau
-    description: null
-    link: null
+    description: |-
+      Aktivitet: <strong>Prova på vinyltryckning</strong>.
+
+      Tryck på tyg. Enkelt och kan vara lätt, men definitivt kul att sätta sitt avtryck och träna på sin kreativa sida. Jag tänkte ta med utrustning och förbrukningsvaror i år igen.
+
+      &nbsp;
+
+      Tanken är då att man kan ta med egna tygsaker att trycka på (100% bomull, allt på egen risk) så kan man få sitt motiv att trycka på detta, eller så kan man testa att skapa och trycka sitt motiv på tygkassar jag tar med. Tar med några färger på tygkassar, några färger på vinyl.
+
+      &nbsp;
+
+      Kostnadsfritt för ett tryck per deltagande barn, föreningen bjuder på det.
+
+      &nbsp;
+
+      Vill man förbereda kan man rita lite eller göra design man gillar. Rita på papper, generera i AI. Enklare motiv är väsentligt lättare än komplexa motiv. Motiven blir monokroma, en färg (vinylens) på bakgrund (tyget). Man kan innan testa att manipulera motiven i Inkscape (gratis) eller Adobe Illustrator för att skapa vektorfil som original.
+
+      OBS att detta är en aktivitet för ungarna där man kan hjälpa till som äldre deltagare. Skulle ungarna vara intresserade av att trycka motiv med "Ditt företag AB" blir jag fundersam Vill du ha något skapat och tryck kan jag lämna en offert till dig/ert företag. Jag är också väldigt strikt kring att inte använda någon annans intellektuella egendom, så tryck av Musse Pigg, eller Balenciaga blir det stopp på.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3798422803766762/
     owner:
       name: ''
       email: ''
@@ -942,8 +1009,8 @@ events:
     end: '15:00'
     location: GA Stilla hyllan
     responsible: D Tiger Gruneau
-    description: null
-    link: null
+    description: "<p class=\"p1\"><span class=\"s1\">Aktivitet: </span><strong><span class=\"s2\">Prova på vinyltryckning</span></strong><span class=\"s1\">. </span></p>\n<p class=\"p1\"><span class=\"s1\">Tryck på tyg. Enkelt och kan vara lätt, men definitivt kul att sätta sitt avtryck och träna på sin kreativa sida. Jag tänkte ta med utrustning och förbrukningsvaror i år igen.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Tanken är då att man kan ta med egna tygsaker att trycka på (100% bomull, allt på egen risk) så kan man få sitt motiv att trycka på detta, eller så kan man testa att skapa och trycka sitt motiv på tygkassar jag tar med. Tar med några färger på tygkassar, några färger på vinyl.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Kostnadsfritt för ett tryck per deltagande barn, föreningen bjuder på det.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Vill man förbereda kan man rita lite eller göra design man gillar. Rita på papper, generera i AI. Enklare motiv är väsentligt lättare än komplexa motiv. Motiven blir monokroma, en färg (vinylens) på bakgrund (tyget). Man kan innan testa att manipulera motiven i Inkscape (gratis) eller Adobe Illustrator för att skapa vektorfil som original.</span></p>\n<p class=\"p1\"><span class=\"s1\">OBS att detta är en aktivitet för ungarna där man kan hjälpa till som äldre deltagare. Skulle ungarna vara intresserade av att trycka motiv med “Ditt företag AB” blir jag fundersam Vill du ha något skapat och tryck kan jag lämna en offert till dig/ert företag. Jag är också väldigt strikt kring att inte använda någon annans intellektuella egendom, så tryck av Musse Pigg, eller Balenciaga blir det stopp på.</span></p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3798422803766762/
     owner:
       name: ''
       email: ''
@@ -957,8 +1024,8 @@ events:
     end: '15:00'
     location: GA Stilla hyllan
     responsible: D Tiger Gruneau
-    description: null
-    link: null
+    description: "<p class=\"p1\"><span class=\"s1\">Aktivitet: </span><strong><span class=\"s2\">Prova på vinyltryckning</span></strong><span class=\"s1\">. </span></p>\n<p class=\"p1\"><span class=\"s1\">Tryck på tyg. Enkelt och kan vara lätt, men definitivt kul att sätta sitt avtryck och träna på sin kreativa sida. Jag tänkte ta med utrustning och förbrukningsvaror i år igen.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Tanken är då att man kan ta med egna tygsaker att trycka på (100% bomull, allt på egen risk) så kan man få sitt motiv att trycka på detta, eller så kan man testa att skapa och trycka sitt motiv på tygkassar jag tar med. Tar med några färger på tygkassar, några färger på vinyl.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Kostnadsfritt för ett tryck per deltagande barn, föreningen bjuder på det.</span></p>\n<p class=\"p1\"><span class=\"s1\">\_</span></p>\n<p class=\"p1\"><span class=\"s1\">Vill man förbereda kan man rita lite eller göra design man gillar. Rita på papper, generera i AI. Enklare motiv är väsentligt lättare än komplexa motiv. Motiven blir monokroma, en färg (vinylens) på bakgrund (tyget). Man kan innan testa att manipulera motiven i Inkscape (gratis) eller Adobe Illustrator för att skapa vektorfil som original.</span></p>\n<p class=\"p1\"><span class=\"s1\">OBS att detta är en aktivitet för ungarna där man kan hjälpa till som äldre deltagare. Skulle ungarna vara intresserade av att trycka motiv med “Ditt företag AB” blir jag fundersam Vill du ha något skapat och tryck kan jag lämna en offert till dig/ert företag. Jag är också väldigt strikt kring att inte använda någon annans intellektuella egendom, så tryck av Musse Pigg, eller Balenciaga blir det stopp på.</span></p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3798422803766762/
     owner:
       name: ''
       email: ''
@@ -972,8 +1039,8 @@ events:
     end: '12:30'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: "<p>Deltagare: Charlie, Hilding, Thor och Hampus, 10 år.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -987,7 +1054,7 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Magnus carlsson '
-    description: null
+    description: "<p>Tänkte att vi målar modeller till spelet, för att sedan vi ett senare tillfälle spela igenom ett eller fler scenarion.</p>\n<p>Passande för åldrar 12 och uppåt.\_</p>\n<p>5platser .</p>"
     link: null
     owner:
       name: ''
@@ -1002,8 +1069,8 @@ events:
     end: '10:00'
     location: Servicehus
     responsible: RFSB Stockholm/Mälardalen
-    description: null
-    link: null
+    description: "<p>Måndag direkt efter frukost kl 9.15 ordnar vi ett \"Lära känna\" Bingo för ALLA.</p>\n<p>Det är viktigt att nya och gamla deltagare dyker upp för att knyta nya vänskapsband.</p>\n<p>Självklart kommer det att finnas glass för de barn som lämnar in ett slutfört uppdrag, men vi vill att även vuxna deltar.\_</p>\n<p>Vi ses utanför servicehuset.</p>\n<p>Välkomna!</p>"
+    link: https://www.facebook.com/share/p/p83zRmTYXiifFEdN/
     owner:
       name: ''
       email: ''
@@ -1017,8 +1084,8 @@ events:
     end: '22:30'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: Spelledarkurs – kurskampanj 1 session 1 – Fullbokad
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3789144938027882/
     owner:
       name: ''
       email: ''
@@ -1032,8 +1099,8 @@ events:
     end: '20:00'
     location: Annat
     responsible: Andreas (Lägernissen)
-    description: null
-    link: null
+    description: "<strong>Bilder finns i facebook - se länken.\n\nMöte:</strong>\nVi börjar med avetablering, alla hjälps åt!\nNär vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.\nOfta en gemensam bild på alla deltagare.\n\n<strong>Avetablering:</strong>\n<ul>\n \t<li>Gemensam översyn på området med iordningställande och städ.</li>\n \t<li>Alla tält packas ner.</li>\n \t<li>All utrustning tas om hand.</li>\n \t<li>Alla gemensamma ytor sopas.</li>\n \t<li>Gräsytor utomhus gås igenom och skräp plockas upp.</li>\n</ul>\nLost and found, vid ingång till GA-hallen.\n\n<strong>Plats:</strong>\nGräsytan mellan tälten och lekplatsen.\nVid dåligt väder, GA-hallen."
+    link: https://www.facebook.com/groups/syssleback2024/posts/3817946891814353/
     owner:
       name: ''
       email: ''
@@ -1041,13 +1108,13 @@ events:
       created_at: '2024-06-22 22:31:14'
       updated_at: '2024-06-22 22:31:14'
   - id: bygg-ditt-egna-bradspel-2024-06-24-1830
-    title: 'Bygg ditt egna brädspel!'
+    title: Bygg ditt egna brädspel!
     date: '2024-06-24'
     start: '18:30'
     end: '20:00'
     location: GA Stilla hyllan
     responsible: Ivar och Harald Ängquist
-    description: null
+    description: Vi tar fram lite kartonger, platsfigurer, kort och annat material som passar för brädspelsbygge. En kreativ aktivitet för alla som gillar brädspel och/eller att pyssla.
     link: null
     owner:
       name: ''
@@ -1062,8 +1129,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!<br /><br />Frågor? Se FB-tråden.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1077,8 +1144,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!<br /><br />Frågor? Se FB-tråden.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1092,8 +1159,10 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!</p>
+      <p>Frågor? Se FB-tråden.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1107,8 +1176,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1122,8 +1191,10 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!</p>
+      <p>Frågor? Se FB-tråden.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1137,8 +1208,10 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Gillar du att sjunga eller spela instrument? Varje dag klockan 16 träffas vi och sjunger och spelar ihop, nybörjare som erfarna. Opretantiöst och relativt oorganiserat. Någon föreslår en låt, vi letar upp lite ackord, noter och text på internet eller spelar efter gehör eller tittar på hur någon annan gör, och vi försöker spela och sjunga låten ihop. Ibland låter det riktigt bra och ibland får vi inte ihop det alls, men vi har väldigt kul och lär oss! Vi kör dagligen, så man har alltid möjlighet att och öva på någon låt till nästa dag om man vill. Alla instrument är välkomna. Vi har haft gitarrer, bas, olika slagverk, violin, keyboards m.m. och ju större variation, destu roligare!</p>
+      <p>Frågor? Se FB-tråden.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813205018955207/
     owner:
       name: ''
       email: ''
@@ -1146,14 +1219,16 @@ events:
       created_at: '2024-06-23 10:23:07'
       updated_at: '2024-06-23 10:23:07'
   - id: i-wanna-rock-elgitarr-for-nyborjare-2024-06-24-1400
-    title: 'I WANNA ROCK! – Elgitarr för nybörjare'
+    title: I WANNA ROCK! – Elgitarr för nybörjare
     date: '2024-06-24'
     start: '14:00'
     end: '15:45'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Elgitarr för nybörjare! Ta med gitarr och förstärkare. Se FB-tråd för detaljer.</p>
+      <p>(Om ni har en akustisk gitarr men ändå vill spela hårdare rock så går det att lära sig elgitarrsgrunderna även på en akustisk, även om det inte låter alls så rockigt)</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3812101165732259/
     owner:
       name: ''
       email: ''
@@ -1167,7 +1242,7 @@ events:
     end: '23:55'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: <p>Platshållare för att indikera att dagen är slut, inga mer aktiviteter.</p>
     link: null
     owner:
       name: ''
@@ -1182,7 +1257,7 @@ events:
     end: '15:00'
     location: Grillplats
     responsible: 'Charlotte Anderberg '
-    description: null
+    description: "<p style=\"text-align: center\"><!--more-->Kom ner till grillplatsen vid älven och baka tunnbröd med familjen Jarder Anderberg. I år prövas nytt recept med jäst.\_</p>\n<p>Deg finns färdig. Kavla, stek brödet på stekhäll och så får man sen få mumsa i sig \"Gudruns mjuka tunnbröd\" med lite smör.</p>\n<p>Drop-in: med start 13.00 och fortsätter till 15 eller till att degen tar slut.\_</p>\n<p>Behöver man hjälp med att steka brödet är det bra med en förälder.\_</p>"
     link: null
     owner:
       name: ''
@@ -1197,8 +1272,12 @@ events:
     end: '11:30'
     location: Annat
     responsible: 'Elin Sommerfeld '
-    description: null
-    link: null
+    description: |-
+      <p class="p1">Systemkamerans grunder</p>
+      <p class="p1"><span class="s1">Vi går igenom hur man fotar manuellt. </span></p>
+      <p class="p1"><span class="s1">Bländare-slutare-iso hur de funkar och samspelar. Sen får man testa att fota och vi finns med och hjälper till. </span></p>
+      <p class="p1"><span class="s1">Plats: kvistbergsvägen 2, man går in genom grinden och in u det vita tornet. </span></p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813344288941280/
     owner:
       name: ''
       email: ''
@@ -1212,8 +1291,11 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Jessica Larsson
-    description: null
-    link: null
+    description: |-
+      <p class="p1"><span class="s1">Välkommen att vara med på en dansaktivitet där vi lär oss en koreograferad dans till låten ”My oh my” av Ava Max som Nelly Bergqvist har koreograferat. </span></p>
+      <p class="p1"><span class="s1">Alla som vill är välkomna att delta. Målet (för dom som vill) är att visa upp dansen under Open stage men det är inget tvång att uppträda. Kom ändå även om du bara vill lära dig dansen. </span></p>
+      <p class="p1"><span class="s1">Samling vid kaffetältet så dansar vi på gräsmattan.</span></p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813649962244046/
     owner:
       name: ''
       email: ''
@@ -1227,7 +1309,7 @@ events:
     end: '15:30'
     location: Kaffetält
     responsible: Caroline och Kerstin Bastholm
-    description: null
+    description: "<p>Skapa kreativa figurer och alster i papperslera. Leran behöver inte brännas och kan målas/färgläggas med tuschpennor efter ett par dagar när den torkat. Det går bra att komma och gå som man vill under passets gång.\_</p>"
     link: null
     owner:
       name: ''
@@ -1242,7 +1324,7 @@ events:
     end: '11:45'
     location: Servicehus
     responsible: Christina Falk
-    description: null
+    description: "<p>Vi tränar in en lägerdans tillsammans (Jazz- och streetinspirerat). De som vill kan sedan visa upp den på Open Stage på onsdagen. Vi tränar förstås fler gånger under veckan.</p>\n<p>Selma 11 år, vars stora intresse är dans, har gjort dans-koreografin och kommer att lära ut den.\_\_</p>\n<p>Alla är välkomna!</p>"
     link: null
     owner:
       name: ''
@@ -1257,7 +1339,7 @@ events:
     end: '16:10'
     location: Nerf-arena
     responsible: Astor och Martin
-    description: null
+    description: <p>Strid i nerf-arenan med lajvvapen.Ta med om ni har, vi har fyra svärd.</p>
     link: null
     owner:
       name: ''
@@ -1272,7 +1354,7 @@ events:
     end: '12:30'
     location: Annat
     responsible: Robert Sabelström
-    description: null
+    description: <p>Välkomna alla barn.</p>
     link: null
     owner:
       name: ''
@@ -1286,8 +1368,8 @@ events:
     start: '10:30'
     end: '12:00'
     location: Tält1
-    responsible: 'Malin, Simon'
-    description: null
+    responsible: Malin, Simon
+    description: "<p>Nyfiken på hur det egentligen går till vid en uppflytt? Malin delar med sig av sina erfarenheter som förälder och Simon från ett elevperspektiv. Kanske du också har erfarenheter att dela med dig av?\_</p>"
     link: null
     owner:
       name: ''
@@ -1302,7 +1384,7 @@ events:
     end: '14:30'
     location: Annat
     responsible: 'Familjen Thulemark '
-    description: null
+    description: "<p>Kom och rita på krypplast som blir till små nyckelringar (eller annat).\_</p>\n<p>Vi sitter i vandrarhemmet och värmer plasten här.\_</p>"
     link: null
     owner:
       name: ''
@@ -1317,7 +1399,7 @@ events:
     end: '16:30'
     location: GA Stilla hyllan
     responsible: Anna Björnson
-    description: null
+    description: "<p>Hej alla föräldrar/vårdnadshavare till barn/ungdomar som ska spela rollspel i de kamanjer mm som samordnas av Jenny von Bahr.</p>\n<p>\_Kl 16.00 idag måndag ses vi vuxna/vårdnadshavare på \"hyllan\" i GA-hallen för att bestämma vilka som fixar fika till vilket pass.</p>\n<p>2 vuxna per pass ansvarar för att se till att det finns saft, vatten, fika och frukt till de som spelar.</p>"
     link: null
     owner:
       name: ''
@@ -1347,8 +1429,8 @@ events:
     end: '20:30'
     location: GA Idrott
     responsible: Ivar Ängquist
-    description: null
-    link: null
+    description: En klassisk rfsb-tävling där du får utmana alla hjärnans delar. Slå ihop 3-5 kloka huvuden och visa vad ni går för i ett dussintal stationer. Både föräldrar, barn och ungdomar är välkomna.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3812892522319790/?app=fbl
     owner:
       name: ''
       email: ''
@@ -1362,8 +1444,22 @@ events:
     end: '13:00'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: |-
+      <div dir="auto">
+      <div dir="auto">
+
+      Föräldrar får gärna stanna kvar under passet och hjälpa till med enklare göromål som att trä tråd på nålar, hjälpa till att klippa filt/vadmal etc.
+
+      Drop in, och det har varit fler barn på passen periodvis än vad jag(Helena) ensam kan hantera. Det blir så långa köer för att få hjälp annars.
+
+      </div>
+      <div dir="auto">Föräldrar får också väldigt gärna sy ett eget litet projekt under tiden, det finns material så det räcker!</div>
+      Syhörnan med skarvsöm och annat uppe på hyllan i idrotshallen hann dra igång på begäran redan innan jag hann lägga upp passet på schemat...men i morgon och alla andra dagar fram t.o.m. lördag så är syhörnan bemannad från 10.00 till 13.00.
+
+      </div>
+      <div dir="auto">Det finns möjlighet till både handsömnad och maskinsömnad, vi hjälps åt med design och mönster eller så finns mallar till några färdiga projekt om man vill börja sy direkt.</div>
+      <div dir="auto">Det kan hända att det kan bli fler tillfällen, det handlar om när det finns plats uppe på hyllan. Kolla med mig om du har lust att sy/designa/skapa utöver det dagliga passet.</div>
+    link: https://www.facebook.com/groups/syssleback2024/posts/3814071042201938/
     owner:
       name: ''
       email: ''
@@ -1377,8 +1473,22 @@ events:
     end: '13:00'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: |-
+      <div dir="auto">
+      <div dir="auto">
+
+      Föräldrar får gärna stanna kvar under passet och hjälpa till med enklare göromål som att trä tråd på nålar, hjälpa till att klippa filt/vadmal etc.
+
+      Drop in, och det har varit fler barn på passen periodvis än vad jag(Helena) ensam kan hantera. Det blir så långa köer för att få hjälp annars.
+
+      </div>
+      <div dir="auto">Föräldrar får också väldigt gärna sy ett eget litet projekt under tiden, det finns material så det räcker!</div>
+      Syhörnan med skarvsöm och annat uppe på hyllan i idrotshallen hann dra igång på begäran redan innan jag hann lägga upp passet på schemat...men i morgon och alla andra dagar fram t.o.m. lördag så är syhörnan bemannad från 10.00 till 13.00.
+
+      </div>
+      <div dir="auto">Det finns möjlighet till både handsömnad och maskinsömnad, vi hjälps åt med design och mönster eller så finns mallar till några färdiga projekt om man vill börja sy direkt.</div>
+      <div dir="auto">Det kan hända att det kan bli fler tillfällen, det handlar om när det finns plats uppe på hyllan. Kolla med mig om du har lust att sy/designa/skapa utöver det dagliga passet.</div>
+    link: https://www.facebook.com/groups/syssleback2024/posts/3814071042201938/
     owner:
       name: ''
       email: ''
@@ -1392,8 +1502,22 @@ events:
     end: '13:00'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: |-
+      <div dir="auto">
+      <div dir="auto">
+
+      Föräldrar får gärna stanna kvar under passet och hjälpa till med enklare göromål som att trä tråd på nålar, hjälpa till att klippa filt/vadmal etc.
+
+      Drop in, och det har varit fler barn på passen periodvis än vad jag(Helena) ensam kan hantera. Det blir så långa köer för att få hjälp annars.
+
+      </div>
+      <div dir="auto">Föräldrar får också väldigt gärna sy ett eget litet projekt under tiden, det finns material så det räcker!</div>
+      Syhörnan med skarvsöm och annat uppe på hyllan i idrotshallen hann dra igång på begäran redan innan jag hann lägga upp passet på schemat...men i morgon och alla andra dagar fram t.o.m. lördag så är syhörnan bemannad från 10.00 till 13.00.
+
+      </div>
+      <div dir="auto">Det finns möjlighet till både handsömnad och maskinsömnad, vi hjälps åt med design och mönster eller så finns mallar till några färdiga projekt om man vill börja sy direkt.</div>
+      <div dir="auto">Det kan hända att det kan bli fler tillfällen, det handlar om när det finns plats uppe på hyllan. Kolla med mig om du har lust att sy/designa/skapa utöver det dagliga passet.</div>
+    link: https://www.facebook.com/groups/syssleback2024/posts/3814071042201938/
     owner:
       name: ''
       email: ''
@@ -1407,8 +1531,22 @@ events:
     end: '13:00'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: |-
+      <div dir="auto">
+      <div dir="auto">
+
+      Föräldrar får gärna stanna kvar under passet och hjälpa till med enklare göromål som att trä tråd på nålar, hjälpa till att klippa filt/vadmal etc.
+
+      Drop in, och det har varit fler barn på passen periodvis än vad jag(Helena) ensam kan hantera. Det blir så långa köer för att få hjälp annars.
+
+      </div>
+      <div dir="auto">Föräldrar får också väldigt gärna sy ett eget litet projekt under tiden, det finns material så det räcker!</div>
+      Syhörnan med skarvsöm och annat uppe på hyllan i idrotshallen hann dra igång på begäran redan innan jag hann lägga upp passet på schemat...men i morgon och alla andra dagar fram t.o.m. lördag så är syhörnan bemannad från 10.00 till 13.00.
+
+      </div>
+      <div dir="auto">Det finns möjlighet till både handsömnad och maskinsömnad, vi hjälps åt med design och mönster eller så finns mallar till några färdiga projekt om man vill börja sy direkt.</div>
+      <div dir="auto">Det kan hända att det kan bli fler tillfällen, det handlar om när det finns plats uppe på hyllan. Kolla med mig om du har lust att sy/designa/skapa utöver det dagliga passet.</div>
+    link: https://www.facebook.com/groups/syssleback2024/posts/3814071042201938/
     owner:
       name: ''
       email: ''
@@ -1422,8 +1560,22 @@ events:
     end: '13:00'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: |-
+      <div dir="auto">
+      <div dir="auto">
+
+      Föräldrar får gärna stanna kvar under passet och hjälpa till med enklare göromål som att trä tråd på nålar, hjälpa till att klippa filt/vadmal etc.
+
+      Drop in, och det har varit fler barn på passen periodvis än vad jag(Helena) ensam kan hantera. Det blir så långa köer för att få hjälp annars.
+
+      </div>
+      <div dir="auto">Föräldrar får också väldigt gärna sy ett eget litet projekt under tiden, det finns material så det räcker!</div>
+      Syhörnan med skarvsöm och annat uppe på hyllan i idrotshallen hann dra igång på begäran redan innan jag hann lägga upp passet på schemat...men i morgon och alla andra dagar fram t.o.m. lördag så är syhörnan bemannad från 10.00 till 13.00.
+
+      </div>
+      <div dir="auto">Det finns möjlighet till både handsömnad och maskinsömnad, vi hjälps åt med design och mönster eller så finns mallar till några färdiga projekt om man vill börja sy direkt.</div>
+      <div dir="auto">Det kan hända att det kan bli fler tillfällen, det handlar om när det finns plats uppe på hyllan. Kolla med mig om du har lust att sy/designa/skapa utöver det dagliga passet.</div>
+    link: https://www.facebook.com/groups/syssleback2024/posts/3814071042201938/
     owner:
       name: ''
       email: ''
@@ -1437,7 +1589,7 @@ events:
     end: '18:30'
     location: GA Kreativ hörna
     responsible: Robert Sabelström
-    description: null
+    description: <p><strong>jag målar naglarna på andra med små detaljer, t.e.x blommor och annat.</strong></p>
     link: null
     owner:
       name: ''
@@ -1452,8 +1604,10 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Anne och Anna
-    description: null
-    link: null
+    description: |-
+      <p>Lägrets första föräldrafika, där vi delar erfarenheter och tips om 2e (npf i kombination med särskild begåvning).</p>
+      <p>Du är välkommen både om ditt barn redan har en npf-diagnos eller om ni funderar på om barnet skulle vara 2e.</p>
+    link: https://www.facebook.com/story.php?id=3573251722950539&amp;story_fbid=3814221818853527
     owner:
       name: ''
       email: ''
@@ -1461,14 +1615,14 @@ events:
       created_at: '2024-06-24 17:37:57'
       updated_at: '2024-06-24 17:37:57'
   - id: foraldrafika-provning-uppflytt-att-ta-studenten-vid-16-2024-06-27-1000
-    title: 'Föräldrafika - prövning, uppflytt, att ta studenten vid 16'
+    title: Föräldrafika - prövning, uppflytt, att ta studenten vid 16
     date: '2024-06-27'
     start: '10:00'
     end: '11:00'
     location: Tält1
     responsible: Anne och Anna
-    description: null
-    link: null
+    description: <p>Lägrets andra föräldrafika, där vi delar erfarenheter och tips om om uppflytt, prövning och vad man kan göra när man tagit studenten som 16-åring.</p>
+    link: https://www.facebook.com/story.php?id=3573251722950539&amp;story_fbid=3814221818853527
     owner:
       name: ''
       email: ''
@@ -1482,8 +1636,8 @@ events:
     end: '11:00'
     location: Tält1
     responsible: Anna
-    description: null
-    link: null
+    description: <p>Lägrets sista föräldrafika, där vi delar erfarenheter och tips om dyslexi i kombination med särskild begåvning.</p>
+    link: https://www.facebook.com/story.php?id=3573251722950539&amp;story_fbid=3814240985518277
     owner:
       name: ''
       email: ''
@@ -1496,9 +1650,9 @@ events:
     start: '20:00'
     end: '22:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Albin, Malin, Karin'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Malin, Karin
+    description: <p>En lugn stund. Färgpennor, akvarell, markers och annat finns. Ta med eget om du har favoriter. Tilde och Albin tar med extra eget som lånas ut. Anmäl på FB eller till Tilde och få bekräftat att plats finns då det är liten plats.</p>
+    link: https://www.facebook.com/share/p/qghR4yeFUaUPdUdo/
     owner:
       name: ''
       email: ''
@@ -1512,7 +1666,7 @@ events:
     end: '14:30'
     location: Kaffetält
     responsible: 'Kerstin Eiman '
-    description: null
+    description: "<p>Ta med din stickning eller virkning och en kopp kaffe eller te. Behöver du hjälp så är vi flera som kan sticka som kan hjälpa till.\_</p>"
     link: null
     owner:
       name: ''
@@ -1527,7 +1681,10 @@ events:
     end: '13:30'
     location: Rollspelstält2
     responsible: Malin
-    description: null
+    description: |-
+      <p>Lär dig skriva vackert med penselpennor.</p>
+      <p>Begränsat antal platser: 5 personer.</p>
+      <p>För anmälan, sms:a till 0708-897998.</p>
     link: null
     owner:
       name: ''
@@ -1542,7 +1699,9 @@ events:
     end: '16:15'
     location: GA Datorsal
     responsible: Lukas/Birgitta
-    description: null
+    description: |-
+      <p>Förklaring av vad 5d schack är och hur det funkar.</p>
+      <p>Samma genomgång som 13.30</p>
     link: null
     owner:
       name: ''
@@ -1557,8 +1716,8 @@ events:
     end: '22:15'
     location: Servicehus
     responsible: Ola Hammar
-    description: null
-    link: null
+    description: Musikquiz för den som har lust! Varierande svårighetsgrad. Vi tävlar i lag och alla är välkomna.
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3811005829175126/?app=fbl
     owner:
       name: ''
       email: ''
@@ -1572,7 +1731,7 @@ events:
     end: '11:30'
     location: Servicehus
     responsible: Christina Falk
-    description: null
+    description: "<p>Fortsättning från måndagen - men även nya är välkomna, vi blir gärna fler!</p>\n<p>Vi tränar in en lägerdans tillsammans (Jazz- och streetinspirerat). De som vill kan sedan visa upp den på Open Stage på onsdagen. Vi tränar förstås fler gånger under veckan.</p>\n<p>Selma 11 år, vars stora intresse är dans, har gjort dans-koreografin och kommer att lära ut den.\_\_</p>\n<p>Alla är välkomna!</p>"
     link: null
     owner:
       name: ''
@@ -1587,7 +1746,10 @@ events:
     end: '13:45'
     location: GA Stilla hyllan
     responsible: Malin Tvedt
-    description: null
+    description: |-
+      <p>Lär dig skriva vackert med penselpennor.</p>
+      <p>Begränsat antal platser: 5 personer.</p>
+      <p>För anmälan, sms:a till <a href="tel:0708-897998">0708-897998</a>.</p>
     link: null
     owner:
       name: ''
@@ -1602,7 +1764,10 @@ events:
     end: '15:50'
     location: GA Stilla hyllan
     responsible: Malin Tvedt
-    description: null
+    description: |-
+      <p>Lär dig rita ett realistiskt öga med blyerts.</p>
+      <p>Boka på 0708-897998. Begränsat antal platser (5 st), eftersom det är en lite komplicerad kurs och jag vill se till att alla hänger med, men fler tillfällen kommer under veckan. <br />För barn under 10 år blir nog denna kurs för svår, tyvärr.</p>
+      <p>De som inte får plats vid bordet kan självklart stå runt omkring bordet, titta på och lyssna. &lt;3</p>
     link: null
     owner:
       name: ''
@@ -1617,7 +1782,10 @@ events:
     end: '16:50'
     location: GA Stilla hyllan
     responsible: Malin Tvedt
-    description: null
+    description: |-
+      <p>Lär dig grundteknikerna i akvarell.</p>
+      <p>Boka på 0708-897998. Begränsat antal platser (10 st), eftersom det är en lite komplicerad kurs och jag vill se till att alla hänger med, men fler tillfällen kommer under veckan. <br />För barn under 10 år blir nog denna kurs för svår, tyvärr.</p>
+      <p>De som inte får plats vid bordet kan självklart stå runt omkring bordet, titta på och lyssna. &lt;3</p>
     link: null
     owner:
       name: ''
@@ -1631,8 +1799,8 @@ events:
     start: '13:00'
     end: '15:00'
     location: GA Kreativ hörna
-    responsible: 'Annelie, Charlotte, Christina'
-    description: null
+    responsible: Annelie, Charlotte, Christina
+    description: "<p>Vi pysslar Therianmasker och liknande inför SyssCon.\_</p>\n<p>Pappersmasker finns, och filtmaterial m.m. att jobba med.</p>"
     link: null
     owner:
       name: ''
@@ -1646,8 +1814,8 @@ events:
     start: '13:00'
     end: '15:00'
     location: GA Kreativ hörna
-    responsible: 'Annelie, Charlotte, Christina'
-    description: null
+    responsible: Annelie, Charlotte, Christina
+    description: "<p>Vi pysslar Therianmasker och liknande inför SyssCon.\_</p>\n<p>Pappersmasker finns, och filtmaterial m.m. att jobba med.</p>"
     link: null
     owner:
       name: ''
@@ -1662,7 +1830,18 @@ events:
     end: '22:30'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: |-
+      Diverse kunskapsspel tas med och vi enas om vad vi vill spela
+
+      TP
+      NE
+      När då då
+
+      Riket
+
+      &nbsp;
+
+      OBS om det blir grillkväll vid älven torsdag så ställs detta evenemang in
     link: null
     owner:
       name: ''
@@ -1692,7 +1871,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>I den frigörande dansen fokuserar vi inåt, dansar med stängda ögon och låter kroppen utforska nya rörelsemönster.</p>\n<p>Inga krav, ingen förbestämd koreografi men en chans att stärka kroppsmedvetenheten och självkänsla!\_</p>"
     link: null
     owner:
       name: ''
@@ -1707,7 +1886,17 @@ events:
     end: '17:30'
     location: Annat
     responsible: Elin Sommerfeld
-    description: null
+    description: |-
+      Ta bättre bilder (i vardagen)
+
+      Tips och trix hur du tar bättre bilder och blir en bättre fotograf. Vi varvar teori och praktik.
+      Vi går igenom lite ljusteori, komposition och enkla fotoregler.
+
+      Funkar bra både för dig som fotar med systemkamera eller med mobilen.
+
+      Plats: Vandrarhemmet
+
+      &nbsp;
     link: null
     owner:
       name: ''
@@ -1722,7 +1911,9 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: 'Hampus Sommerfeld '
-    description: null
+    description: |-
+      <p>Denna aktivitet riktar sig främst till de som är helt nya till schack eller har väldigt få kunskaper om spelet. Vi kommer gå igenom hur spelet fungerar i sin grund samt tävlingsetikett och klockanvändning. Idén är att ha lektioner för nybörjare samt låta dem spela lite partier. Våra bräden kommer dock stå framme under tiden och andra spelare som inte deltar i lektionen är välkomna att spela.</p>
+      <p>Alla är välkomna!</p>
     link: null
     owner:
       name: ''
@@ -1737,7 +1928,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: Platshållare för att indikera att dagen är slut, inga mer aktiviteter.
     link: null
     owner:
       name: ''
@@ -1752,7 +1943,7 @@ events:
     end: '17:00'
     location: Tält2
     responsible: 'Martina Sjöström '
-    description: null
+    description: '<p><span style="font-weight: 400">Lär dig göra japansk snodd. Det är en flätteknik från Japan. Enkelt att göra när du får in snitsen. Japansk snodd blir ett cylindriskt snöre i 3 färger och kan användas som tex armband. Det går bra att komma när som helst och även att bara dyka upp sista kvarten för att bli igångsatt och sedan fortsatt själv på tex grillkvällen.</span></p>'
     link: null
     owner:
       name: ''
@@ -1767,7 +1958,7 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Rosanna Grytsan '
-    description: null
+    description: "<p>Liten föredrag om ukrainska mat och kultur. Vi kommer äta ukrainska dumpling: vareniniki och pelmeni. Vegetariskt alternativ med laktos och gluten.\_</p>\n<p>Max 10 personer</p>"
     link: null
     owner:
       name: ''
@@ -1782,8 +1973,11 @@ events:
     end: '22:15'
     location: Rollspelstält1
     responsible: Jenny von Bahr
-    description: null
-    link: null
+    description: |-
+      <p>Jag lägger in en aktivitet på fredag klockan 21.30 för att planera nästa års Klurumläger. Klurumlägret är för deltagare över 13 år med fokus på roll- och brädspel och har genomförts dagarna mellan nyår och skolstart i Stockholm.</p>
+      <p>Ungdomarna sköter det mesta men vi har haft vuxna på plats. Välkomna till aktiviteten är unga och vuxna som vill vara med och arrangera Klurumlägret 2025.</p>
+      <p>Varmt välkomna! /Jenny</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3814735035468872/
     owner:
       name: ''
       email: ''
@@ -1797,8 +1991,8 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Magnus Carlsson '
-    description: null
-    link: null
+    description: <p>Vi fortsätter att måla.</p>
+    link: https://www.facebook.com/share/p/aXkpk6cZba4y1RLH/
     owner:
       name: ''
       email: ''
@@ -1812,8 +2006,8 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: 'Hampus Sommerfeld '
-    description: null
-    link: null
+    description: "<p>Schacktävling i blixt med tidskontroll 3|2\_</p>\n<p>Tio rundor spelas med klocka.\_<br />Det är bra att komma lite innan tiden börjar då vi vill kunna starta den första rundan så snart som möjligt.\_<br /><br /></p>\n<p>Anmälan kan ske på plats upp till tio minuter innan första rundan, via Facebook eller genom att kontakta mig på +46 79 339 79 38</p>\n<p>Mer information finns i den länkade Facebook tråden.</p>\n<p>Alla med grundläggande kunskaper inom schack samt godtyckliga kunskaper inom schacks tävlingsetikett är välkomna!</p>"
+    link: https://www.facebook.com/share/p/gGMHtLyJTMnH1Sjy/?
     owner:
       name: ''
       email: ''
@@ -1827,8 +2021,8 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: 'Hampus Sommerfeld '
-    description: null
-    link: null
+    description: "<p>Schacktävling i snabbschack med tidskontroll 10 minuter\_</p>\n<p>Sex rundor spelas med klocka.\_<br />Det är bra att komma lite innan tiden börjar då vi vill kunna starta den första rundan så snart som möjligt.\_<br /><br /></p>\n<p>Anmälan kan ske på plats upp till tio minuter innan första rundan, via Facebook eller genom att kontakta mig på +46 79 339 79 38</p>\n<p>Mer information finns i den länkade Facebook tråden.</p>\n<p>Alla med grundläggande kunskaper inom schack samt godtyckliga kunskaper inom schacks tävlingsetikett är välkomna!</p>"
+    link: https://www.facebook.com/share/p/gGMHtLyJTMnH1Sjy/?
     owner:
       name: ''
       email: ''
@@ -1842,7 +2036,7 @@ events:
     end: '12:00'
     location: GA Stilla hyllan
     responsible: Karin
-    description: null
+    description: <p>Vi fortsätter tills konstverken blir klara, alla välkomna.</p>
     link: null
     owner:
       name: ''
@@ -1857,8 +2051,8 @@ events:
     end: '18:00'
     location: Annat
     responsible: Petter Åström
-    description: null
-    link: null
+    description: <p>En sund knopp på en sund kropp! Vi kör ett lekfullt träningspass för hela familjen, men som ändå får upp pulsen vilket är viktigt för att må bra. Efter passet hinner man lagom bada innan grillningen. Samling vid pingisbordet utomhus.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3814800465462329/
     owner:
       name: ''
       email: ''
@@ -1872,8 +2066,13 @@ events:
     end: '12:00'
     location: Kaffetält
     responsible: 'Jessica Larsson '
-    description: null
-    link: null
+    description: |-
+      <p class="p1"><span class="s1">Välkommen att vara med på en dansaktivitet där vi lär oss en koreograferad dans till låten ”My Oh my” av Ava Max som Nelly Bergqvist har koreograferat. </span></p>
+      <p class="p1"><span class="s1">Alla som vill är välkomna att delta. Målet (för dom som vill) är att visa upp dansen under Open stage men det är inget tvång att uppträda. Kom ändå även om du bara vill lära dig dansen.</span></p>
+      <p>Fortsättning från i måndags men ni som inte var med då är självklart välkomna ändå.</p>
+      <p class="p1"><span class="s1">Samling vid kaffetältet så dansar vi på gräsmattan.</span></p>
+      <p>Onsdag 11.30-12.00</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3813649962244046/
     owner:
       name: ''
       email: ''
@@ -1887,8 +2086,8 @@ events:
     end: '14:30'
     location: Tält1
     responsible: Gustav Eklöf
-    description: null
-    link: null
+    description: "<p>Rubiks kub, prova på. <br />Lär dig lösa Rubiks kub 3x3. Har du provat förut och kan lösa finns det timers för att testa sin snabbhet. <br />Fokuset ligger på 3x3 men det finns andra former och storlekar att försöka med.</p>\n<p>Alla som har med sig kuber och timers är välkomna att vara med och hjälpa till!\_</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3815130435429332/
     owner:
       name: ''
       email: ''
@@ -1902,7 +2101,7 @@ events:
     end: '15:30'
     location: GA Datorsal
     responsible: Lukas
-    description: null
+    description: <p>Lukas och Simon lånar ut sina datorer som har 5d schack för en turnering för de som vill prova på att spela 5d schack.</p>
     link: null
     owner:
       name: ''
@@ -1917,8 +2116,8 @@ events:
     end: '19:00'
     location: Tält1
     responsible: Ivar Ängquist
-    description: null
-    link: null
+    description: <p>Vad har kartor, sociala nätverk, wikipediasidor och molekyler gemensamt? Svaret är att de alla kan modelleras med så kallade "grafer" - en matematisk struktur av noder (prickar) ihopkopplade av kanter (linjer). I denna lektion ger jag en kort introduktion till grafteorin och vad som gör detta matematiska område så intressant. Lektionen kommer hålla ett högt tempo, men inga specifika förkunskaper krävs.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3815148732094169/
     owner:
       name: ''
       email: ''
@@ -1932,7 +2131,7 @@ events:
     end: '14:00'
     location: Annat
     responsible: 'Elli Thulemark '
-    description: null
+    description: <p>Kom och rita på krympplast som man sen kan göra till nyckelringar. Alla är välkomna)</p>
     link: null
     owner:
       name: ''
@@ -1947,8 +2146,8 @@ events:
     end: '19:30'
     location: GA Stilla hyllan
     responsible: 'Martina Sjöström '
-    description: null
-    link: null
+    description: "<p>Gör pappersblommor av kaffefilter. Klipp former och knyckla ihop eller klipp ut individuella blomblad. Fäst på en grillpinne med eller utan pistiller. Sätt dit en pompom som ståndare och klä in grillpinnen i färgade papperstejp eller inte. Måla med akvarellfärg på pappersblommorna. Du gör lite som du känner för. Vi (Martina och Linn) skapar ett tillfälle för att skapa pappersblommor. Har du möjlighet får du gärna ta med en extra sax.<br />Begränsat antal platser, invänta bekräftelse för godkänd anmälan. Barn under 10 tar med en vuxen.\_</p>"
+    link: https://www.facebook.com/share/p/Mp6E7asc6YFMQLt2/
     owner:
       name: ''
       email: ''
@@ -1961,9 +2160,24 @@ events:
     start: '22:30'
     end: '00:30'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Albin, Moa, Karin'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Moa, Karin
+    description: |-
+      Då var det dags för tecknarstudio nr 2!
+
+      Det är som sagt snålt med platser i år så det krävs bekräftad anmälan antingen genom Facebook inlägget eller genom någon av följande alternativ:
+
+      Skriv via messenger.
+
+      Hitta mig (Tilde, Blått hår.) och be mig skriva upp dig.
+
+      Eller SMSa Karin på 070 196 15 00
+
+      Invänta bekräftan då det är varmt och trångt på hyllan.
+
+      Barn 10 år och yngre behöver vuxet sällskap som ansvarar för dem
+
+      Hoppas vi ses!
+    link: https://www.facebook.com/share/p/6b1bEudFAw2DGdok/
     owner:
       name: ''
       email: ''
@@ -1977,7 +2191,7 @@ events:
     end: '18:00'
     location: Annat
     responsible: Petter Åström
-    description: null
+    description: <p>En sund knopp på en sund kropp! Kl 17:30-18:00 kör vi ett lekfullt träningspass för hela familjen, men som ändå får upp pulsen vilket är viktigt för att må bra. Samling vid pingisbordet utomhus.</p>
     link: null
     owner:
       name: ''
@@ -1991,8 +2205,8 @@ events:
     start: '14:00'
     end: '15:00'
     location: Nerf-arena
-    responsible: 'Martin &amp; Astor'
-    description: null
+    responsible: Martin &amp; Astor
+    description: <p>Strider med lajvvapen i nerf-arenan. Ta gärna med om ni har egna (inte för hårda).</p>
     link: null
     owner:
       name: ''
@@ -2007,7 +2221,7 @@ events:
     end: '14:30'
     location: Kaffetält
     responsible: 'Kerstin Eiman '
-    description: null
+    description: <p>Informell fika för föräldrar och barn/ungdomar som kommer från Göteborgsregionen. Ta med dig något att dricka. Familjen Eiman tar med kakor. ☺️</p>
     link: null
     owner:
       name: ''
@@ -2022,7 +2236,7 @@ events:
     end: '15:00'
     location: Annat
     responsible: Selma
-    description: null
+    description: <p>Kom klockan 14:00 och ge boktips till varandra! Man kan droppa in under hela aktiviteten. Vi kommer hålla hus vid träden nedanför lekstugorna. Alla som kommer får kex och saft.</p>
     link: null
     owner:
       name: ''
@@ -2037,8 +2251,8 @@ events:
     end: '15:00'
     location: Annat
     responsible: Linda Backman
-    description: null
-    link: null
+    description: "<p>Samling vid tält 1, så sätter vi oss i lämplig skugga.</p>\n<p>Vad är ångest? Varför kommer den? Hur får jag bort den? Det och mycket annat pratar vi om.</p>\n<p>Den här träffen riktar jag till ungefär tonåringarna.\_</p>\n<p>Finns intresse från yngre barn så kör jag gärna ett pass för dem också.</p>"
+    link: https://www.facebook.com/share/p/nD6tDGJk8NtzgjSB/
     owner:
       name: ''
       email: ''
@@ -2052,7 +2266,7 @@ events:
     end: '02:00'
     location: GA Datorsal
     responsible: Anne och Linda
-    description: null
+    description: "<p>Datahäng där vi spelar Minecraft\_</p>"
     link: null
     owner:
       name: ''
@@ -2067,7 +2281,7 @@ events:
     end: '11:00'
     location: Tält1
     responsible: Anna
-    description: null
+    description: <p>Lägrets näst sista föräldrafika, där vi delar erfarenheter och tips kring "hemmasittare", eller som jag hellre säger, barn med problematisk skolnärvaro.</p>
     link: null
     owner:
       name: ''
@@ -2082,8 +2296,22 @@ events:
     end: '12:30'
     location: Tält1
     responsible: 'Emma Neal '
-    description: null
-    link: null
+    description: |-
+      Jag är akademisk utvecklings/personlighetspsykolog och psykodynamisk terapeut, anställd vid lärosätet i Jönköping men undervisar även på Stockholms universitet. Jag öppnar gärna för samtal som tangerar exempelvis följande områden:
+
+      Utveckling av emotionsreglering och empati
+
+      Diagnos, bristande omgivning, eller adaptiv utvecklingskris
+
+      Reparation av förälder-till-barn-allians efter perioder med konflikter
+
+      Problembeteende - Antipati, narcissism eller frustration av grundläggande psykologiska behov
+
+      Asynkronisitet och ett lyhört föräldraskap
+
+      Eller annat som rör våra barn.
+      Skriv gärna i tråden om Ni är intresserade.
+    link: https://www.facebook.com/groups/syssleback2024/posts/3815959902013052/
     owner:
       name: ''
       email: ''
@@ -2097,7 +2325,7 @@ events:
     end: '12:00'
     location: Tält1
     responsible: 'Malin Isenfors '
-    description: null
+    description: "<p>Vad då prepping? Varför då? Det gäller väl inte mig? Var ska man börja? Är det inte krångligt? Och dyrt? Hur ska man tänka?\_</p>\n<p>Krig, strömavbrott, pandemier, terrorbrott, hackerattacker, extremväder, solstormar eller zombieappokalyps?\_</p>\n<p>Alla kan hjälpa till att ta hand om sig själva och sin familj. Tillsammans hjälpa vi åt att stärka Sverige.</p>\n<p>Tillsammans diskuterar vi vad vi kan göra.\_</p>"
     link: null
     owner:
       name: ''
@@ -2106,14 +2334,16 @@ events:
       created_at: '2024-06-27 00:39:15'
       updated_at: '2024-06-27 00:39:15'
   - id: vad-ar-en-sten-2024-06-28-1400
-    title: 'VAD ÄR EN STEN?'
+    title: VAD ÄR EN STEN?
     date: '2024-06-28'
     start: '14:00'
     end: '16:00'
     location: Annat
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: |-
+      <p>Vi utforskar materialet på Klarälvens strand!</p>
+      <p>För mer info, se Fb-inlägget :)</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3816230391986003/
     owner:
       name: ''
       email: ''
@@ -2127,7 +2357,10 @@ events:
     end: '12:30'
     location: Annat
     responsible: Sebastian Senning
-    description: null
+    description: |-
+      Vi ses vid parkeringen för avfärd 11.05. 13 min bilresa, ca 5 minuter promenad till vattenfallet. Vi tror man kan bada där och att det är lite skuggigt så passar en varm dag.
+
+      Familjerna Senning-Granberg och Rydell kan lösa upp till 7 platser lediga i bilarna. Vi samåker på lämpligt sätt. Ring 0734405287 om ni vill stämma av.
     link: null
     owner:
       name: ''
@@ -2142,7 +2375,7 @@ events:
     end: '18:00'
     location: Annat
     responsible: Petter Åström
-    description: null
+    description: <p>En sund knopp på en sund kropp! Kl 17:30-18:00 kör vi ett lekfullt träningspass för hela familjen, men som ändå får upp pulsen vilket är viktigt för att må bra. Samling vid pingisbordet utomhus.</p>
     link: null
     owner:
       name: ''
@@ -2157,7 +2390,10 @@ events:
     end: '20:45'
     location: Nerf-arena
     responsible: Nerf-spelare och deras vuxna
-    description: null
+    description: |-
+      Alla nerfskott och nerfpistoler SKA ligga i Nerf-lådan.
+
+      De som använder pistolerna bidrar.
     link: null
     owner:
       name: ''
@@ -2172,7 +2408,10 @@ events:
     end: '20:45'
     location: Nerf-arena
     responsible: Nerf-spelare och deras vuxna
-    description: null
+    description: |-
+      Alla nerfskott och nerfpistoler SKA ligga i Nerf-lådan.
+
+      De som använder pistolerna bidrar.
     link: null
     owner:
       name: ''
@@ -2187,8 +2426,8 @@ events:
     end: '14:00'
     location: Kaffetält
     responsible: Anna Björnson
-    description: null
-    link: null
+    description: <p>Jag delar med mig av min kunskap om hur man bäst åker på semester och/eller jobbresa med tåg i Europa, både resor med Interrailkort och utan.</p>
+    link: https://www.facebook.com/story.php?id=3573251722950539&amp;story_fbid=3815811218694587
     owner:
       name: ''
       email: ''
@@ -2202,7 +2441,7 @@ events:
     end: '16:30'
     location: Tält1
     responsible: Karin F
-    description: null
+    description: <p>Vi spelar maffia/varulvar tillsammans. Alla välkomna!</p>
     link: null
     owner:
       name: ''
@@ -2217,7 +2456,7 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Magnus Carlsson '
-    description: null
+    description: "<p>Efter att ha målat i två tillfällen så ska det provspelas.\_</p>"
     link: null
     owner:
       name: ''
@@ -2232,7 +2471,9 @@ events:
     end: '17:30'
     location: Annat
     responsible: Elin
-    description: null
+    description: |-
+      <p>Plats ändrad från Tornet till vandrarhemmet.</p>
+      <p>För beskrivning se den ursprungliga posten.</p>
     link: null
     owner:
       name: ''
@@ -2247,7 +2488,7 @@ events:
     end: '17:00'
     location: Tält1
     responsible: 'RFSB Stockholm/Mälardalen '
-    description: null
+    description: "<p>Vi planerar in datum och ansvariga för de event som vi önskar under hösten.\_</p>\n<p>Finns det nya idéer och önskemål så kom förbi så lägger vi till dessa också.\_</p>"
     link: null
     owner:
       name: ''
@@ -2262,7 +2503,7 @@ events:
     end: '11:00'
     location: Tält2
     responsible: Seméli Papadogiannakis
-    description: null
+    description: "Svarar på frågor om allt från rymdskrot till universums accelererande expansion.\_ Jag har doktorerat i astrofysik och jobbar nu som rymdforskare och gör mitt bästa att svara på frågor."
     link: null
     owner:
       name: ''
@@ -2277,7 +2518,9 @@ events:
     end: '15:00'
     location: Tält1
     responsible: Annelie Mattson-Djos och Cecilia Löfgreen
-    description: null
+    description: |-
+      <p>Inför val är bra tillfälle att påverka politiker och göra t.ex. debattartiklar.</p>
+      <p>Vi pratar om hur 2 olika partier fungerar, och när, vem, hur man kan påverka.</p>
     link: null
     owner:
       name: ''
@@ -2292,8 +2535,14 @@ events:
     end: '13:00'
     location: Annat
     responsible: Malin Tvedt
-    description: null
-    link: null
+    description: |-
+      <p>Kom och lek med färg och skapa roliga mönstereffekter!</p>
+      <p>Passar för barn upp till 11 år. En vuxen måste medfölja barnet. <strong>&lt;— Viktigt!</strong></p>
+      <p>Anmälan görs i Facebooktråden: https://www.facebook.com/groups/syssleback2024/permalink/3816542808621428/</p>
+      <p>Plats: Chokladfabriken</p>
+      <p>Tid: Lördag, kl: 12.00-13.00</p>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3816542808621428/
     owner:
       name: ''
       email: ''
@@ -2307,8 +2556,14 @@ events:
     end: '16:00'
     location: Annat
     responsible: Malin Tvedt
-    description: null
-    link: null
+    description: |-
+      <p>Lär dig grunderna i akvarellmåleri eller måla fritt på egen hand med gott sällskap och lite vägledning. &lt;3</p>
+      <p>Passar från 11 år och uppåt, eftersom det är svårt att behärska akvarell som målarmedium.</p>
+      <p>Anmälan görs i Facebooktråden: https://www.facebook.com/groups/syssleback2024/permalink/3816545441954498/</p>
+      <p>Plats: Chokladfabriken</p>
+      <p>Tid: Lördag, kl: 14.30-16.00</p>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3816545441954498/
     owner:
       name: ''
       email: ''
@@ -2322,7 +2577,7 @@ events:
     end: '18:45'
     location: GA Idrott
     responsible: Jenny von Bahr
-    description: null
+    description: "<p>Tanken är att alla från lägret som ska till NärCon bestämmer en tid och plats under NärCon då de träffas. Tex under en aktivitet eller att alla äter mat ihop. Jag sätter upp ett anslag i GA-hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -2337,7 +2592,7 @@ events:
     end: '01:00'
     location: GA Datorsal
     responsible: 'Alexander Wilén Löfgreen '
-    description: null
+    description: <p>Ett nattpass med MineCraft</p>
     link: null
     owner:
       name: ''
@@ -2352,8 +2607,8 @@ events:
     end: '11:30'
     location: GA Stilla hyllan
     responsible: Helena
-    description: null
-    link: null
+    description: "<div class=\"xdj266r x11i5rnm xat24cr x1mh8g0r x1vvkbs x126k92a\">\n<div dir=\"auto\">Sista passet i skarvsöm/handsömnad på lördag är för er som inte hunnit bli klara med era projekt. Vi kommer alltså inte påbörja nya då.</div>\n<div dir=\"auto\">\_</div>\n</div>\n<div class=\"x11i5rnm xat24cr x1mh8g0r x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">Det är jättekul att se all kreativitet och skaparglädje!</div>\n</div>"
+    link: https://www.facebook.com/groups/syssleback2024/posts/3816525478623161
     owner:
       name: ''
       email: ''
@@ -2367,7 +2622,7 @@ events:
     end: '15:45'
     location: GA Idrott
     responsible: Linn Sjöström
-    description: null
+    description: "<ol>\n<li>Vi (Linn och Martina) kör en nybörjarlektion i taekwondo. Linn är 8,5år och har gult bälte. Vi kör helt enkelt en prova på lektion. Kom och se hur roligt taekwondo är. Uppvärmning, stretchning, någon lek, slag och sparkar i luften, på mitts och bräda. Krävs visst fokus. Både barn och vuxna är välkomna.\_</li>\n</ol>"
     link: null
     owner:
       name: ''
@@ -2382,8 +2637,18 @@ events:
     end: '14:00'
     location: Tält2
     responsible: Morgan
-    description: null
-    link: null
+    description: |-
+      Generativ AI skapar nya möjligheter.
+      Bilder, texter, filmer, musik, med mera går redan att skapa med hjälp av AI-tjänster.
+      Fordon kan parkera själva, köra delar av vägen själva. Det finns förarlösa fordon i olika delar av transportsektorn, och fler kommer.
+
+      Hur ser DU på framtiden om 10-15 år?
+      Vad tror du kommer vara annorlunda då mot nu?
+      Vad vill du ska ske?
+      Vad vill du INTE ska ske?
+
+      <img class="alignnone size-medium wp-image-772" src="https://sbsommar.se/wp-content/uploads/2024/06/AIcreatingAI-300x300.jpeg" alt="" width="300" height="300" />
+    link: https://www.facebook.com/groups/syssleback2024/posts/3816740265268349/
     owner:
       name: ''
       email: ''
@@ -2396,9 +2661,24 @@ events:
     start: '13:30'
     end: '15:30'
     location: Annat
-    responsible: 'Tilde, Albin, Karin'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Karin
+    description: |-
+      Tecknarstudio en lugn stund i Chokladfabriken. (Naturpralinen)
+      För tonåringar (13 år och uppåt) som vill sitta tillsammans i lugn miljö och teckna/måla på olika sätt.
+
+      Fredag kl 13.30 - 15.30
+
+      Anmälan i tråden eller till mig via sms 070-1961500 eller messenger eller till Tilde.
+
+      Vänta in bekräftelse då det bara finns 12 platser.
+
+      På plats finns olika pennor, akvarell, alkoholbaserade brush markers och olika papper. Självklart kan du ta med egna saker och även måla digitalt om du har platta eller annat.
+
+      🌧☔️ Om det regnar blir det inställt då chokladfabriken behöver rummet för sina gäster.
+      Det vet vi när vi närmar oss 13.00 hur det ser ut.
+
+      Välkomna! 🎨🖌️
+    link: https://www.facebook.com/share/p/JwB15VTQLRoS8sDQ/
     owner:
       name: ''
       email: ''
@@ -2412,8 +2692,11 @@ events:
     end: '21:30'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Länk till anmälningsformulär: <a href="https://forms.gle/zHY6vNH4EabC2B1K9">https://forms.gle/zHY6vNH4EabC2B1K9</a></p>
+      <p>Anmälan till Open Stage, RFSB Sysslebäck, Fredag 28/6! Efter onsdagens mycket uppskattade Open Stage så kör vi en omgång till!<br /><br />Breda och varierande program är alltid väldigt uppskattade, så skickar vi med en extra uppmuntan till er som läser dikter, jonglerar, utför trolleri, spelar teater, dansar, spelar instrument m.m. att skicka in en anmälan.<br /><br />För att lättare planera, förbereda eventuell musik eller teknik och för att skapa ett välbalanserat program om det blir fullt, vill vi ha in anmälan på det här formuläret.</p>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3817066791902363/
     owner:
       name: ''
       email: ''
@@ -2421,14 +2704,14 @@ events:
       created_at: '2024-06-28 12:14:24'
       updated_at: '2024-06-28 12:14:24'
   - id: blixttal-max-5-min-talare-lank-till-anmalan-2024-06-29-1500
-    title: 'Blixttal (max 5 min/talare, länk till anmälan)'
+    title: Blixttal (max 5 min/talare, länk till anmälan)
     date: '2024-06-29'
     start: '15:00'
     end: '16:00'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p>Länk till anmälan:<a href=\"https://forms.gle/rkb1mdD3a3VLmyREA\">https://forms.gle/rkb1mdD3a3VLmyREA</a></p>\n<p>Ett blixttal är ett kort tal som kan handla om\_<b>precis vad som helst</b>! Dela med er av er kunskap, berätta om något som är viktigt för dig eller väck nya intressen hos lägerdeltagarna - vad som helst! Talet är begränsat till\_<b>max 5 minuter</b>\_(hård deadline).</p>\n<p>&nbsp;</p>"
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3817077745234601/
     owner:
       name: ''
       email: ''
@@ -2442,7 +2725,7 @@ events:
     end: '17:30'
     location: GA Idrott
     responsible: 'Rebecca och Malin Isenfors '
-    description: null
+    description: "<p>Idag gör Nagelstudion ett gästspel på Sysscon, nu med möjlighet att även måla tånaglar.\_</p>\n<p>Glitter, lim och stenar har vi en 13-årsgräns på.\_</p>\n<p>Yngre barn behöver ha förälder/vuxen med sig.\_</p>"
     link: null
     owner:
       name: ''
@@ -2457,8 +2740,8 @@ events:
     end: '18:00'
     location: Annat
     responsible: Petter Åström
-    description: null
-    link: null
+    description: <p>En sund knopp på en sund kropp! Kl 17:30-18:00 kör vi ett lekfullt träningspass för hela familjen, men som ändå får upp pulsen vilket är viktigt för att må bra. Samling vid pingisbordet utomhus, MEN Petter är iväg på annan aktivitet med familjen så någon annan vuxen får ta ledningen! Jag har länkat till ett FB-inlägg med våra övningar, anpassade för att det är blött i gräset. Det går också att gå upp till sporthallen och köra.</p>
+    link: https://www.facebook.com/groups/syssleback2024/permalink/3817127768562932?locale=sv_SE
     owner:
       name: ''
       email: ''
@@ -2471,9 +2754,9 @@ events:
     start: '22:00'
     end: '01:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Albin, Karin'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Karin
+    description: "<p>Tecknarstudio ikväll efter open stage!</p>\n<p>Vi börjar runt kl 22 (möjligen lite senare om open stage drar ut på tiden då vi inte vill vara i vägen)</p>\n<p>För tonåringar (13 år och uppåt) som vill sitta tillsammans i lugn miljö och teckna/måla på olika sätt.</p>\n<p>Bekräftad ANMÄLAN KRÄVS då vi har begränsat antalplatser, antingen genom inlägget eller till mig personligen</p>\n<p>Vi håller till på Hyllan I GA hallen igen\_</p>\n<p>Vi arrangörer önskar er varmt välkomna, hoppas vi ses!</p>"
+    link: https://www.facebook.com/share/p/KdrRnqLupBSKqz6k/
     owner:
       name: ''
       email: ''
@@ -2487,7 +2770,7 @@ events:
     end: '01:00'
     location: GA Datorsal
     responsible: 'Alexander Wilén Löfgreen '
-    description: null
+    description: "<p>Kör ett kvällspass med lugnare spel på Minecraft servrarna.\_</p>"
     link: null
     owner:
       name: ''
@@ -2496,13 +2779,13 @@ events:
       created_at: '2024-06-28 21:37:09'
       updated_at: '2024-06-28 21:37:09'
   - id: dalarna-gavleborg-glass-fika-samt-input-kring-aktiviteter-2024-06-29-1400
-    title: 'Dalarna Gävleborg, Glass/fika samt input kring aktiviteter'
+    title: Dalarna Gävleborg, Glass/fika samt input kring aktiviteter
     date: '2024-06-29'
     start: '14:00'
     end: '15:30'
     location: Annat
     responsible: Jessica Larsson
-    description: null
+    description: "<p>Nu när sommarens lägervecka går mot sitt slut så är vi några från Dalarna Gävleborg som tänkte ta en glass/fika på Chokladfabriken. Ni får gärna hänga med och samtidigt även ge oss input om vilka aktiviteter ni önskar till kommande år för vår lokalförening.</p>\n<p>Plats: Chokladfabriken\_</p>"
     link: null
     owner:
       name: ''
@@ -2516,9 +2799,9 @@ events:
     start: '13:00'
     end: '14:30'
     location: Annat
-    responsible: 'Tilde, Albin, Karin'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Karin
+    description: "<p>Då var det dags för sista tecknarstudion för i år!\_</p>\n<p>Från kl 13 till 14.30 håller vi till i chokladfabriken.\_</p>\n<p>För tonåringar (13 år och uppåt) som vill sitta tillsammans i lugn miljö och teckna/måla på olika sätt.</p>\n<p>Anmäl er i inlägget alt direkt till mig via messenger eller personligen. Tyvärr fortfarande ont om plats så se till att få bekräftad anmälan.</p>\n<p>Varmt välkomna!</p>"
+    link: https://m.facebook.com/groups/syssleback2024/permalink/3817513955190980/
     owner:
       name: ''
       email: ''
@@ -2532,7 +2815,7 @@ events:
     end: '17:30'
     location: Annat
     responsible: Petter Åström
-    description: null
+    description: <p>Familjevänlig träning för alla åldrar.</p>
     link: null
     owner:
       name: ''
@@ -2547,7 +2830,7 @@ events:
     end: '16:00'
     location: Tält2
     responsible: Martina och Linn
-    description: null
+    description: "<p>Hattleken - min favoritlek som Linn 8.5 år också är väldigt förtjust i. Typ Alias 2.0 med bara personer och en liten liten hint charader.</p>\n<p>&nbsp;</p>\n<p>Alla skriver ner 3-5 personer/karaktärer på lappar. Vi är i två lag och 1 person går fram i taget och ska nu få ditt lag att gissa på vad som står på lapparna under tid.</p>\n<p>Det kommer vara 3 omgångar:</p>\n<p>1 berätta med hur många ord som helst</p>\n<p>2 ett ord</p>\n<p>3 charader\_</p>\n<p>Jag är inget superfan av charader så låt inte detta avskräcka dig. Jag brukar säga att det inte är charaden som är tillräckligt bra utan ditt lag är för dåliga på att gissa. Alla kommer ju nämligen hört alla ord 2ggr redan och bör därför kunna komma på med väldigt lite hjälp/charad. Det är tillåtet att passa, men uppmuntras att inte göra det.</p>\n<p>&nbsp;</p>\n<p>Vi kör ett pass 15-16 i Tält 2. Välkomna vuxna och barn och alla däremellan. Det krävs läskunnighet, att kunna vänta på sin tur och vara tyst när det andra laget kör. Om någon har en hatt att lägga lapparna i, är det en bonus.</p>"
     link: null
     owner:
       name: ''
@@ -2562,7 +2845,10 @@ events:
     end: '15:00'
     location: GA Idrott
     responsible: Christina Falk
-    description: null
+    description: |-
+      <p>Vi lär ut hur man jonglerar med 2, 3 eller 4 bollar. Alla är välkomna, särskilt nybörjare.</p>
+      <p>Om det känns svårt med 2, kan man även börja med 1.</p>
+      <p>Vi tycker själva om att jonglera med ganska stora bollar, så det får ni också gärna pröva.</p>
     link: null
     owner:
       name: ''
@@ -2576,8 +2862,8 @@ events:
     start: '16:00'
     end: '16:45'
     location: Tält2
-    responsible: 'Isak, Manfred, Embla och Enok'
-    description: null
+    responsible: Isak, Manfred, Embla och Enok
+    description: <p>Välkomna på Natur Djur Geografi Quiz skapat av några barn som älskar dessa ämnen. Gå ihop i lag eller om du hellre är själv. För alla åldrar. Utlovad spännande fakta och utmaning även för dig som är vuxen med intresse för området.</p>
     link: null
     owner:
       name: ''
@@ -2592,7 +2878,9 @@ events:
     end: '18:00'
     location: Annat
     responsible: Sarah
-    description: null
+    description: |-
+      <p>Vid kl 17 möts vi upp vid utomhusduschen utanför kaffetältet för det årliga vattenkriget. Ta med era vattenpistoler, byttor, sprayflaskor eller muggar och gör er redo för att bli blöta!</p>
+      <p>Reglerna för vattenkrigets område mm tas på plats innan vi börjar.</p>
     link: null
     owner:
       name: ''

--- a/source/data/2025-06-syssleback.yaml
+++ b/source/data/2025-06-syssleback.yaml
@@ -12,7 +12,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -27,7 +27,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -42,7 +42,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -57,7 +57,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -72,7 +72,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -87,7 +87,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -102,7 +102,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -117,7 +117,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -132,7 +132,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -147,7 +147,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -162,7 +162,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -177,7 +177,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -192,7 +192,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: myggorna
-    description: null
+    description: En "hållare" för att synliggöra på skärmen vid servicehuset att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -207,7 +207,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -222,7 +222,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -237,7 +237,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -252,7 +252,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -267,7 +267,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -282,7 +282,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -297,7 +297,10 @@ events:
     end: '23:30'
     location: Annat
     responsible: alla
-    description: null
+    description: |-
+      Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+
+      Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt!
     link: null
     owner:
       name: ''
@@ -312,7 +315,11 @@ events:
     end: '15:00'
     location: Annat
     responsible: alla
-    description: null
+    description: |-
+      Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.
+      Det finns parkering för de som vill vara redo för “hemfärd”.
+      Annars är det en lagom promenad på vägen bakom receptionen.
+      Tiden är för det brukar vara lite “drop-in”.
     link: null
     owner:
       name: ''
@@ -327,7 +334,7 @@ events:
     end: '10:30'
     location: GA Idrott
     responsible: Lägernissen
-    description: null
+    description: Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
     link: null
     owner:
       name: ''
@@ -342,7 +349,7 @@ events:
     end: '16:00'
     location: Annat
     responsible: vuxna
-    description: null
+    description: Bara att gå in och bada. Tänk på att vuxna är ansvariga för barn i bassängen.
     link: null
     owner:
       name: ''
@@ -357,7 +364,9 @@ events:
     end: '17:00'
     location: Tält3
     responsible: Cecilia (ordförande RFSB)
-    description: null
+    description: |-
+      Vid detta tillfälle får ni chansen att träffa era lokala RFSB föreningar för er där det finns en, för övriga så ger det chansen att se om ni är några som gemensamt kan starta upp en!
+      Samling i tält3 för att dela upp i respektive föreningar.
     link: null
     owner:
       name: ''
@@ -372,8 +381,25 @@ events:
     end: '20:00'
     location: Annat
     responsible: Andreas (lägernissen)
-    description: null
-    link: null
+    description: |-
+      <p><strong>Möte:</strong></p>
+      <p>Vi börjar med avetablering, alla hjälps åt!</p>
+      <p>När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.</p>
+      <p>Ofta en gemensam bild på alla deltagare(som vill).</p>
+      <p>&nbsp;</p>
+      <p><strong>Avetablering:</strong></p>
+      <p>Gemensam översyn på området med iordningställande och städ.</p>
+      <p>Alla tält packas ner.</p>
+      <p>All utrustning tas om hand.</p>
+      <p>Alla gemensamma ytor sopas.</p>
+      <p>Kyl/frys-skåp töms, torkas ur och tas till förrådet.</p>
+      <p>Gräsytor utomhus gås igenom och skräp plockas upp.</p>
+      <p>Lost and found, vid ingång till GA-hallen.</p>
+      <p>&nbsp;</p>
+      <p><strong>Plats:</strong></p>
+      <p>Gräsytan mellan tälten och lekplatsen.</p>
+      <p>Vid dåligt väder, GA-hallen.</p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1134660732025238/?app=fbl
     owner:
       name: ''
       email: ''
@@ -387,7 +413,7 @@ events:
     end: '10:30'
     location: GA Idrott
     responsible: 'Sofia Wiklund '
-    description: null
+    description: "<p>Barndans för yngre åldrar\_</p>\n<p>Låtar:</p>\n<ul>\n<li>Huvud, axlar, knä och tå\_</li>\n<li>\"Vipp på rumpan\" - affär\_</li>\n<li>Små grodorna\_</li>\n<li>Honki-tonki</li>\n<li>Studsa som en boll</li>\n<li>Drakdansen (bolibompa)\_</li>\n</ul>\n<p>Ledare: Laura 8 år</p>\n<p>Vuxen: Sofia W</p>"
     link: null
     owner:
       name: ''
@@ -402,7 +428,11 @@ events:
     end: '23:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: |-
+      <p>Diverse sällskapsspel.</p>
+      <p>Vi ser vad majoritet vill spela.</p>
+      <p>Kan bli flera under kvällen.</p>
+      <p>Ingen fast sluttid.</p>
     link: null
     owner:
       name: ''
@@ -417,7 +447,12 @@ events:
     end: '23:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: |-
+      <p>Diverse sällskapsspel.</p>
+      <p>Vi ser vad majoritet vill spela.</p>
+      <p>Kan bli flera under kvällen.</p>
+      <p>&nbsp;</p>
+      <p>Ingen fast sluttid.</p>
     link: null
     owner:
       name: ''
@@ -432,7 +467,7 @@ events:
     end: '23:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: "<p>Diverse brädspel\_</p>"
     link: null
     owner:
       name: ''
@@ -447,8 +482,8 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: <p>Vi bakar MOCHIGLASS tillsammans baserat på Ai Venturas bakbok ”Baka Kawaii”. Anmälan sker via separat länk på bifogad Fb-inlägg :)</p>
+    link: https://www.facebook.com/share/p/15YpUWvhLQ/?
     owner:
       name: ''
       email: ''
@@ -462,8 +497,8 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: <p>Vi bakar MOCHIGLASS tillsammans baserat på Ai Venturas bakbok ”Baka Kawaii”. Anmälan sker via separat länk på bifogad Fb-inlägg :)</p>
+    link: https://www.facebook.com/share/p/15YpUWvhLQ/?
     owner:
       name: ''
       email: ''
@@ -477,8 +512,8 @@ events:
     end: '17:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: <p>Vi bakar MOCHIGLASS tillsammans baserat på Ai Venturas bakbok ”Baka Kawaii”. Anmälan sker via separat länk på bifogad Fb-inlägg 🙂</p>
+    link: https://www.facebook.com/share/p/15YpUWvhLQ/?
     owner:
       name: ''
       email: ''
@@ -486,14 +521,18 @@ events:
       created_at: '2025-06-17 17:28:37'
       updated_at: '2025-06-17 17:28:37'
   - id: sa-kul-med-lager-vill-vi-ha-fler-2025-06-25-1600
-    title: 'Så kul med läger! – vill vi ha fler?'
+    title: Så kul med läger! – vill vi ha fler?
     date: '2025-06-25'
     start: '16:00'
     end: '17:00'
     location: Kaffetält
     responsible: Cecilia Löfgreen
-    description: null
-    link: null
+    description: |-
+      <p style="font-weight: 400">Så kul med läger! – vill vi ha fler?<br /><br />Riksförbundet vill gärna hitta fler engagerade som vill ta ansvar för fler läger. Beroende på plats och tidpunkt så finns möjlighet att dela material mellan lägren, alltid möjigt att dela know how samt tillgång till alla våra medlemmar.</p>
+      <p style="font-weight: 400">Onsdag på junilägret bjuder vi därför in till en träff att prata kring vad vi tycker är viktigt med lägren, hur vi ger bäst förutsättningar för att göra fler läger och finns det några som vill vara med och arbeta aktivt för fler läger?</p>
+      <p style="font-weight: 400">Vi ses i kaffetältet onsdag kl 16!</p>
+      <p style="font-weight: 400">Det går också bra att börja resonera och göra medskick i denna tråd!</p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1126663519491626/
     owner:
       name: ''
       email: ''
@@ -507,7 +546,11 @@ events:
     end: '18:00'
     location: Nerf-arena
     responsible: Astor/Selma/Martin
-    description: null
+    description: |-
+      <p>Strid med lajv svärd.</p>
+      <p style="text-align: left">Alla barn är välkomna slåss med svärd. Vi ses i nerfarenan (de små husen) och går igenom säkerhet och slåss! Ta gärna med egna lajvvapen (speciella vapen som man inte gör sig illa på). I år finns det minst 16 vapen!</p>
+      <p>&nbsp;</p>
+      <p><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTMi8tXS3YD5DktXAQfPCuLm-EBJdA8UpClUQ&amp;s" alt="barn med vapen " /></p>
     link: null
     owner:
       name: ''
@@ -522,8 +565,8 @@ events:
     end: '14:00'
     location: Annat
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: "<p>Barnens morfar tar oss med till en av norra Värmlands gammelskog för en artbestämningsaktivitet. Observera att guiden endast pratar västvärmländsk dialekt!</p>\n<p>Vi träffas kl 10 på GA-hallens parkering för gemensam transport till gammelskogen och är tillbaka senast kl 14.\_</p>\n<p>Se till att packa med myggmedel, oömma kläder, bra skor och matsäck.\_</p>\n<p><br />För anmälan och info se bifogad Fb-tråd!</p>"
+    link: https://www.facebook.com/share/p/1YYfcWYWjs/?
     owner:
       name: ''
       email: ''
@@ -537,7 +580,7 @@ events:
     end: '15:00'
     location: Rollspelstält1
     responsible: Hampus Sommerfeld
-    description: null
+    description: "<p>Göra karaktärer rollspel Hampus kampanj.\_</p>\n<p>Deltagare: Xander, Johan, Ludvig, Isabella, Edgar</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -552,7 +595,7 @@ events:
     end: '15:00'
     location: Rollspelstält2
     responsible: Astor
-    description: null
+    description: "<p>Skapa karaktärer rollspel Astors kampanj</p>\n<p>Deltagare: Viktor, Otto, Gustav, Hugo\_</p>"
     link: null
     owner:
       name: ''
@@ -567,7 +610,7 @@ events:
     end: '17:00'
     location: Rollspelstält2
     responsible: Xander
-    description: null
+    description: "<p>Skapa karaktärer rollspel Xanders kampanj</p>\n<p>Deltagare: Zet, Markus, Thor, Miranda, Syno\_</p>"
     link: null
     owner:
       name: ''
@@ -582,8 +625,8 @@ events:
     end: '17:00'
     location: Annat
     responsible: Johanna Fransila
-    description: null
-    link: null
+    description: "<p>Surrning för de med förkunskaper. Aktiviteten kräver att man är självgående.\_</p>\n<p>Aktiviteten är en bygg-utmaning där man i grupp ska lösa en uppgift. Det ingår att man hämtar sina egna slanor genom att såga/hugga och bära från intilliggande slyskog, som sedan surras ihop.\_</p>\n<p>Ta gärna med såg, yxa och/eller kniv om du vill, annars finns begränsat antal att låna.\_</p>\n<p>Återkommer närmare om exakt plats i Facebooktråd.\_</p>"
+    link: https://www.facebook.com/share/p/1CBMCTqBd7/
     owner:
       name: ''
       email: ''
@@ -597,8 +640,8 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Hampus
-    description: null
-    link: null
+    description: "<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs xlh3980 xvmahel x1n0sxbx x6prxxf xvq8zen xo1l8bm xzsf02u\">Tävling i blixtschack med tidskontroll 5|3, det innebär att man börjar med fem minuter var och får tre sekunder för varje drag man gör. Fem rundor spelas efter varandra följt av en 30 minuter lång paus innan resterande fem rundor spelas.</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs xlh3980 xvmahel x1n0sxbx x6prxxf xvq8zen xo1l8bm xzsf02u\">Det är inte obligatoriskt att delta i samtliga rundor, man kan vara med några rundor här och där. Värt att notera är att poäng utdelas för närvaro vid en runda. Om du anmäler dig får du plats i samtliga rundor.</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs xlh3980 xvmahel x1n0sxbx x6prxxf xvq8zen xo1l8bm xzsf02u\">Vid anmälan ber jag om för- och efternamn för att kunna skilja på olika personer skulle fler än en med samma namn anmäla sig. Ni kan också skicka er anmälan till mig privat via +46 79 339 79 38 alternativ använda Messenger på Facebook. Vidare kan ni anmäla er på plats innan en runda börjar.</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs xlh3980 xvmahel x1n0sxbx x6prxxf xvq8zen xo1l8bm xzsf02u\">Alla med grundläggande kunskaper inom schack samt godtyckliga kunskap inom tävlingsetikett är välkomna!</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">Mer information finns i länkade facebook-tråd.\_</div>\n</div>"
+    link: https://www.facebook.com/share/p/1HZsivDWRL/?
     owner:
       name: ''
       email: ''
@@ -612,7 +655,9 @@ events:
     end: '13:00'
     location: Rollspelstält1
     responsible: Wilhelm
-    description: null
+    description: |-
+      <p>Rollspel Wilhelms kampanj</p>
+      <p>Session 2</p>
     link: null
     owner:
       name: ''
@@ -627,7 +672,9 @@ events:
     end: '13:00'
     location: Rollspelstält1
     responsible: Wilhelm
-    description: null
+    description: |-
+      <p>Rollspel Wilhelms kampanj</p>
+      <p>Session 1</p>
     link: null
     owner:
       name: ''
@@ -642,7 +689,9 @@ events:
     end: '13:00'
     location: Rollspelstält1
     responsible: Wilhelm
-    description: null
+    description: |-
+      <p>Rollspel Wilhelms kampanj</p>
+      <p>Session 3</p>
     link: null
     owner:
       name: ''
@@ -651,13 +700,20 @@ events:
       created_at: '2025-06-21 15:01:38'
       updated_at: '2025-06-21 15:01:38'
   - id: obs-alla-deltar-nya-lite-extra-rigga-talt-och-stalla-i-ordning-ga-hall-2025-06-22-1800
-    title: '(OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall'
+    title: (OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall
     date: '2025-06-22'
     start: '18:00'
     end: '20:30'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Vi hjälps åt att hämta material från förrådet vid receptionen.<br />
+      Bygger massa tält.<br />
+      Gör iordning GA-hallen.<br />
+      <br />
+      Nya deltagare har här chansen att komma in, bidra, och bli delaktiga i lägret!<br />
+      Det blir vad vi gör det till. Fråga den jämte dig, vad du kan göra.<br />
+      Passa på att fråga om namn också. :)
     link: null
     owner:
       name: ''
@@ -672,7 +728,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -687,7 +743,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -702,8 +758,16 @@ events:
     end: '17:00'
     location: AndreasTältet
     responsible: Amanda och Stina
-    description: null
-    link: null
+    description: |-
+      Bokcirkel på junilägret.
+      Vi har läst/lyssnat på Djurens gård av George Orwell och diskuterar och analyserar tillsammans.
+      (Cirka fyra timmar ljudbok.)
+
+
+      https://www.storytel.com/se/books/djurens-g%C3%A5rd-27783
+      https://nextory.com/se/book/djurens-gard-2387361
+      https://www.bookbeat.com/se/book/djurens-gard-18187</li>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1116731837151461/?__cft__%5B0%5D=AZWWFS62Rd4znnnde5E4wxFgNK5my62k_QoJ-MazK9KKkKhltc7OAS12UjGarauT2UbvjNj7EbxmDCk_FPNx03OGt6RuZQWS_Aa_QwpjGGKfHJbq2mFw-4j4kn6UGQheMPUPfnl7ht-DUzQQ5T5womP3YMvH1l2l_0reUU4zsBS3Wh4VFarpDKYGoFLVA6G3N8VilQsovqruRgV0ltWdgPZA&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -717,7 +781,10 @@ events:
     end: '17:00'
     location: Rollspelstält1
     responsible: Wilhelm
-    description: null
+    description: |-
+      <p>Skapa karaktärer rollspel Wilhelms kampanj</p>
+      <p>Deltagare: Jacob, Elias, Oskar, Alex</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -732,7 +799,10 @@ events:
     end: '16:00'
     location: Rollspelstält2
     responsible: Astor
-    description: null
+    description: |-
+      <p>Rollspel Astors kampanj</p>
+      <p>Session 1</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -747,7 +817,9 @@ events:
     end: '16:00'
     location: Rollspelstält2
     responsible: Astor
-    description: null
+    description: |-
+      <p>Rollspel Astors kampanj</p>
+      <p>Session 2</p>
     link: null
     owner:
       name: ''
@@ -762,7 +834,9 @@ events:
     end: '16:00'
     location: Rollspelstält2
     responsible: Astor
-    description: null
+    description: |-
+      <p>Rollspel Astors kampanj</p>
+      <p>Session 3</p>
     link: null
     owner:
       name: ''
@@ -771,14 +845,19 @@ events:
       created_at: '2025-06-22 11:16:06'
       updated_at: '2025-06-22 11:16:06'
   - id: lar-kanna-varandra-lagret-och-campingen-2025-06-23-0900
-    title: 'Lär känna varandra, lägret och campingen!'
+    title: Lär känna varandra, lägret och campingen!
     date: '2025-06-23'
     start: '09:00'
     end: '09:30'
     location: Servicehus
     responsible: Cecilia (ordf RFSB)
-    description: null
-    link: null
+    description: |-
+      <p style="font-weight: 400">09:00-09:30 på måndag så kan alla gå en uppgifts-runda. Vi möts vid sittplatserna vid servicehusets kortsida.</p>
+      <p style="font-weight: 400">För alla innebär det en möjlighet att lära känna fler, för nya innebär det även en liten rundtur av campingen och lägret.</p>
+      <p style="font-weight: 400">Det är drop-in och målsättningen är att alla som deltar ska få chansen att lära känna andra på lägret. Därför vill vi gärna blanda grupperna med deltagare som är på lägret första gången och de som varit med förut.</p>
+      <p style="font-weight: 400">Grupperna kommer vara 3-7 personer och man får vänta vid servicehuset tills man har hittat en grupp att gå med – oroa er inte, vi hjälps åt för att försöka bilda grupper eftersom så att alla som vill har en grupp att gå med.</p>
+      <p style="font-weight: 400">Alla som deltar får tandtrollsföda efter genomförd uppgiftsrunda.</p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1126663519491626/
     owner:
       name: ''
       email: ''
@@ -792,7 +871,10 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Hampus
-    description: null
+    description: |-
+      <p>Rollspel Hampus kampanj</p>
+      <p>Session 1</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -807,7 +889,9 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Hampus
-    description: null
+    description: |-
+      <p>Rollspel Hampus kampanj</p>
+      <p>Session 2</p>
     link: null
     owner:
       name: ''
@@ -822,7 +906,9 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Hampus
-    description: null
+    description: |-
+      <p>Rollspel Hampus kampanj</p>
+      <p>Session 3</p>
     link: null
     owner:
       name: ''
@@ -837,7 +923,10 @@ events:
     end: '16:30'
     location: Rollspelstält1
     responsible: Hampus
-    description: null
+    description: |-
+      <p>Rollspel Hampus kampanj</p>
+      <p>Session 4</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -852,7 +941,15 @@ events:
     end: '23:55'
     location: Grillplats
     responsible: Malin Isenfors
-    description: null
+    description: |-
+      Veckans grillkväll vid älven.
+      En del grillar och äter vid älven, andra medtager dryck, musik och glatt häng. Några hopppar i plurret.
+
+      Lägret bjuder på marsmallows och popcorn till alla barn.
+
+      För kvälls och nattaktiva pågår grillkvällen till tidig morgon.
+
+      Hjälp till att städa efter oss!!
     link: null
     owner:
       name: ''
@@ -867,7 +964,9 @@ events:
     end: '16:30'
     location: Fotbollsplan
     responsible: 'Fredrik Julius '
-    description: null
+    description: |-
+      <p>Alla som vill samlas för lite fotbollsspel.</p>
+      <p>Ta med vattenflaska.</p>
     link: null
     owner:
       name: ''
@@ -882,7 +981,9 @@ events:
     end: '16:30'
     location: Fotbollsplan
     responsible: Fredrik Julius
-    description: null
+    description: |-
+      <p>Alla som vill samlas för fotbollsspel</p>
+      <p>Ta med vattenflaska.</p>
     link: null
     owner:
       name: ''
@@ -897,8 +998,8 @@ events:
     end: '12:00'
     location: Annat
     responsible: Johanna Fransila
-    description: null
-    link: null
+    description: "<p>Prova på att bygga med rep och pinnar (sisal och slanor). Alla kan vara med, vuxna stöttar sina barn om man tror det krävs.\_</p>\n<p>återkommer om plats!\_</p>\n<p>Anmäl gärna i tråden på FB eller PM!</p>"
+    link: https://www.facebook.com/share/p/19h54n3QAj/?
     owner:
       name: ''
       email: ''
@@ -912,7 +1013,7 @@ events:
     end: '12:00'
     location: GA Datorsal
     responsible: Lukas
-    description: null
+    description: "<p>Demo 5D schack\_</p>\n<p>Obs Datasalen</p>\n<p>(Fanns inte som valbart alternativ)</p>"
     link: null
     owner:
       name: ''
@@ -927,7 +1028,7 @@ events:
     end: '16:30'
     location: Fotbollsplan
     responsible: Fredrik Julius
-    description: null
+    description: "<p>Alla som vill samlas för fotbollsspel\_</p>\n<p>Ta med vattenflaska\_</p>\n<p>Ålder 6-96</p>"
     link: null
     owner:
       name: ''
@@ -942,7 +1043,7 @@ events:
     end: '16:30'
     location: Fotbollsplan
     responsible: Fredrik Julius
-    description: null
+    description: "<p>Alla som vill samlas för fotbollsspel\_</p>\n<p>Ta med vattenflaska\_</p>\n<p>Ålder 6-96</p>"
     link: null
     owner:
       name: ''
@@ -957,7 +1058,10 @@ events:
     end: '14:30'
     location: GA Idrott
     responsible: Kerstin Mossed
-    description: null
+    description: |-
+      <p>Välkomna till barnens bokhörna!</p>
+      <p>&nbsp;</p>
+      <p>Vi visar och tipsar varandra om böcker. Alla är välkomna att visa. Tisdag: ca 7-14 år</p>
     link: null
     owner:
       name: ''
@@ -972,7 +1076,7 @@ events:
     end: '14:30'
     location: Nerf-arena
     responsible: 'Kerstin Mossed '
-    description: null
+    description: "<p>Favorit i repris :)\_</p>\n<p>Förra året var detta snabba, roliga spel lyckat (5-15 deltagare som kan läsa och skriva). Vi kör i år igen!\_</p>"
     link: null
     owner:
       name: ''
@@ -987,7 +1091,7 @@ events:
     end: '17:30'
     location: GA Idrott
     responsible: 'Kerstin Mossed '
-    description: null
+    description: "<p>Brädspelsträff!\_</p>\n<p>&nbsp;</p>\n<p>Vi är tre familjer som har tagit med våra olika favoritspel för olika åldrar. Vi spelar tillsammans och väljer spel utifrån vad vi är sugna på där och då. Paus för lunch ca kl 12, nästa \"spelstart\" kl 13.30</p>\n<p>Exempel:</p>\n<p>Cryptid\_</p>\n<p>Taco Cat</p>\n<p>Exploding Kittens\_</p>\n<p>Catan Energy</p>\n<p>Ticket to Ride</p>\n<p>Mfl.\_</p>"
     link: null
     owner:
       name: ''
@@ -1002,7 +1106,7 @@ events:
     end: '12:00'
     location: Annat
     responsible: Mika
-    description: null
+    description: <p>Kom till tonårsstugan</p>
     link: null
     owner:
       name: ''
@@ -1017,7 +1121,7 @@ events:
     end: '15:00'
     location: Tält2
     responsible: Malin Isenfors och Johan Nyh
-    description: null
+    description: "<p>Har du funderingar eller bara är nyfiken på hur en radikalaccelation går till, så är du välkommen för en allmän diskussion där vi som har erfarenhet delar med oss.\_</p>"
     link: null
     owner:
       name: ''
@@ -1032,7 +1136,7 @@ events:
     end: '15:00'
     location: Kaffetält
     responsible: 'Emma Neal '
-    description: null
+    description: "<p>Med utgångspunkt i människans grundläggande psykologiska behov närmar vi oss den känslomässiga upplevelsen av att vara särskilt begåvad, både som barn och som vuxen. Med denna förståelse so. Grund ger vi oss sedan vidare in i hur vi kan hantera naturliga konflikter i familjelivets vardag.\_</p>"
     link: null
     owner:
       name: ''
@@ -1047,7 +1151,7 @@ events:
     end: '15:00'
     location: Tält1
     responsible: 'Seméli Papadogiannakis '
-    description: null
+    description: <p>Vi gör figurer med lufttorkande lera. Bara fantasin sätter gränsen!</p>
     link: null
     owner:
       name: ''
@@ -1056,13 +1160,13 @@ events:
       created_at: '2025-06-23 11:30:59'
       updated_at: '2025-06-23 11:30:59'
   - id: talj-en-penna-eller-vad-som-helst-2025-06-24-1300
-    title: 'Tälj en penna eller vad som helst!'
+    title: Tälj en penna eller vad som helst!
     date: '2025-06-24'
     start: '13:00'
     end: '15:00'
     location: Tält1
     responsible: 'Christer Pertun '
-    description: null
+    description: "<p>Tälja med täljkniv. Tälj en penna eller något annat spännande.\_ Allt material finns, så även plåster. Jag finns i ett tält bakom hantverkstältet vid GA-hallen.</p>\n<p>Välkommen!\_</p>\n<p>Christer Pertun\_</p>"
     link: null
     owner:
       name: ''
@@ -1077,7 +1181,7 @@ events:
     end: '15:00'
     location: Kaffetält
     responsible: Kerstin Eiman
-    description: null
+    description: "<p>Ta med ditt stick- eller virkprojekt och en kopp kaffe eller te. Drop in - kom när det passar.\_</p>"
     link: null
     owner:
       name: ''
@@ -1092,7 +1196,7 @@ events:
     end: '16:30'
     location: Kaffetält
     responsible: Lotta Tyldhed
-    description: null
+    description: "<p>Välkommen på träff för Dalarna Gävleborg!\_</p>"
     link: null
     owner:
       name: ''
@@ -1101,14 +1205,14 @@ events:
       created_at: '2025-06-23 12:45:59'
       updated_at: '2025-06-23 12:45:59'
   - id: musikjam-2025-06-26-1600
-    title: 'Musikjam!'
+    title: Musikjam!
     date: '2025-06-26'
     start: '16:00'
     end: '17:00'
     location: AndreasTältet
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: <p>Musikjam, dagligen 16:00-17:00 (start tisdag)<br /><br />Kom och sjung och spela tillsammans! Ta med instrument om ni har, så försöker vi köra lite låtar ihop. Det brukar oftast bli lite pop/rocklåtar som de flesta har hört, och vi brukar leta upp texter/ackord/noter på nätet tillsammans. Helt opretentiöst, med fokus på att ha kul!</p>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1130550282436283/?__cft__%5B0%5D=AZXqYBiOD9aCxlyPMvLvYDmpo-uTm7qTAhNpTlLYyw_78bAEG_YESle3Rg07STEgvHErT05alFAJCao5KFBj04d-985MQ0v3LIkwKOHI6JEsIK71aKdugKFAKCsqSXLLnqrV7h4M6Z3xYVuOF1fD5okcuxRmmPSrLHJDUQwGSympvQ&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1122,8 +1226,8 @@ events:
     end: '16:00'
     location: Tält2
     responsible: 'Linda Backman '
-    description: null
-    link: null
+    description: "<p>Samtal om vad ångest är, hur man kan leva med det och hur man kan stötta.</p>\n<p>Jag är kurator och författare till boken Bland tanketroll och känslomonster.\_</p>"
+    link: https://www.facebook.com/share/p/nD6tDGJk8NtzgjSB/
     owner:
       name: ''
       email: ''
@@ -1131,14 +1235,20 @@ events:
       created_at: '2025-06-23 12:52:06'
       updated_at: '2025-06-23 12:52:06'
   - id: musikjam-2025-06-27-1600
-    title: 'Musikjam!'
+    title: Musikjam!
     date: '2025-06-27'
     start: '16:00'
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <div class="xdj266r x14z9mp xat24cr x1lziwak x1vvkbs x126k92a">
+      <div dir="auto">Musikjam, dagligen 16:00-17:00 (start tisdag)</div>
+      </div>
+      <div class="x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a">
+      <div dir="auto">Kom och sjung och spela tillsammans! Ta med instrument om ni har, så försöker vi köra lite låtar ihop. Det brukar oftast bli lite pop/rocklåtar som de flesta har hört, och vi brukar leta upp texter/ackord/noter på nätet tillsammans. Helt opretentiöst, med fokus på att ha kul!</div>
+      </div>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1130550282436283/?__cft__%5B0%5D=AZXqYBiOD9aCxlyPMvLvYDmpo-uTm7qTAhNpTlLYyw_78bAEG_YESle3Rg07STEgvHErT05alFAJCao5KFBj04d-985MQ0v3LIkwKOHI6JEsIK71aKdugKFAKCsqSXLLnqrV7h4M6Z3xYVuOF1fD5okcuxRmmPSrLHJDUQwGSympvQ&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1146,14 +1256,20 @@ events:
       created_at: '2025-06-23 12:52:33'
       updated_at: '2025-06-23 12:52:33'
   - id: musikjam-2025-06-24-1600
-    title: 'Musikjam!'
+    title: Musikjam!
     date: '2025-06-24'
     start: '16:00'
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <div class="xdj266r x14z9mp xat24cr x1lziwak x1vvkbs x126k92a">
+      <div dir="auto">Musikjam, dagligen 16:00-17:00 (start tisdag)</div>
+      </div>
+      <div class="x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a">
+      <div dir="auto">Kom och sjung och spela tillsammans! Ta med instrument om ni har, så försöker vi köra lite låtar ihop. Det brukar oftast bli lite pop/rocklåtar som de flesta har hört, och vi brukar leta upp texter/ackord/noter på nätet tillsammans. Helt opretentiöst, med fokus på att ha kul!</div>
+      </div>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1130550282436283/?__cft__%5B0%5D=AZXqYBiOD9aCxlyPMvLvYDmpo-uTm7qTAhNpTlLYyw_78bAEG_YESle3Rg07STEgvHErT05alFAJCao5KFBj04d-985MQ0v3LIkwKOHI6JEsIK71aKdugKFAKCsqSXLLnqrV7h4M6Z3xYVuOF1fD5okcuxRmmPSrLHJDUQwGSympvQ&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1166,9 +1282,9 @@ events:
     start: '18:00'
     end: '20:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Albin, Moa, (Karin)'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Moa, (Karin)
+    description: "<p>Tecknarstudio ikväll kl 18:00 - ca 20:00</p>\n<p>&nbsp;</p>\n<p>Vi kör första tecknarstudion för i år kl 18 ikväll på hyllan så det är begränsat med plats. ANMÄLAN KRÄVS (sker via Discord eller Facebook)</p>\n<p>&nbsp;</p>\n<p>12 och under behöver vuxet (18+) sällskap.\_</p>\n<p>&nbsp;</p>\n<p>Nytt för i år! Vi har skapat en discord server som man kan anmäla sig genom också (så jag slipper leta efter folk som snackat med mig).\_</p>\n<p>Där kommer det komma ungefär samma info som här, men det är helt enkelt lättare att få tag på oss där.</p>\n<p>&nbsp;</p>\n<p>Varmt välkomna!</p>\n<p>&nbsp;</p>\n<p>/Tecknarstudion</p>\n<p>&nbsp;</p>\n<p>(Vuxna är självklart välkomna att delta också (även i discord om man vill)))</p>\n<p><a href=\"https://discord.gg/662EyaaY\">DISCORD</a>\_</p>\n<p>&nbsp;</p>"
+    link: https://www.facebook.com/share/p/KdrRnqLupBSKqz6k/
     owner:
       name: ''
       email: ''
@@ -1176,14 +1292,20 @@ events:
       created_at: '2025-06-23 12:53:59'
       updated_at: '2025-06-23 12:53:59'
   - id: musikjam-2025-06-28-1600
-    title: 'Musikjam!'
+    title: Musikjam!
     date: '2025-06-28'
     start: '16:00'
     end: '17:00'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <div class="xdj266r x14z9mp xat24cr x1lziwak x1vvkbs x126k92a">
+      <div dir="auto">Musikjam, dagligen 16:00-17:00 (start tisdag)</div>
+      </div>
+      <div class="x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a">
+      <div dir="auto">Kom och sjung och spela tillsammans! Ta med instrument om ni har, så försöker vi köra lite låtar ihop. Det brukar oftast bli lite pop/rocklåtar som de flesta har hört, och vi brukar leta upp texter/ackord/noter på nätet tillsammans. Helt opretentiöst, med fokus på att ha kul!</div>
+      </div>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1130550282436283/?__cft__%5B0%5D=AZXqYBiOD9aCxlyPMvLvYDmpo-uTm7qTAhNpTlLYyw_78bAEG_YESle3Rg07STEgvHErT05alFAJCao5KFBj04d-985MQ0v3LIkwKOHI6JEsIK71aKdugKFAKCsqSXLLnqrV7h4M6Z3xYVuOF1fD5okcuxRmmPSrLHJDUQwGSympvQ&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1191,14 +1313,20 @@ events:
       created_at: '2025-06-23 12:55:07'
       updated_at: '2025-06-23 12:55:07'
   - id: musikjam-2025-06-25-1600
-    title: 'Musikjam!'
+    title: Musikjam!
     date: '2025-06-25'
     start: '16:00'
     end: '17:00'
     location: AndreasTältet
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <div class="xdj266r x14z9mp xat24cr x1lziwak x1vvkbs x126k92a">
+      <div dir="auto">Musikjam, dagligen 16:00-17:00 (start tisdag)</div>
+      </div>
+      <div class="x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a">
+      <div dir="auto">Kom och sjung och spela tillsammans! Ta med instrument om ni har, så försöker vi köra lite låtar ihop. Det brukar oftast bli lite pop/rocklåtar som de flesta har hört, och vi brukar leta upp texter/ackord/noter på nätet tillsammans. Helt opretentiöst, med fokus på att ha kul!</div>
+      </div>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1130550282436283/?__cft__%5B0%5D=AZXqYBiOD9aCxlyPMvLvYDmpo-uTm7qTAhNpTlLYyw_78bAEG_YESle3Rg07STEgvHErT05alFAJCao5KFBj04d-985MQ0v3LIkwKOHI6JEsIK71aKdugKFAKCsqSXLLnqrV7h4M6Z3xYVuOF1fD5okcuxRmmPSrLHJDUQwGSympvQ&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1212,7 +1340,7 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Helena Frejdevi
-    description: null
+    description: "<p style=\"text-align: left\">Vi trycker med akrylfärger på lakansväv och papper. Det finns 6 plattor, bokning av platta sker på anmälningspapper uppsatt i hantverkstältet (Tält 1 vid GA hallens entré). Anmälningspappret finns på plats från kl 13 dagen innan programpunkten sker.\_ Två personer kan dela på en platta om man vill, det är en arbetskrävande procedur så det går bra att hjälpas åt, tex ett barn och en vuxen.</p>\n<p>\_Gellitryck är enkelt i teorin, kan vara utmanande i praktiken. Det är en \"grunge\" konstform, och det blir inte alltid som man tänkt sig. Men just därför är det så himla kul.</p>\n<p>BARN MÅSTE HA VUXEN MED SOM DELTAR AKTIVT.</p>\n<p>OBS! Ha oömma kläder, akrylfärg fäster på textil, och den färg som används på lägret är dessutom utblandad med textilmedium, vilket gör att den fäster extra bra just på textil!</p>\n<p>När tyget torkat (ofta dagen efter) ska det strykfixeras, sedan håller det för tvätt.</p>\n<p>Av tryckt papper kan man göra kollage, presentaskar, multimediakonst osv. Av tryckt tyg kan man sy jongleringsbollar, små fodral och pennskrin till exempel.</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1227,7 +1355,7 @@ events:
     end: '12:00'
     location: Kaffetält
     responsible: 'Birgitta '
-    description: null
+    description: "<p>För att kunna anordna Brain Games behövs det stationer med olika uppgifter.</p>\n<p>Utan uppgifter inget Brain Games.</p>\n<blockquote>\n<p>Kom om du har förslag på \"gren\".\_</p>\n</blockquote>"
     link: null
     owner:
       name: ''
@@ -1242,7 +1370,7 @@ events:
     end: '20:00'
     location: Tält1
     responsible: 'Martina Sjöström '
-    description: null
+    description: <p>Diamond painting</p>
     link: null
     owner:
       name: ''
@@ -1257,7 +1385,7 @@ events:
     end: '21:00'
     location: GA Idrott
     responsible: 'Birgitta '
-    description: null
+    description: "<p>Årets Brain Games\_</p>\n<blockquote>\n<p>Lös kluriga saker i lag.</p>\n</blockquote>"
     link: null
     owner:
       name: ''
@@ -1272,7 +1400,7 @@ events:
     end: '19:30'
     location: GA Idrott
     responsible: Birgitta
-    description: null
+    description: <p>Samling och genomgång för stationsvärdar.</p>
     link: null
     owner:
       name: ''
@@ -1287,7 +1415,7 @@ events:
     end: '19:00'
     location: GA Idrott
     responsible: Elli och Lou
-    description: null
+    description: "<p>MAFIA spel\_</p>\n<p>Vi kommer gå igenom regler vid behov.\_</p>"
     link: null
     owner:
       name: ''
@@ -1302,7 +1430,11 @@ events:
     end: '20:30'
     location: AndreasTältet
     responsible: 'Milo o Anneli '
-    description: null
+    description: |-
+      <blockquote>
+      <p>Quiz, Eurovisiontema.</p>
+      <p>&nbsp;</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -1316,8 +1448,8 @@ events:
     start: '16:00'
     end: '17:00'
     location: Servicehus
-    responsible: 'Johanna,  Michelle och Emma'
-    description: null
+    responsible: Johanna,  Michelle och Emma
+    description: "<p>Utanför i tältet.\_</p>"
     link: null
     owner:
       name: ''
@@ -1332,7 +1464,10 @@ events:
     end: '19:00'
     location: AndreasTältet
     responsible: Malin och Rebecca Isenfors
-    description: null
+    description: |-
+      <p>Kom och måla och fixa dina egna eller någon annans naglar!</p>
+      <p>Vuxet sällskap för mindre barn!</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -1347,8 +1482,12 @@ events:
     end: '12:00'
     location: Tält3
     responsible: Mikael Eiman
-    description: null
-    link: null
+    description: |-
+      <p>Vi har precis börjat lära oss om det här begreppet, och undrar om det finns andra här som vill prata om och kring detta.</p>
+      <p>Vet du inte vad PDA är? Så här presenterar Sveriges första konferens på ämnet PDA:</p>
+      <p>"Extremt kravkänslig, trotsig, motsträvig och samarbetsovillig"</p>
+      <p>- så beskrivs ibland autister med PDA när kunskap saknas. Okunskap om PDA kan leda till problematisk skolfrånvaro, utmaningar i behandlingskontakter och uttalade konflikter mellan föräldrar och barn.</p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1130671302424181/
     owner:
       name: ''
       email: ''
@@ -1362,7 +1501,7 @@ events:
     end: '12:00'
     location: AndreasTältet
     responsible: Kerstin Eiman
-    description: null
+    description: <p>Träff för föräldrar och barn. Med syfte att försöka få igång en lokal styrelse och att barnen ska få lära känna varandra på lägret. Det bjuds på glass. Välkomna!</p>
     link: null
     owner:
       name: ''
@@ -1377,7 +1516,7 @@ events:
     end: '12:00'
     location: Kaffetält
     responsible: 'Kerstin Eiman '
-    description: null
+    description: <p>Ta med dig en kopp kaffe eller te så samlas vi för att prata om trädgård och odling i alla dess former, oavsett om det gäller grönsaker eller blommor. Har du med dig fröer eller växter för att byta så ta med dem, men det är inget krav. Välkomna!</p>
     link: null
     owner:
       name: ''
@@ -1392,7 +1531,9 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Xander
-    description: null
+    description: |-
+      <p>Rollspel Xanders kampanj</p>
+      <p>Session 1</p>
     link: null
     owner:
       name: ''
@@ -1407,7 +1548,9 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Xander
-    description: null
+    description: |-
+      <p>Rollspel Xanders kampanj</p>
+      <p>Session 2</p>
     link: null
     owner:
       name: ''
@@ -1422,7 +1565,9 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Xander
-    description: null
+    description: |-
+      <p>Rollspel Xanders kampanj</p>
+      <p>Session 3</p>
     link: null
     owner:
       name: ''
@@ -1437,7 +1582,7 @@ events:
     end: '15:00'
     location: GA Idrott
     responsible: 'Joel Tegnander '
-    description: null
+    description: <p>Vi tänker visa lite grunder i parkour. Inga anmälningar behövs. Man borde ha kläder man kan enkelt röra sig i men det behöver inte vara idrottskläder utan kan helt enkelt vara shorts och en T-shirt. Jeans är inte lämpliga.</p>
     link: null
     owner:
       name: ''
@@ -1452,7 +1597,10 @@ events:
     end: '13:00'
     location: Rollspelstält2
     responsible: Xander
-    description: null
+    description: |-
+      <p>Rollspel Xanders kampanj</p>
+      <p>Session 4</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -1467,7 +1615,7 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Helena Frejdevi
-    description: null
+    description: "<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">Vi trycker med akrylfärger på lakansväv och papper. Det finns 6 plattor, bokning av platta sker på anmälningspapper uppsatt i hantverkstältet (Tält 1 vid GA hallens entré). Anmälningspappret finns på plats från kl 13 dagen innan programpunkten sker.\_ Två personer kan dela på en platta om man vill, det är en arbetskrävande procedur så det går bra att hjälpas åt, tex ett barn och en vuxen.</p>\n<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">\_Gellitryck är enkelt i teorin, kan vara utmanande i praktiken. Det är en “grunge” konstform, och det blir inte alltid som man tänkt sig. Men just därför är det så himla kul.</p>\n<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">BARN MÅSTE HA VUXEN MED SOM DELTAR AKTIVT.</p>\n<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">OBS! Ha oömma kläder, akrylfärg fäster på textil, och den färg som används på lägret är dessutom utblandad med textilmedium, vilket gör att den fäster extra bra just på textil!</p>\n<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">När tyget torkat (ofta dagen efter) ska det strykfixeras, sedan håller det för tvätt.</p>\n<p style=\"margin: 0px;padding: 0px;border: none;line-height: inherit;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';margin-block-end: var(--theme-content-spacing);color: #3b3a38;background-color: #f5eedf\">Av tryckt papper kan man göra kollage, presentaskar, multimediakonst osv. Av tryckt tyg kan man sy jongleringsbollar, små fodral och pennskrin till exempel.</p>"
     link: null
     owner:
       name: ''
@@ -1482,7 +1630,7 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Helena Frejdevi
-    description: null
+    description: "<p>Vi trycker med akrylfärger på lakansväv och papper. Det finns 6 plattor, bokning av platta sker på anmälningspapper uppsatt i hantverkstältet (Tält 1 vid GA hallens entré). Anmälningspappret finns på plats från kl 13 dagen innan programpunkten sker.\_ Två personer kan dela på en platta om man vill, det är en arbetskrävande procedur så det går bra att hjälpas åt, tex ett barn och en vuxen.</p>\n<p>\_Gellitryck är enkelt i teorin, kan vara utmanande i praktiken. Det är en “grunge” konstform, och det blir inte alltid som man tänkt sig. Men just därför är det så himla kul.</p>\n<p>BARN MÅSTE HA VUXEN MED SOM DELTAR AKTIVT.</p>\n<p>OBS! Ha oömma kläder, akrylfärg fäster på textil, och den färg som används på lägret är dessutom utblandad med textilmedium, vilket gör att den fäster extra bra just på textil!</p>\n<p>När tyget torkat (ofta dagen efter) ska det strykfixeras, sedan håller det för tvätt.</p>\n<p>Av tryckt papper kan man göra kollage, presentaskar, multimediakonst osv. Av tryckt tyg kan man sy jongleringsbollar, små fodral och pennskrin till exempel.</p>"
     link: null
     owner:
       name: ''
@@ -1497,7 +1645,7 @@ events:
     end: '14:00'
     location: Tält2
     responsible: Vilhard
-    description: null
+    description: "<p>Prova på och lär dig lösa Rubiks kub (olika former!) Eller häng här en stund med egna om man har med.\_</p>"
     link: null
     owner:
       name: ''
@@ -1511,8 +1659,8 @@ events:
     start: '10:30'
     end: '11:30'
     location: GA Kreativ hörna
-    responsible: 'Caroline, Kerstin, Marina, Linn'
-    description: null
+    responsible: Caroline, Kerstin, Marina, Linn
+    description: "<p>Kom och lär dig knåpa en snodd vid pysselbordet i hallen! Vi kör en timmes drop in och visar, och lämnar grejerna så man kan knåpa på under veckans gång. Gör en egen snodd eller bidra till en gemensam.\_</p>"
     link: null
     owner:
       name: ''
@@ -1527,7 +1675,7 @@ events:
     end: '16:30'
     location: Nerf-arena
     responsible: Kristin Wallin Hägglund
-    description: null
+    description: <p>Nu är det dags för skattjakt för de yngre barnen. Exakt innehåll är inte helt spikat, men tanken är att barnen får utföra några enklare utmaningar/stationer. Efter varje utfört moment får de en del av skattkartan. När de har alla bitar kan de hitta skatten (en godispåse med lite pyssel i). Ingen anmälan behövs, men max 25 barn kan köra utifrån antalet godispåsar. 😀</p>
     link: null
     owner:
       name: ''
@@ -1536,13 +1684,13 @@ events:
       created_at: '2025-06-23 21:31:05'
       updated_at: '2025-06-23 21:31:05'
   - id: gor-din-egen-trollstav-ca-4-10-ar-2025-06-25-1100
-    title: 'Gör din egen trollstav! (ca 4-10 år)'
+    title: Gör din egen trollstav! (ca 4-10 år)
     date: '2025-06-25'
     start: '11:00'
     end: '12:00'
     location: GA Kreativ hörna
     responsible: 'Kristin Wallin Hägglund '
-    description: null
+    description: "<p>Här får barnen göra sin egen trollstav med hjälp av ätpinnar, lim, färg och lite smått och gott att pynta med.\_</p>\n<p>OBS! Vi kommer att använda limpistol, så barn som inte är tillräckligt stora för att hantera en sådan själv behöver hjälp av en medföljande vuxen. 🙂</p>\n<p>Ingen anmälan krävs, utan vi kör drop in tills pinnarna tar slut.\_<br /><br /></p>\n<p>Välkomna!\_</p>"
     link: null
     owner:
       name: ''
@@ -1557,7 +1705,7 @@ events:
     end: '14:30'
     location: Tält2
     responsible: 'Karin och Fredrik '
-    description: null
+    description: "<p>Utbyte av erfarenheter. Vad kan fungera för att hitta gnistan igen hos barn som ”kraschat” av skolan? \_Vi har inga färdiga lösningar, forum för samtal och tips.\_</p>"
     link: null
     owner:
       name: ''
@@ -1572,8 +1720,12 @@ events:
     end: '15:00'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: |-
+      <p>Blixttal!</p>
+      <p>Vi använder scenen och kör ett pass med ett gäng 5 minuters blixttal! Presentera något du brinner för och lyssna på andra lägerdeltagare som gör samma sak!</p>
+      <p>https://en.m.wikipedia.org/wiki/Lightning_talk</p>
+      <p>&nbsp;</p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1126305689527409/?
     owner:
       name: ''
       email: ''
@@ -1587,7 +1739,7 @@ events:
     end: '19:30'
     location: AndreasTältet
     responsible: 'Malin och Rebecca Isenfors '
-    description: null
+    description: "<p>Kom och måla dina eller någon annans naglar!</p>\n<p>Mindre barn måste ha vuxet sällskap.\_</p>"
     link: null
     owner:
       name: ''
@@ -1602,7 +1754,7 @@ events:
     end: '16:30'
     location: GA Kreativ hörna
     responsible: Alex och Becca Isenfors
-    description: null
+    description: <p>Varulven spel</p>
     link: null
     owner:
       name: ''
@@ -1611,14 +1763,14 @@ events:
       created_at: '2025-06-24 13:32:46'
       updated_at: '2025-06-24 13:32:46'
   - id: powerpoint-karaoke-2025-06-27-1500
-    title: 'Powerpoint Karaoke!'
+    title: Powerpoint Karaoke!
     date: '2025-06-27'
     start: '15:00'
     end: '16:00'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p class=\"xdj266r x14z9mp xat24cr x1lziwak x16tdsg8\" dir=\"ltr\"><strong>Powerpoint Karaoke!</strong><br /><br /><b><strong class=\"x1s688f\">Vågar du ta micken – utan att ha en aning om vad som väntar?</strong></b></p>\n<p class=\"xdj266r x14z9mp xat24cr x1lziwak x16tdsg8\" dir=\"ltr\">Har du vunnit en debatt med bara charm och påhitt? Är du kvick i tanken, vass i repliken och vill passa på att tokljuga inför en publik? Då är det dags att sätta dina färdigheter på prov – i\_<b><strong class=\"x1s688f\">PowerPoint Karaoke</strong></b>!</p>\n<p class=\"xdj266r x14z9mp xat24cr x1lziwak x16tdsg8\" dir=\"ltr\"><br />Du får:</p>\n<ul class=\"xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl xtaz4m5\">\n<li class=\"xzsf02u x1jchvi3 x1xmf6yo x1dqj196 x1e56ztr xvc51xn xhl9i11\" dir=\"ltr\" value=\"1\">En presentation du aldrig sett förut.</li>\n<li class=\"xzsf02u x1jchvi3 x1xmf6yo x1dqj196 x1e56ztr xvc51xn xhl9i11\" dir=\"ltr\" value=\"2\">En scen, en publik och 20 sekunder per bild.</li>\n<li class=\"xzsf02u x1jchvi3 x1xmf6yo x1dqj196 x1e56ztr xvc51xn xhl9i11\" dir=\"ltr\" value=\"3\">En chans att vara en riktig snicksnackare, improvisera och kanske skratta så du gråter! :-)</li>\n</ul>\n<p class=\"xdj266r x14z9mp xat24cr x1lziwak x16tdsg8\" dir=\"ltr\">Målet:<br />Håll ett övertygande, underhållande eller fullständigt galet föredrag – baserat på slumpmässiga slides. Allt handlar om närvaro, snabbhet och att kunna snacka sig ur vilken PowerPoint-situation som helst.</p>"
+    link: https://www.facebook.com/groups/syssleback2025/posts/1131348255689819/?__cft__%5B0%5D=AZWtpLien_AdlkfP2YfuSCSuQMh6jly0cuuGF4x1erhBXVuIyz3F8hsbyTxvjpRnV2NOhKcXygnpkYmQYaqP3a38EgCJtlCrINtvp2M1KFsXBt1_iymfsDmCyzKC0Bd9IelfgdD5h8N71Di0sgky98fL3tp_S3yQnEIefi6APkmpBg&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1632,7 +1784,9 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Selma
-    description: null
+    description: |-
+      <p>Rollspel Selmas kampanj</p>
+      <p>session 1</p>
     link: null
     owner:
       name: ''
@@ -1647,7 +1801,9 @@ events:
     end: '16:00'
     location: Kaffetält
     responsible: Selma
-    description: null
+    description: |-
+      <p>Rollspel Selmas kampanj</p>
+      <p>session 2</p>
     link: null
     owner:
       name: ''
@@ -1662,7 +1818,9 @@ events:
     end: '16:00'
     location: Rollspelstält1
     responsible: Selma
-    description: null
+    description: |-
+      <p>Rollspel Selmas kampanj</p>
+      <p>session 3</p>
     link: null
     owner:
       name: ''
@@ -1677,7 +1835,9 @@ events:
     end: '16:00'
     location: Rollspelstält2
     responsible: Selma
-    description: null
+    description: |-
+      <p>Rollspel Selmas kampanj</p>
+      <p>session 4</p>
     link: null
     owner:
       name: ''
@@ -1692,7 +1852,7 @@ events:
     end: '17:00'
     location: GA Idrott
     responsible: Christina och Selma Falk
-    description: null
+    description: "<p>Gillar du att dansa? Vi övar in en dans tillsammans och deltagarna får vara med och påverka koreografin, om de vill. Selma, som leder, gillar street dance bäst så det blir street-inspirerat.</p>\n<p>Kanske är det några som vill visa upp den på Open stage på fredag.\_</p>\n<p>Nivå: vi håller en relativt hög nivå på rörelserna, men anpassar lite efter vilka som kommer och alla är välkomna. Om man inte hänger med på allt gör man så gott man kan - dans handlar trots allt om att ha kul och att röra på sig.\_</p>\n<p>Selma är 12 år, dansar 3 gånger i veckan och har gått på dans i 6 år.</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1707,8 +1867,8 @@ events:
     end: '19:30'
     location: Kaffetält
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p>Programmerare, låt oss träffas och tjöta lite! Jag såg i presentationerna att det var ett flertal programmerare, och det är alltid roligt att träffas och snacka lite och träffa andra programmerare. Och om det finns barn och ungdomar som vill komma och ställa lite frågor till folk som jobbar med programmering - passa på när vi är flera i samma tält.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2025/posts/1131399909017987/?__cft__%5B0%5D=AZWK3o9O_-ZtfSnfi9oOr6Z6k2sH45KXlwL8qqs7O7m7EMv8e1GfoNBnjtxw6stQXQKx8N2_DtYc4VhpRFrhG1gJmomOxLlOfi6uepEp3BSlKYHf7I_xeh4yvj_VKcFoiw0kQ4LPWaY5dHx-MH9X0uDG1qk5VNljJsCw8u512NH2dA&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -1722,7 +1882,7 @@ events:
     end: '20:00'
     location: Servicehus
     responsible: 'Elli och Lou '
-    description: null
+    description: "<p>MAFIA i servicehuset\_</p>\n<p>vi kommer att gå igenom regler vid behov\_</p>"
     link: null
     owner:
       name: ''
@@ -1736,9 +1896,16 @@ events:
     start: '19:00'
     end: '21:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Moa, Albin, (Karin)'
-    description: null
-    link: null
+    responsible: Tilde, Moa, Albin, (Karin)
+    description: |-
+      <p>Tecknar/Artstudio ikväll kl 19:00 - ca 21:00</p>
+      <p>Kl 19 ikväll på hyllan är det artstudio.<br />Begränsat med plats igen så</p>
+      <p>BEKRÄFTAD ANMÄLAN KRÄVS<br />(Antingen i FB eller genom <a href="https://discord.gg/662EyaaY">discord</a>)</p>
+      <p>12 och under behöver vuxet (18+) sällskap.</p>
+      <p>Varmt välkomna!</p>
+      <p>/Artstudio Teamet</p>
+      <p>(Vuxna är självklart välkomna att delta också (även i discord om man vill)))</p>
+    link: https://www.facebook.com/share/p/16rrz1GT77/
     owner:
       name: ''
       email: ''
@@ -1752,7 +1919,7 @@ events:
     end: '21:00'
     location: Servicehus
     responsible: Lee Nolan-Lönn
-    description: null
+    description: "<p>Reiki behandling (20 minuter)<br />TV/ läs rummet i servicehuset</p>\n<p>Det finns 4 sessioner: 19:00; 19:30; 20:00; 20:30. Skriv upp vilken tid du vill ha på pappret på dörren vid TV/läs rummet.\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1767,7 +1934,7 @@ events:
     end: '21:00'
     location: Servicehus
     responsible: Lee Nolan-Lönn
-    description: null
+    description: "<p>Reiki behandling (20 minuter)<br />TV/ läs rummet i servicehuset</p>\n<p>Det finns 4 sessioner: 19:00; 19:30; 20:00; 20:30. Skriv upp vilken tid du vill ha på pappret på dörren vid TV/läs rummet.\_</p>"
     link: null
     owner:
       name: ''
@@ -1782,7 +1949,7 @@ events:
     end: '19:30'
     location: GA Idrott
     responsible: Elli och Lou
-    description: null
+    description: "<p>MAFIA\_</p>\n<p style=\"text-align: left\">det har blivit ändrade planer så MAFI spelas i GA-hallen mellan 18:30 och 19:30</p>"
     link: null
     owner:
       name: ''
@@ -1797,8 +1964,8 @@ events:
     end: '15:00'
     location: Grillplats
     responsible: 'Charlotte Anderberg '
-    description: null
-    link: null
+    description: "<p>I år bakar vi gáhkku - glödkaka, en variant av samiskt tunnbröd.\_</p>\n<p>Deg finns färdig. Kavla, stek brödet på stekhäll och så får man sen få mumsa i sig med lite smör.</p>\n<p>Håll utkik efter ev. uppdateringar eftersom det inte är så kul att baka i regnet.\_</p>"
+    link: https://www.facebook.com/share/p/16XZHK8pq6/
     owner:
       name: ''
       email: ''
@@ -1812,7 +1979,11 @@ events:
     end: '11:00'
     location: Kaffetält
     responsible: Hampus
-    description: null
+    description: |-
+      <blockquote>
+      <p>Tillfälle att lära sig schack och tävlingsetikett inom schack. Det går också bra att komma bara för att spela. </p>
+      <p>Alla är välkomna!</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -1827,7 +1998,7 @@ events:
     end: '17:00'
     location: GA Stilla hyllan
     responsible: Ragnar och David
-    description: null
+    description: "<p>Prata om Arduino och alla embedded, leka med en cropie, och kanske planera något stort för nästa år.\_</p>"
     link: null
     owner:
       name: ''
@@ -1842,7 +2013,7 @@ events:
     end: '09:00'
     location: Tält2
     responsible: 'Elisabeth Ejeblad '
-    description: null
+    description: "<p>Meditation till trummans slag som sprider lugn och harmoni och hjälper till att släppa spänningar av stress i kroppen.\_</p>\n<p>Ta med liggunderlag mot blöt mark, filt mysigt och värmande när meditationerna genomförs.\_</p>\n<p>PLATS, NERE VID ÄLVEN</p>\n<p>Kom gärna lite innan 8.00 så du hittat plats och vi får ut så mycket av tiden till olika meditationer.\_</p>\n<p>Elisabeth 🥰</p>"
     link: null
     owner:
       name: ''
@@ -1857,7 +2028,9 @@ events:
     end: '17:30'
     location: Nerf-arena
     responsible: 'Martin / David och Astor '
-    description: null
+    description: |-
+      <p>Alla barn är välkomna slåss med svärd och strumpa. Ta med en egen strumpa!!</p>
+      <p>Vi ses i nerfarenan (de små husen) och går igenom säkerhet och slåss! Ta gärna med egna lajvvapen (speciella vapen som man inte gör sig illa på).</p>
     link: null
     owner:
       name: ''
@@ -1872,7 +2045,7 @@ events:
     end: '12:00'
     location: Tält1
     responsible: 'Martina Sjöström '
-    description: null
+    description: <p>Diamond painting vi ställer borden runt hörnet så blir det lite tystare.</p>
     link: null
     owner:
       name: ''
@@ -1881,13 +2054,15 @@ events:
       created_at: '2025-06-25 00:04:06'
       updated_at: '2025-06-25 00:04:06'
   - id: stand-up-comedy-vad-ar-det-och-hur-gor-man-ett-skamt-2025-06-25-1600
-    title: 'Stand up comedy - vad är det och hur gör man ett skämt?'
+    title: Stand up comedy - vad är det och hur gör man ett skämt?
     date: '2025-06-25'
     start: '16:00'
     end: '17:00'
     location: Tält2
-    responsible: 'Annelie Mattson-Djos, Kristin Wallin Hägglund'
-    description: null
+    responsible: Annelie Mattson-Djos, Kristin Wallin Hägglund
+    description: |-
+      <p>Stand up comedy - vad är det och hur gör man ett skämt?</p>
+      <p>Vi samtalar om humor och stand up; vad är det och vad är det inte. Eventuellt gör vi någon övning och testar att göra skämt.</p>
     link: null
     owner:
       name: ''
@@ -1902,7 +2077,7 @@ events:
     end: '12:00'
     location: AndreasTältet
     responsible: 'Martina Sjöström '
-    description: null
+    description: <p>Blandat musikquiz med allt från artister födda 1901 till låtar som släppts i år. Barn kan bidra (antagligen), men tålamodet kanske gör att de inte orkar vara med hela vägen. Så kom själv eller med familjen och satsa på medspelare som kompletterar varandra.</p>
     link: null
     owner:
       name: ''
@@ -1917,7 +2092,7 @@ events:
     end: '12:00'
     location: AndreasTältet
     responsible: 'Martina Sjöström '
-    description: null
+    description: <p>Blandat musikquiz med allt från artister födda 1901 till låtar som släppts i år. Barn kan bidra (antagligen), men tålamodet kanske gör att de inte orkar hela vägen. Så kom själv eller med familjen och satsa på medspelare som kompletterar varandra.</p>
     link: null
     owner:
       name: ''
@@ -1932,7 +2107,9 @@ events:
     end: '16:00'
     location: Annat
     responsible: 'Elin '
-    description: null
+    description: |-
+      <p>Vi går en fotopromenad tillsammans och blandar teori och praktik. Vi pratar ljus, bakgrund och enklare bildkomposition. Hur kan du på ett enkelt sätt ta bättre bilder? Funkar för såväl systemkamera som smartphone.</p>
+      <p>Vi samlas utanför servicehuset.</p>
     link: null
     owner:
       name: ''
@@ -1941,13 +2118,15 @@ events:
       created_at: '2025-06-25 00:40:20'
       updated_at: '2025-06-25 00:40:20'
   - id: familjetraning-utomhus-nedanfor-beachvolleyplan-nara-gungorna-2025-06-25-1015
-    title: 'Familjeträning utomhus, nedanför beachvolleyplan, nära gungorna'
+    title: Familjeträning utomhus, nedanför beachvolleyplan, nära gungorna
     date: '2025-06-25'
     start: '10:15'
     end: '10:45'
     location: Annat
     responsible: Agnes Granberg
-    description: null
+    description: |-
+      <p>Det är roligare att träna ihop! Styrketräning och lite kondition för alla som vill. Övningar som funkar ute där vi slipper bli blöta av gräset men vill man ha någon handduk eller annat som underlag för skor/fötter och händer kan man ta med det. Går bra att ha sina vanliga kläder, att köra barfota eller med skor - nivå och tempo går att anpassa.</p>
+      <p>Jag som håller i passet har som ung jobbat som PT, styrketräningsinstruktör, pilates och yogalärare så jag inproviserar lite utifrån vilka som kommer och förslag på övningar från andra deltagare också välkommet.</p>
     link: null
     owner:
       name: ''
@@ -1962,7 +2141,7 @@ events:
     end: '15:00'
     location: Tält1
     responsible: 'Christer Pertun '
-    description: null
+    description: "<p>Tälj fritt eller kanske en blyertspenna!\_\_</p>\n<p>Finns bakom hantverkstältet.\_</p>"
     link: null
     owner:
       name: ''
@@ -1977,7 +2156,11 @@ events:
     end: '14:30'
     location: GA Kreativ hörna
     responsible: 'Becca &amp; Alex Isenfors '
-    description: null
+    description: |-
+      <p>Spel, varulvar</p>
+      <p>Ålder: 7+</p>
+      <p>Kom och gå som ni vill, ha kul!</p>
+      <p style="text-align: right">Ingen erfarenhet krävs, bara bråka inte, skrik inte, och lyssna på spelledaren (Spelledaren byts för varje omgång)</p>
     link: null
     owner:
       name: ''
@@ -1992,7 +2175,9 @@ events:
     end: '20:00'
     location: Servicehus
     responsible: Lee Nolan-Lönn
-    description: null
+    description: |-
+      <p>Reiki behandling (20 minuter)<br />TV/ läs rummet i servicehuset</p>
+      <p>Det finns 3 sessioner: 18:30; 19:00; 19:30. Skriv upp vilken tid du vill ha på pappret på dörren vid TV/läs rummet.</p>
     link: null
     owner:
       name: ''
@@ -2001,13 +2186,18 @@ events:
       created_at: '2025-06-25 10:15:44'
       updated_at: '2025-06-25 10:15:44'
   - id: ai-ett-samtal-om-framtid-ideer-och-manniskan-2025-06-26-1400
-    title: 'AI – ett samtal om framtid, idéer och människan'
+    title: AI – ett samtal om framtid, idéer och människan
     date: '2025-06-26'
     start: '14:00'
     end: '15:00'
     location: Tält2
     responsible: 'Ingimar &amp; David '
-    description: null
+    description: |-
+      <p>Välkommen till ett öppet samtal där vi utforskar vad AI betyder för oss – nu och framåt.</p>
+      <p>Alla som är nyfikna är välkomna, oavsett ålder. Du kanske använder AI ofta. Du kanske är skeptisk, rädd eller bara full av frågor. Kanske har du redan tänkt tankar ingen annan har hunnit tänka än.</p>
+      <p>Det här är ett samtal där vi tillsammans formar riktningen. Vad vi pratar om beror på er som kommer.</p>
+      <p>Vi kanske landar i framtiden, filosofin, tekniken, skolan, makten, kreativiteten, livet eller något helt annat.</p>
+      <p>Du behöver inte kunna något särskilt. Det räcker att du är med.</p>
     link: null
     owner:
       name: ''
@@ -2022,7 +2212,9 @@ events:
     end: '11:00'
     location: GA Idrott
     responsible: Hanna Walsö
-    description: null
+    description: |-
+      <p>Dans , rytm, rörelse och sång hänger samman. En aktivitet för barn och förälder/vuxen tillsammans, där det viktigaste är att vi har kul tillsammans. Brukar passa för barn i förskoleåldern och tidig skolålder, men det går också fint att hänga med i sele/sjal för de allra yngsta.</p>
+      <p>Vi möts kravlöst och utan prestation!</p>
     link: null
     owner:
       name: ''
@@ -2037,7 +2229,10 @@ events:
     end: '20:30'
     location: GA Idrott
     responsible: Birgitta
-    description: null
+    description: |-
+      <ol>
+      <li>Prisutdelning för torsdagens tävling.</li>
+      </ol>
     link: null
     owner:
       name: ''
@@ -2046,14 +2241,17 @@ events:
       created_at: '2025-06-25 12:28:57'
       updated_at: '2025-06-25 12:28:57'
   - id: spelutveckling-med-godot-en-kort-intro-2025-06-27-1330
-    title: 'Spelutveckling med Godot, en kort intro'
+    title: Spelutveckling med Godot, en kort intro
     date: '2025-06-27'
     start: '13:30'
     end: '14:30'
     location: GA Stilla hyllan
     responsible: Mikael E
-    description: null
-    link: null
+    description: |-
+      <p class="p1"><span class="s1">Sugen på att göra digitala spel, men vet inte var man börjar?</span></p>
+      <p class="p1"><span class="s1">Godot är en (relativt!) lättanvänd spelmotor man kan använda för att göra alla möjliga sorters spel, och dessutom gratis och open source.</span></p>
+      <p class="p1"><span class="s1">Vi tittar på hur Godot fungerar och hur man knyter ihop det med lite bild och ljud till ett spel.</span></p>
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1132100412281270/
     owner:
       name: ''
       email: ''
@@ -2066,8 +2264,8 @@ events:
     start: '09:30'
     end: '11:00'
     location: Tält1
-    responsible: 'Malin, Caroline, Kerstin'
-    description: null
+    responsible: Malin, Caroline, Kerstin
+    description: "<p>Vi skapar pappersblommor av kräppapper och kaffefilter. Passar alla åldrar! Välkomna\_</p>"
     link: null
     owner:
       name: ''
@@ -2076,13 +2274,13 @@ events:
       created_at: '2025-06-25 12:47:01'
       updated_at: '2025-06-25 12:47:01'
   - id: stand-up-comedy-vad-ar-det-och-hur-gor-man-ett-skamt-2025-06-26-1100
-    title: 'Stand up comedy - vad är det och hur gör man ett skämt?'
+    title: Stand up comedy - vad är det och hur gör man ett skämt?
     date: '2025-06-26'
     start: '11:00'
     end: '12:00'
     location: Tält2
     responsible: Annelie Mattson-Djos
-    description: null
+    description: <p>Vi samtalar om humor och stand up; vad är det och vad är det inte. Eventuellt gör vi någon övning och testar att göra skämt.</p>
     link: null
     owner:
       name: ''
@@ -2091,13 +2289,13 @@ events:
       created_at: '2025-06-25 14:24:27'
       updated_at: '2025-06-25 14:24:27'
   - id: jobbigt-att-prata-infor-klassen-kollegorna-publik-kom-hit-for-lite-tips-2025-06-27-1100
-    title: 'Jobbigt att prata inför klassen, kollegorna, publik - kom hit för lite tips'
+    title: Jobbigt att prata inför klassen, kollegorna, publik - kom hit för lite tips
     date: '2025-06-27'
     start: '11:00'
     end: '12:00'
     location: GA Stilla hyllan
     responsible: Morgan
-    description: null
+    description: Vi tränar lite inför blixttal, powerpointkaraoke och vardagslivets uppgifter. Med att stå framför en grupp människor och prata. För många något av det jobbigaste som finns.
     link: null
     owner:
       name: ''
@@ -2111,9 +2309,9 @@ events:
     start: '16:00'
     end: '17:00'
     location: Fotbollsplan
-    responsible: 'Amanda, Mika och Mirabelle'
-    description: null
-    link: null
+    responsible: Amanda, Mika och Mirabelle
+    description: "<p>Kom alla som vill, vuxna som barn! Man behöver inte vara bra, ju fler dessto bättre.</p>\n<p style=\"text-align: left\">Vi tänker att vi köra 5mot5, möjligtvis 7mot7 om det blir väldigt många, och 12 minuters matcher.\_\_</p>\n<p>Vi kör en kort genomgång om fotbollsregler för de som är osäkra på dem, och delar in i lag på plats.</p>"
+    link: https://www.facebook.com/share/p/1AfkynRtZr/
     owner:
       name: ''
       email: ''
@@ -2127,7 +2325,7 @@ events:
     end: '18:30'
     location: Tält1
     responsible: 'Mija '
-    description: null
+    description: "<p>Kom och vaxa tyg i hantverkstältet.\_</p>\n<p>Skapa vaxtyg som ersätter plastfolie vid matförvaring. Använd i kylen direkt eller sy en liten påse som kan packas med i väskan.\_</p>"
     link: null
     owner:
       name: ''
@@ -2142,7 +2340,10 @@ events:
     end: '17:30'
     location: Nerf-arena
     responsible: 'Martina Sjöström '
-    description: null
+    description: |-
+      <blockquote>
+      <p>Klassiskt vattenkrig mellan barn och vuxna. Kom igen nu vuxna, jag håller koll på er. Inga vuxna på sidlinjen, var på planen!</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -2156,9 +2357,9 @@ events:
     start: '13:00'
     end: '15:30'
     location: Annat
-    responsible: 'Tilde, Albin, Moa, (Karin)'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Moa, (Karin)
+    description: "<p>Artstudio för äldre tonåringar/unga vuxna (fyllt 15 och uppåt)</p>\n<p>&nbsp;</p>\n<p>Idag kl 13 - 15.30 i chokladfabriken</p>\n<p>&nbsp;</p>\n<p>Extremt begränsat med platser</p>\n<p>BEKRÄFTAD ANMÄLAN KRÄVS\_</p>\n<p>(I <a href=\"https://discord.gg/662EyaaY\">discord</a>, Facebook eller direkt till Tilde)</p>\n<p>&nbsp;</p>\n<p>Varmt välkomna!</p>\n<p>/Artstudio Teamet</p>"
+    link: https://www.facebook.com/share/p/14F44NGaY93/
     owner:
       name: ''
       email: ''
@@ -2172,7 +2373,10 @@ events:
     end: '11:00'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: |-
+      <p>Välkommen att testa på en klass i frigörande dans!</p>
+      <p>Denna form av meditation i rörelse har varit en stor hjälp för mig som lätt fastnar i hjärnan med tankar som rusar iväg. Den ger en möjlighet att fokusera inåt och landa i kroppen samtidigt som man utforskar både rörelse och musik. 😌</p>
+      <p>Du bestämmer själv hur du vill röra dig och tanken är att låta kroppen styra efter dagsform och behov. Jag bidrar med inspiration, förslag på rörelser och fokus! ✨</p>
     link: null
     owner:
       name: ''
@@ -2187,8 +2391,12 @@ events:
     end: '13:30'
     location: AndreasTältet
     responsible: CJ
-    description: null
-    link: null
+    description: |-
+      <p>Testa en antik mekanisk räknemaskin (bifogad video via FB-länken är en repris från Filurums skafferigrupp). <br /><br />Jag tar även med tre klassiska abakus-kulramar. Speciellt en moderniserad variant lärs än idag ut i skolan till unga elever i många asiatiska länder, ofta med mål att övergå till mental abakus - en osynlig kulram i huvudet (tillsammans med fingerrörelser i luften), som gör det möjligt att göra aritmetiska beräkningar väl så snabbt som med en miniräknare (ni kanske har sett filmer med det på youtube). Jag är själv nybörjare även på enklare addition och subtraktion på kulram, men låt oss workshoppa och se vad vi gemensamt lyckas med på en halvtimme (och fortsättning för de som vill jobba vidare). Multiplikation, division och kvadratrötter kanske någon yngre förmåga grejar att lära sig och lära vidare.<br /><br />Några filmer om abakus att gärna se redan innan:<br /><br /><a class="x1fey0fg xmper1u x1edh9d7" dir="ltr" href="https://youtu.be/2TIUPuDIbOI?si=deUp_N2lPpc2uAi3">https://youtu.be/2TIUPuDIbOI?si=deUp_N2lPpc2uAi3</a><br /><br /><a class="x1fey0fg xmper1u x1edh9d7" dir="ltr" href="https://youtube.com/playlist?list=PLVYm4hbKyOudk5Mjuw6pv_pKJmJIwDD1O&amp;si=kGGyyn75v0taXE7_">https://youtube.com/playlist?list=PLVYm4hbKyOudk5Mjuw6pv_pKJmJIwDD1O&amp;si=kGGyyn75v0taXE7_</a><br /><br />(det finns även en tillhörande gratisapp att ladda ner)<br /><br />(i tältet bredvid servicehuset)</p>
+      <p>
+
+      </p>
+    link: https://www.facebook.com/share/v/1QktDdd1Wg/
     owner:
       name: ''
       email: ''
@@ -2202,7 +2410,10 @@ events:
     end: '12:00'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: |-
+      <p>Välkommen att testa på en klass i frigörande dans!</p>
+      <p>Denna form av meditation i rörelse har varit en stor hjälp för mig som lätt fastnar i hjärnan med tankar som rusar iväg. Den ger en möjlighet att fokusera inåt och landa i kroppen samtidigt som man utforskar både rörelse och musik. 😌</p>
+      <p>Du bestämmer själv hur du vill röra dig och tanken är att låta kroppen styra efter dagsform och behov. Jag bidrar med inspiration, förslag på rörelser och fokus! ✨</p>
     link: null
     owner:
       name: ''
@@ -2217,7 +2428,11 @@ events:
     end: '16:30'
     location: GA Kreativ hörna
     responsible: Alex och Rebecca Isenfors
-    description: null
+    description: |-
+      <p>Varulvar!</p>
+      <p>Ålder: 7+</p>
+      <p>Kom och gå som ni vill, ha kul.</p>
+      <p>Ingen erfarenhet krävs, bara lyssna på spelledared och bråka inte. Har ni frågor så kan ni fråga Rebecca eller Alex (Isenfors)</p>
     link: null
     owner:
       name: ''
@@ -2232,7 +2447,17 @@ events:
     end: '16:30'
     location: GA Kreativ hörna
     responsible: Alex och Rebecca Isenfors
-    description: null
+    description: |-
+      <p>Varulvar!</p>
+      <p>&nbsp;</p>
+      <p>Ålder: 7+</p>
+      <p>&nbsp;</p>
+      <p>Kom och gå som ni vill, ha kul.</p>
+      <p>Kan hållas längre beroende på hur många som vill fortsätta</p>
+      <p>&nbsp;</p>
+      <blockquote>
+      <p>Ingen erfarenhet krävs, bara lyssna på spelledared och bråka inte. Har ni frågor så kan ni fråga Alex eller Rebecca (Isenfors)</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -2247,7 +2472,7 @@ events:
     end: '15:00'
     location: GA Idrott
     responsible: 'Joel Tegnander '
-    description: null
+    description: <p>Kom i kläder du kan kan röra dig bra i. Det måste inte vara träningskläder. Man ska inte ha strumpor.</p>
     link: null
     owner:
       name: ''
@@ -2262,7 +2487,7 @@ events:
     end: '12:30'
     location: Kaffetält
     responsible: 'Thomas Ringnér '
-    description: null
+    description: "<p>Välkommen till det konstituerade årsmötet för RFSB Väst!\_<br />Vi träffas och sätter spaden i marken för en ny regional förening i förbundet. Vi ska godkänna stadgar och styrelse för kommande år, och diskutera möjliga aktiviteter för barn och föräldrar.<br />Nominerade till styrelsen finns - välkommen!\_</p>"
     link: null
     owner:
       name: ''
@@ -2271,14 +2496,14 @@ events:
       created_at: '2025-06-26 19:22:38'
       updated_at: '2025-06-26 19:22:38'
   - id: it-projekt-agila-ramverk-m-m-informellt-snack-2025-06-27-1000
-    title: 'IT-projekt, agila ramverk m.m. Informellt snack'
+    title: IT-projekt, agila ramverk m.m. Informellt snack
     date: '2025-06-27'
     start: '10:00'
     end: '11:00'
     location: Kaffetält
     responsible: Jonas Lindstrii Ingvarsson
-    description: null
-    link: null
+    description: "<p>\"IT-projekt\". En spin-off på programmerare-mötet som var häromdagen.</p>\n<p>Finns säkert både bra och avskräckande exempel vi varit med om och kan dela med oss lite av.\_</p>"
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1132871618870816/?app=fbl
     owner:
       name: ''
       email: ''
@@ -2292,8 +2517,8 @@ events:
     end: '14:30'
     location: Tält2
     responsible: Malin och Ingimar Isenfors
-    description: null
-    link: null
+    description: "<p>En prepper är väl en galning som när katastrofen kommer sitter och kramar ett automatgevär i en bunker, omgiven av konservburkar? Eller?\_</p>\n<p>Var för ska just JAG peppa? Är det inte bara för galningar?\_</p>"
+    link: https://www.facebook.com/share/p/1C8WJ9rzex/
     owner:
       name: ''
       email: ''
@@ -2307,8 +2532,8 @@ events:
     end: '15:00'
     location: Tält1
     responsible: 'Martina Sjöström '
-    description: null
-    link: null
+    description: '<p style="text-align: left">9 platser bokning fb-tråd avancerad, räkna med att använda typ 2h. Vanlig drop-in på klistermärken, djur och glitter.<!--more--></p>'
+    link: https://www.facebook.com/share/p/16gFnfgUzD/
     owner:
       name: ''
       email: ''
@@ -2322,7 +2547,13 @@ events:
     end: '16:30'
     location: GA Idrott
     responsible: CJ
-    description: null
+    description: |-
+      <p>Direkt efter Powerpoint-karaoken tänkte jag (Johan/"CJ") köra igenom samma föreläsning som jag höll på den stora internationella ECHA-konferensen (European Council for High Ability) i Karlstad tidigare i sommar. Konferenstemat var inkludering för särskilt begåvade och jag ville röra om lite i grytan och utmana de dominerande strömningarna, som utgår från att alla ska inkluderas i en skola och klass för alla. Formatet var en kort dragning på ca 15 minuter.<br>
+      <br>
+      Med lägrets klientel som publik så utgår jag från att det till största delen kommer vara öppna dörrar som slås in, men föreläsningen kommer att vara översatt till svenska och ni är de första utanför ECHA-konferensen som får ta del av den.</p>
+      <p>
+
+      </p>
     link: null
     owner:
       name: ''
@@ -2331,13 +2562,16 @@ events:
       created_at: '2025-06-27 03:49:41'
       updated_at: '2025-06-27 03:49:41'
   - id: neurodiversitet-2e-iq-begreppet-bra-att-veta-om-hur-psykologer-kan-tanka-2025-06-27-1800
-    title: 'Neurodiversitet, 2E, IQ-begreppet, bra att veta om hur psykologer kan tänka'
+    title: Neurodiversitet, 2E, IQ-begreppet, bra att veta om hur psykologer kan tänka
     date: '2025-06-27'
     start: '18:00'
     end: '18:45'
     location: Annat
     responsible: Agnes Granberg
-    description: null
+    description: |-
+      <p>På förfrågan kommer här från en psykologs perspektiv en beskrivning av lite forskning, olika trender och aktuella diskussioner inom psykologins fält gällande kognitiva bedömningar, IQ-begreppet, 2E, fördelar och nackdelar med det diagnossystem vi har idag. Neurodiversitet och andra relevanta perspektiv beskrivs. Utifrån vad som är av intresse kn även ges en generell beskrivning av vad en psykolog är och gör, olika utbildning, synsätt och arbetssätt som psykologer kan ha.</p>
+      <p>Frågor välkomna och diskussion i smågrupper.</p>
+      <p>Vi sitter på gräset utanför GA-hallen - ändras vädret hittar vi ett tak.</p>
     link: null
     owner:
       name: ''
@@ -2352,7 +2586,7 @@ events:
     end: '14:30'
     location: Tält1
     responsible: 'Malin, Kerstin och Caroline '
-    description: null
+    description: "<p>Vi skapar pappersblommor av kräppapper och kaffefilter. Passar alla åldrar.\_</p>"
     link: null
     owner:
       name: ''
@@ -2361,14 +2595,14 @@ events:
       created_at: '2025-06-27 11:36:02'
       updated_at: '2025-06-27 11:36:02'
   - id: open-stage-med-anmalningslank-2025-06-27-2030
-    title: 'Open Stage - med anmälningslänk!'
+    title: Open Stage - med anmälningslänk!
     date: '2025-06-27'
     start: '20:30'
     end: '22:30'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<div class=\"x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">Anmälningslänk: \_<a href=\"https://l.facebook.com/l.php?u=https%3A%2F%2Fforms.gle%2FzLCAk919x57S6X7A8%3Ffbclid%3DIwZXh0bgNhZW0CMTAAYnJpZBExalh4WFJXcHpVdHZPVHo2OAEeQS282kf43ePaHYWnYw53maWxyBiPwuuMxsmJw1CRtpWSnzpCs2PepdXbb1c_aem_VeLti425Nxy8jFF_l6WLbg&amp;h=AT1nPKH_M2O6SpxsnMpkh3ZIn8lI8U1xT0W_uc8UFoRZSk-CquW3Zdu1WFbFyWKwcNwzRgYwROGYfMLbDLIRVSx-mdmT6I_hCsSqsB_O1ds12vauXrJw49-e25c-d5cY9bZlnjfDKwtd9lIwl-F-j2cHCqBRzog4IrE&amp;__tn__=-UK-R&amp;c%5B0%5D=AT0Exww4-VfvwpPPz6GAGEUsfE2RH1Q7LJw-vdy9wTBNlu54vdn3o_yGljZjxr7IF2bUh8PaYuBUJVD51gUz295p2JM-bsJ_kZYti-RFSm-9KFkKBMPwECAEfWmHCW6vB-jfi_EwwuX4DUENfM5b2OpnoL5m-wu77MNBMl-jsp2qsqDpQ6_QLK4tGKiUxV4xQosWcyw05nqt8vVNKcLlfVsqNlAzVoQ\">https://forms.gle/zLCAk919x57S6X7A8</a><br /><br />Som förra året så kommer vi att sätta upp en scen i GA-hallen för ett event med Open Stage. På Open Stage får alla som vill chansen att stå på scen och uppträda inför publik, vare sig det är med sång, dans, musik, poesi, cirkustricks, stand-up comedy, buktaleri, ett kort teaterframträdande, eller något annat ni vill visa upp. Karaoken har ett separat block (men det har funnit exempel på sång med bakgrundsmusik som ändå passar bättre in på Open Stage, kom och fråga om du är osäker).</div>\n</div>\n<div class=\"x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">\_</div>\n</div>\n<div class=\"x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">Det krävs ingen föranmälan innan lägret – du kan bestämma på plats om du vill vara med, och det kommer dyka upp ett anmälningsformulär i veckan. På många läger där det finns Open Stage händer det också att man övar in något under lägret med några vänner och sedan uppträder tillsammans. Om det är första gången du uppträder är Open Stage på ett läger där du har lärt känna lite folk under veckan, ett utmärkt och tryggt tillfälle att prova dina vingar för första gången.</div>\n</div>\n<div class=\"x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">Det kommer att finnas ljud- och ljusanläggning, mikrofoner, en cajón (trumlåda), och några gitarreffekter/förstärkarsimuleringar tillgängliga. Övrig rekvisita (instrument eller liknande) ordnar man själv. Det kommer också finnas möjlighet att ha inspelad bakgrundsmusik till sitt uppträdande, men större delen av karaoken tar vi vid ett separat tillfälle.\n<p>&nbsp;</p>\n</div>\n</div>\n<div class=\"x14z9mp xat24cr x1lziwak x1vvkbs xtlvy1s x126k92a\">\n<div dir=\"auto\">Fundera på vad ni vill uppträda med, både ungdomar och vuxna, och börja eventuella förberedelser! Vi ses på Open Stage i GA-hallen!</div>\n</div>"
+    link: https://www.facebook.com/groups/syssleback2025/posts/1126301326194512/?__cft__%5B0%5D=AZUFGq4uRe2QULfXB-MDmtfxLv7kxqhgvbOtM-16EJ_LSDAKZJ_5mZRS6buNBpm4OtWx6jsMwrvc6Bp5Q9ThAORl1_FtG9v2U9K9g34Os_ryUQeosB6xgo1NjCcUNwOwF7YbN1NbJ7Qz7jh447YTxMcXg8g6p9K9MzliqZSKylKMouLnp9zwrbpqzsL5JVhEwULEoap9iYryr32LJrl7pciL&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -2376,14 +2610,14 @@ events:
       created_at: '2025-06-27 11:52:55'
       updated_at: '2025-06-27 11:52:55'
   - id: karaoke-med-anmalningslank-2025-06-27-1800
-    title: 'Karaoke - med anmälningslänk!'
+    title: Karaoke - med anmälningslänk!
     date: '2025-06-27'
     start: '18:00'
     end: '20:00'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
-    link: null
+    description: "<p>Anmälningslänk: \_<a class=\"x1i10hfl xjbqb8w x1ejq31n x18oe1m7 x1sy0etr xstzfhl x972fbf x10w94by x1qhh985 x14e42zd x9f619 x1ypdohk xt0psk2 xe8uvvx xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x16tdsg8 x1hl2dhg xggy1nq x1a2a7pz xkrqix3 x1sur9pj x1fey0fg x1s688f\" role=\"link\" href=\"https://forms.gle/FNMeugbPwuzwPvbe8?fbclid=IwZXh0bgNhZW0CMTAAYnJpZBExalh4WFJXcHpVdHZPVHo2OAEeYg2WxY9geHedYNi86ZRYoM-qPrjrwSS8IrGmhyJzxyZZ5vgVLvJ52zeaCS0_aem_8yM2ETbWkyovXXBQewQjPg\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">https://forms.gle/FNMeugbPwuzwPvbe8</a></p>\n<div class=\"xdj266r x14z9mp xat24cr x1lziwak x1vvkbs x126k92a\">\n<div dir=\"auto\">Karaoke!\n<p>Förra årets karaoke var mycket populärt, så vi kör en omgång i år också! Öva hemma framför spegeln så kör vi!</p>\n</div>\n</div>"
+    link: https://www.facebook.com/groups/syssleback2025/posts/1126301899527788/?__cft__%5B0%5D=AZVdAEzFKlkJRglDpwUYcD8MRy18PWk5oLWNREcLEDwCxpS7cOSj3quVJyA87YmmDEJ_ewJ9F3Z7Oh9r2tafH5UogWwo1S_tETV0V0o07QH0JLKOKvnAOYNOceLtQZYikQKhmtHUWOGOFq_VwFGRNoQvUYl9SyRmBKPS7MSu-4MnoUyqc0n4509nr2hltjgbiOqYlIPyX5M1IcqWPCyRwYHg&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -2396,9 +2630,9 @@ events:
     start: '18:00'
     end: '20:00'
     location: Annat
-    responsible: 'Tilde, Albin, Moa, (Karin)'
-    description: null
-    link: null
+    responsible: Tilde, Albin, Moa, (Karin)
+    description: "<p>Artstudio kl 18 - ca 20 i Hantverkstältet\_</p>\n<p>&nbsp;</p>\n<p>Begränsat med plats</p>\n<p>BEKRÄFTAD ANMÄLAN KRÄVS\_</p>\n<p>(Antingen genom Facebook eller <a href=\"https://discord.gg/v8Qeu4Bb\">discord</a>)</p>\n<p>&nbsp;</p>\n<p>Barn 12- behöver vuxen (18+) medföljare\_</p>\n<p>&nbsp;</p>\n<p>Vuxna är självklart välkomna att delta</p>\n<p>&nbsp;</p>\n<p>Varmt välkomna!</p>\n<p>/Artstudio Teamet\_</p>\n<p>&nbsp;</p>\n<p><a href=\"https://discord.gg/v8Qeu4Bb\">DISCORD</a></p>"
+    link: https://www.facebook.com/share/p/185XRYUzzV/
     owner:
       name: ''
       email: ''
@@ -2406,13 +2640,19 @@ events:
       created_at: '2025-06-27 15:30:24'
       updated_at: '2025-06-27 15:30:24'
   - id: tank-dig-innanfor-boxen-tillfalle-2-2025-06-28-1700
-    title: 'Tänk dig innanför boxen! Tillfälle 2'
+    title: Tänk dig innanför boxen! Tillfälle 2
     date: '2025-06-28'
     start: '17:00'
     end: '18:00'
     location: AndreasTältet
     responsible: 'Charlie Rexgård '
-    description: null
+    description: |-
+      <p>Uppgiften är att du/ni ska kunna öppna fyra magiska kodlås och bli stenrika på kuppen.</p>
+      <p>&nbsp;</p>
+      <ol>
+      <li>Medtag gärna lillhjärna 😀</li>
+      <li>Obs samma kodlås som tillfälle 1</li>
+      </ol>
     link: null
     owner:
       name: ''
@@ -2421,13 +2661,21 @@ events:
       created_at: '2025-06-27 17:07:10'
       updated_at: '2025-06-27 17:07:10'
   - id: tank-dig-innanfor-boxen-tillfalle-1-2025-06-28-1300
-    title: 'Tänk dig innanför boxen! Tillfälle 1'
+    title: Tänk dig innanför boxen! Tillfälle 1
     date: '2025-06-28'
     start: '13:00'
     end: '14:00'
     location: AndreasTältet
     responsible: 'Charlie Rexgård '
-    description: null
+    description: |-
+      <p>Uppgiften är att du/ni ska kunna öppna fyra magiska kodlås och bli stenrika på kuppen.</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>Medtag gärna lillhjärna 😀</p>
+      <p>&nbsp;</p>
+      <p>Obs samma kodlås som tillfälle 2</p>
     link: null
     owner:
       name: ''
@@ -2441,9 +2689,9 @@ events:
     start: '18:00'
     end: '20:00'
     location: Annat
-    responsible: 'Tilde, Moa, Albin, (Karin)'
-    description: null
-    link: null
+    responsible: Tilde, Moa, Albin, (Karin)
+    description: "<p>Artstudio kl 18 – ca 20 i Hantverkstältet\_</p>\n<p>&nbsp;</p>\n<p>Begränsat med plats</p>\n<p>BEKRÄFTAD ANMÄLAN KRÄVS\_</p>\n<p>(Antingen genom Facebook eller\_<a href=\"https://discord.gg/v8Qeu4Bb\">discord</a>)</p>\n<p>&nbsp;</p>\n<p>Barn 12- behöver vuxen (18+) medföljare\_</p>\n<p>&nbsp;</p>\n<p>Vuxna är självklart välkomna att delta</p>\n<p>&nbsp;</p>\n<p>Varmt välkomna!</p>\n<p>/Artstudio Teamet\_</p>\n<p>&nbsp;</p>\n<p><a href=\"https://discord.gg/v8Qeu4Bb\">DISCORD</a></p>"
+    link: https://www.facebook.com/share/p/185XRYUzzV/
     owner:
       name: ''
       email: ''
@@ -2451,13 +2699,13 @@ events:
       created_at: '2025-06-27 17:11:53'
       updated_at: '2025-06-27 17:11:53'
   - id: powerpoint-karaoke-2-a-tillfallet-2025-06-28-1430
-    title: 'Powerpoint-Karaoke, 2:a tillfället'
+    title: Powerpoint-Karaoke, 2:a tillfället
     date: '2025-06-28'
     start: '14:30'
     end: '15:30'
     location: GA Idrott
     responsible: Niclas Nilsson
-    description: null
+    description: <p>Repris på gårdagens aktivitet (se mer info i fredagens schema)</p>
     link: null
     owner:
       name: ''
@@ -2472,7 +2720,11 @@ events:
     end: '11:45'
     location: Tält2
     responsible: 'Anna-Karin Jäderberg '
-    description: null
+    description: |-
+      <p>Allmänt hundsnack med er som är intresserade.</p>
+      <p>Möjligheter och betydelse för familjen i allmänhet och barnen i synnerhet.</p>
+      <p>Intresse eller erfarenhet av olika former av arbetande hundar? Ex asistanshund eller social tjänstehund.</p>
+      <p>Tält 2 eller utanför beroende på vädret.</p>
     link: null
     owner:
       name: ''
@@ -2481,13 +2733,21 @@ events:
       created_at: '2025-06-27 19:48:37'
       updated_at: '2025-06-27 19:48:37'
   - id: fa-hjalp-med-att-ga-med-i-rfsb-discord-kan-bli-grejen-framover-samma-som-de-yngre-https-discord-gg-gbcfxsek-2025-06-28-1100
-    title: 'Få hjälp med att gå med i RFSB Discord (kan bli grejen framöver, samma som de yngre) - https://discord.gg/gBCfxseK'
+    title: Få hjälp med att gå med i RFSB Discord (kan bli grejen framöver, samma som de yngre) - https://discord.gg/gBCfxseK
     date: '2025-06-28'
     start: '11:00'
     end: '12:00'
     location: KaffePaviljongen
     responsible: Morgan
-    description: null
+    description: |-
+      Discord? Vad är det? Hur får jag in det på min telefon/dator?
+      Ta och sväng förbi kaffepaviljongen för att få hjälp.
+
+
+      RFSB servern:
+      https://discord.gg/gBCfxseK
+
+      För unga, så har de en egen server. Den kan vi fixa en inbjudan till också. Görs genom att kontakta någon ungdom i servern, eller ställa en fråga digital i RFSB servern.
     link: null
     owner:
       name: ''
@@ -2502,7 +2762,7 @@ events:
     end: '16:30'
     location: GA Idrott
     responsible: 'Cecilia Löfgreen '
-    description: null
+    description: "<p>Ta del av unik data och insikter från Kairos Futures långtidsserie om svenskarnas värderingar och data från andra av våra undersökningar.\_</p>\n<p><br />Vi ses vid scenen i GA-hallen.\_</p>"
     link: null
     owner:
       name: ''
@@ -2517,7 +2777,7 @@ events:
     end: '23:00'
     location: Servicehus
     responsible: 'Martina Sjöström '
-    description: null
+    description: <p>Samma musikquiz. Bra med blandade ålder på lagen.</p>
     link: null
     owner:
       name: ''
@@ -2532,7 +2792,10 @@ events:
     end: '01:10'
     location: Nerf-arena
     responsible: //Pelle
-    description: null
+    description: |-
+      <p>https://forms.gle/8Rv5VC7GJQKSapt76</p>
+      <p>Mvh</p>
+      <p>//Pelle</p>
     link: null
     owner:
       name: ''

--- a/source/data/2025-08-syssleback.yaml
+++ b/source/data/2025-08-syssleback.yaml
@@ -12,7 +12,14 @@ events:
     end: '20:30'
     location: GA Idrott
     responsible: Alla
-    description: null
+    description: |-
+      Vi hjälps åt att hämta material från förrådet vid receptionen.
+      Bygger massa tält.
+      Gör iordning GA-hallen.
+
+      Nya deltagare har här chansen att komma in, bidra, och bli delaktiga i lägret!
+      Det blir vad vi gör det till. Fråga den jämte dig, vad du kan göra.
+      Passa på att fråga om namn också. 🙂
     link: null
     owner:
       name: ''
@@ -27,7 +34,10 @@ events:
     end: '23:30'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+
+      Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt!
     link: null
     owner:
       name: ''
@@ -42,7 +52,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -57,7 +67,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -72,7 +82,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -87,7 +97,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -102,7 +112,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -117,7 +127,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -132,7 +142,7 @@ events:
     end: '18:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -147,7 +157,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -162,7 +172,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -177,7 +187,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -192,7 +202,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -207,7 +217,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -222,7 +232,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -237,7 +247,7 @@ events:
     end: '13:00'
     location: Servicehus
     responsible: Alla
-    description: null
+    description: Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
     link: null
     owner:
       name: ''
@@ -252,7 +262,30 @@ events:
     end: '20:30'
     location: GA Idrott
     responsible: Lägernissen (Andreas)
-    description: null
+    description: |-
+      <strong>Möte:</strong>
+
+      Vi börjar med avetablering, alla hjälps åt!
+
+      När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.
+
+      Ofta en gemensam bild på alla deltagare (som vill).
+
+      <strong>Avetablering:</strong>
+
+      Gemensam översyn på området med iordningställande och städ.
+
+      Alla tält packas ner.
+
+      All utrustning tas om hand.
+
+      Alla gemensamma ytor sopas.
+
+      Kyl/frys-skåp töms, torkas ur och tas till förrådet.
+
+      Gräsytor utomhus gås igenom och skräp plockas upp.
+
+      Lost and found, vid ingång till GA-hallen.
     link: null
     owner:
       name: ''
@@ -267,7 +300,14 @@ events:
     end: '12:00'
     location: GA Idrott
     responsible: Lägernissen (Andreas)
-    description: null
+    description: |-
+      Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
+
+      Första delen - cirka 30 minuter är för alla.
+      Därefter delas det upp i mindre grupper för olika syften, för att planera veckan och sätta gemensamma ramar.
+      * Datorsal
+      * Tonårsstuga
+      * med mera
     link: null
     owner:
       name: ''
@@ -282,7 +322,11 @@ events:
     end: '15:00'
     location: Annat
     responsible: Alla
-    description: null
+    description: |-
+      Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.<br />
+      Det finns parkering för de som vill vara redo för “hemfärd”.<br />
+      Annars är det en lagom promenad på vägen bakom receptionen.<br />
+      Tiden är för det brukar vara lite “drop-in”.
     link: null
     owner:
       name: ''
@@ -297,7 +341,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -312,7 +356,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -327,7 +371,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -342,7 +386,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -357,7 +401,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -372,7 +416,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -387,7 +431,7 @@ events:
     end: '23:59'
     location: Annat
     responsible: Myggorna
-    description: null
+    description: En “hållare” för att synliggöra på informationskärmar att alla aktiviter för dagen syns.
     link: null
     owner:
       name: ''
@@ -402,8 +446,23 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: Amanda Johansson
-    description: null
-    link: null
+    description: |-
+      Jag skulle gärna vilja höra om olika upplevelser av boken beroende på om man läser eller lyssnar, samt olika åldrar. Själv har jag läst den och tror att det gör att man får bättre uppfattning, eftersom att man då får mer tid att tänka på vad som faktiskt händer.
+
+      Storytel:
+      <a href="https://www.storytel.com/se/books/fr%C3%A4mlingen-925079" target="_blank" rel="noopener">https://www.storytel.com/se/books/fr%C3%A4mlingen-925079</a>
+      Nextory:
+      <a href="https://nextory.com/se/book/framlingen-2048198" target="_blank" rel="noopener">https://nextory.com/se/book/framlingen-2048198</a>
+      Bookbeat:
+      <a href="https://www.bookbeat.com/se/book/framlingen-246096" target="_blank" rel="noopener">https://www.bookbeat.com/se/book/framlingen-246096</a>
+
+      Pdf på engelska:
+      <a href="https://www.slps.org/site/handlers/filedownload.ashx?moduleinstanceid=27607&amp;dataid=78367&amp;FileName=The%20Stranger%20-%20Albert%20Camus.pdf" target="_blank" rel="noopener">https://www.slps.org/site/handlers/filedownload.ashx?moduleinstanceid=27607&amp;dataid=78367&amp;FileName=The%20Stranger%20-%20Albert%20Camus.pdf</a>
+
+      Finns säkerligen på ditt bibliotek som ebok att låna också.
+      Biblio har den. Och dit är många bibliotek anslutna!
+      <a href="https://biblio.app/material/9789100188344" target="_blank" rel="noopener">https://biblio.app/material/9789100188344</a>
+    link: https://www.facebook.com/groups/syssleback2025/posts/1148232150668096/?__cft__%5B0%5D=AZUvkC1DoJJniPu7T7GkcI7qVkH_7r6NbjAtI0KHGDc_Z5MSTzQB-m6o2GNfVU7gwRdUSvAR0FmjJ2NmBWbH9Se9JydNGa7clifWBMqVieQ3N3NhHWoCh5V3o1hvQ5WtL6KG4sdPc8maK6t7jJuQU5xFj0_wJmEf7XhrcTWx7Vv4IT12Iop4lvE8yBbzMgXfvSWCZCYMBvwRiy_qkJ41rD9N&amp;__tn__=%2CO%2CP-R
     owner:
       name: ''
       email: ''
@@ -416,8 +475,10 @@ events:
     start: '14:00'
     end: '14:15'
     location: Tält1
-    responsible: 'Kajsa &amp; Theo (12)'
-    description: null
+    responsible: Kajsa &amp; Theo (12)
+    description: |-
+      <p><span class="s1">Pokémon Go-träff. <br /></span></p>
+      <p><span class="s1">Finns det andra på lägret som spelar Pokémon go? Vi tar en kort träff och säger hej så att vi vet vem vi kan locka med på raider och annat under veckan. Både barn och vuxna välkomna!</span></p>
     link: null
     owner:
       name: ''
@@ -432,7 +493,7 @@ events:
     end: '16:00'
     location: Tält2
     responsible: 'Christina Johansson '
-    description: null
+    description: <p>Kom och kör knasiga charader eller bara gissa på andras charader. Passar alla åldrar, barn och vuxna.</p>
     link: null
     owner:
       name: ''
@@ -447,7 +508,7 @@ events:
     end: '17:00'
     location: Kaffetält
     responsible: 'Christina & Amanda '
-    description: null
+    description: <p>Kom och prata böcker, ge och få tips på bra böcker. Alla åldrar, alla sorters böcker får vara med.</p>
     link: null
     owner:
       name: ''
@@ -456,14 +517,14 @@ events:
       created_at: '2025-07-22 10:06:49'
       updated_at: '2025-07-22 10:06:49'
   - id: rollspel-gor-karaktarer-viktors-fm-dnd-grupp-kvall-2025-08-04-1300
-    title: 'Rollspel. Gör karaktärer. Viktors, fm, DnD-grupp, kväll'
+    title: Rollspel. Gör karaktärer. Viktors, fm, DnD-grupp, kväll
     date: '2025-08-04'
     start: '13:00'
     end: '14:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
-    link: null
+    description: "<p style=\"text-align: left\">Ta fram karaktärer för Viktors DnD-kampanj (fm) för föranmälda spelare 13-16 år.\_</p>"
+    link: https://Se%20Facebookgruppen
     owner:
       name: ''
       email: ''
@@ -471,14 +532,14 @@ events:
       created_at: '2025-07-22 16:25:31'
       updated_at: '2025-07-22 16:25:31'
   - id: rollspel-gora-karaktarer-viktor-em-daggerheart-2025-08-04-1500
-    title: 'Rollspel. Göra karaktärer. Viktor, em, Daggerheart'
+    title: Rollspel. Göra karaktärer. Viktor, em, Daggerheart
     date: '2025-08-04'
     start: '15:00'
     end: '17:00'
     location: Rollspelstält1
-    responsible: 'Viktor Ängquist, 0730714200'
-    description: null
-    link: null
+    responsible: Viktor Ängquist, 0730714200
+    description: Gör karaktärer inför Viktors Daggerheartkampanj. Föranmälan. 17-22 år.
+    link: https://www.facebook.com/share/p/1P1fKH83FP/?
     owner:
       name: ''
       email: ''
@@ -486,14 +547,14 @@ events:
       created_at: '2025-07-22 16:40:35'
       updated_at: '2025-07-22 16:40:35'
   - id: rollspel-viktor-daggerheart-session-1-2025-08-04-1830
-    title: 'Rollspel, Viktor, Daggerheart, Session 1'
+    title: Rollspel, Viktor, Daggerheart, Session 1
     date: '2025-08-04'
     start: '18:30'
     end: '22:00'
     location: Rollspelstält1
-    responsible: 'Viktor Ängquist, 0730714200'
-    description: null
-    link: null
+    responsible: Viktor Ängquist, 0730714200
+    description: <p>Session 1 av Viktors Daggerheartkampanj. Föranmälan. (Denna kampanj hålls normalt under eftermiddagen, men ej på måndagen pga informationsmötet).</p>
+    link: https://www.facebook.com/share/p/1P1fKH83FP/?
     owner:
       name: ''
       email: ''
@@ -506,8 +567,8 @@ events:
     start: '14:00'
     end: '16:30'
     location: GA Idrott
-    responsible: 'Ivar Ängquist, 073-6413320'
-    description: null
+    responsible: Ivar Ängquist, 073-6413320
+    description: "<p><strong>BRAINGAMES</strong></p>\n<p>Den ultimata lagtävlingen där barn och vuxna tävlar i kluriga grenar. Lagen delas in på plats. Vi kommer även behöva ~15 funktionärer. Ingen föranmälan behövs. Ivar Ä, Anna B och Jenny v B ordnar.\_</p>"
     link: null
     owner:
       name: ''
@@ -521,9 +582,9 @@ events:
     start: '18:30'
     end: '22:00'
     location: Rollspelstält2
-    responsible: 'Harald Ängquist, 0735045212'
-    description: null
-    link: null
+    responsible: Harald Ängquist, 0735045212
+    description: <p>Detta är den första sessionen för Haralds Daggerheart-kampanj. 16-20 år. Föranmälan. Kampanjen sker parallellt med Viktors kampanj, men det är två olika kampanjer.</p>
+    link: https://www.facebook.com/share/p/1P1fKH83FP/?
     owner:
       name: ''
       email: ''
@@ -531,13 +592,13 @@ events:
       created_at: '2025-07-22 17:40:36'
       updated_at: '2025-07-22 17:40:36'
   - id: rollspel-viktor-dnd-session-1-2025-08-05-1000
-    title: 'Rollspel, Viktor DnD, session 1'
+    title: Rollspel, Viktor DnD, session 1
     date: '2025-08-05'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält1
-    responsible: 'Viktor Ängquist, 0730714200'
-    description: null
+    responsible: Viktor Ängquist, 0730714200
+    description: "<p>Rollspel, Viktors DnD kampanj, 13-16 år. Föranmälan krävs.\_</p>"
     link: null
     owner:
       name: ''
@@ -546,14 +607,14 @@ events:
       created_at: '2025-07-23 21:03:28'
       updated_at: '2025-07-23 21:03:28'
   - id: rollspel-viktors-daggerheart-kampanj-session-2-2025-08-05-1430
-    title: 'Rollspel, Viktors Daggerheart kampanj, session 2'
+    title: Rollspel, Viktors Daggerheart kampanj, session 2
     date: '2025-08-05'
     start: '14:30'
     end: '18:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist 0730714200
-    description: null
-    link: null
+    description: "<p>Viktors Daggerheart-kampanj. 17-22 år. Föranmälan krävs.\_</p>"
+    link: https://www.facebook.com/share/p/1BApBUFoh1/?
     owner:
       name: ''
       email: ''
@@ -561,14 +622,14 @@ events:
       created_at: '2025-07-23 21:06:15'
       updated_at: '2025-07-23 21:06:15'
   - id: haralds-daggerheart-kampanj-session-2-2025-08-05-1430
-    title: 'Haralds Daggerheart-kampanj, session 2'
+    title: Haralds Daggerheart-kampanj, session 2
     date: '2025-08-05'
     start: '14:30'
     end: '18:00'
     location: Rollspelstält2
-    responsible: 'Harald Ängquist, 0735045212'
-    description: null
-    link: null
+    responsible: Harald Ängquist, 0735045212
+    description: "<p>Haralds Daggerheart-kampanj, session 2. 16-20 år. Endast föranmälda.\_</p>"
+    link: https://www.facebook.com/share/p/1BApBUFoh1/?
     owner:
       name: ''
       email: ''
@@ -576,13 +637,13 @@ events:
       created_at: '2025-07-23 21:08:45'
       updated_at: '2025-07-23 21:08:45'
   - id: rollspel-gora-karaktarer-johan-d-amp-d-grupp-1-fm-rs-talt-2-2025-08-04-1300
-    title: 'Rollspel. Göra karaktärer. Johan D&amp;D grupp 1 fm. RS tält 2'
+    title: Rollspel. Göra karaktärer. Johan D&amp;D grupp 1 fm. RS tält 2
     date: '2025-08-04'
     start: '13:00'
     end: '14:00'
     location: Rollspelstält2
     responsible: Johann
-    description: null
+    description: <p>Vi gör karaktärer för morgondagens spel. Tänk gärna på i förväg vad du skulle vilja spela och kanske något kring karaktärernas bakgrund.</p>
     link: null
     owner:
       name: ''
@@ -591,13 +652,13 @@ events:
       created_at: '2025-07-25 10:37:22'
       updated_at: '2025-07-25 10:37:22'
   - id: rollspel-gora-karaktarer-johan-d-amp-d-grupp-2-kvall-2025-08-04-1400
-    title: 'Rollspel. Göra karaktärer, Johan D&amp;D grupp 2 kväll'
+    title: Rollspel. Göra karaktärer, Johan D&amp;D grupp 2 kväll
     date: '2025-08-04'
     start: '14:00'
     end: '15:00'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: <p>Rollspel. Göra karaktärer, Johan D&amp;D grupp 2 kväll</p>
     link: null
     owner:
       name: ''
@@ -606,13 +667,13 @@ events:
       created_at: '2025-07-25 10:41:18'
       updated_at: '2025-07-25 10:41:18'
   - id: spel-d-amp-d-session-1-grupp-1-2025-08-05-1000
-    title: 'Spel. D&amp;D session 1, grupp 1'
+    title: Spel. D&amp;D session 1, grupp 1
     date: '2025-08-05'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: <p>Spel. D&amp;D session 1, Johan, grupp 1</p>
     link: null
     owner:
       name: ''
@@ -621,13 +682,13 @@ events:
       created_at: '2025-07-25 10:45:19'
       updated_at: '2025-07-25 10:45:19'
   - id: spel-d-amp-d-session-1-grupp-2-2025-08-05-1830
-    title: 'Spel. D&amp;D session 1, grupp 2'
+    title: Spel. D&amp;D session 1, grupp 2
     date: '2025-08-05'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: <p>Spel. D&amp;D session 1, grupp 2</p>
     link: null
     owner:
       name: ''
@@ -636,13 +697,13 @@ events:
       created_at: '2025-07-25 10:47:16'
       updated_at: '2025-07-25 10:47:16'
   - id: spel-d-amp-d-session-2-grupp-1-2025-08-06-1000
-    title: 'Spel. D&amp;D session 2, grupp 1'
+    title: Spel. D&amp;D session 2, grupp 1
     date: '2025-08-06'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: "<p>Rollspel, \_D&amp;D session 2, \_grupp 1</p>"
     link: null
     owner:
       name: ''
@@ -651,13 +712,13 @@ events:
       created_at: '2025-07-25 10:50:12'
       updated_at: '2025-07-25 10:50:12'
   - id: rollspel-d-amp-d-session-2-grupp-2-2025-08-06-1830
-    title: 'Rollspel,  D&amp;D session 2,  grupp 2'
+    title: "Rollspel, \_D&amp;D session 2, \_grupp 2"
     date: '2025-08-06'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: "<p>Rollspel, \_D&amp;D session 2, \_grupp 2</p>"
     link: null
     owner:
       name: ''
@@ -666,13 +727,13 @@ events:
       created_at: '2025-07-25 10:52:05'
       updated_at: '2025-07-25 10:52:05'
   - id: rollspel-d-amp-d-session-3-grupp-1-2025-08-07-1000
-    title: 'Rollspel,  D&amp;D session 3,  grupp 1'
+    title: "Rollspel, \_D&amp;D session 3, \_grupp 1"
     date: '2025-08-07'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: "<p>Rollspel, \_D&amp;D session 3, grupp 1</p>"
     link: null
     owner:
       name: ''
@@ -681,13 +742,13 @@ events:
       created_at: '2025-07-25 10:54:11'
       updated_at: '2025-07-25 10:54:11'
   - id: rollspel-d-amp-d-session-3-grupp-2-2025-08-07-1830
-    title: 'Rollspel,  D&amp;D session 3, grupp 2'
+    title: "Rollspel, \_D&amp;D session 3,\_grupp 2"
     date: '2025-08-07'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält2
     responsible: Johan
-    description: null
+    description: "<p>Rollspel, \_D&amp;D session 3, grupp 2</p>"
     link: null
     owner:
       name: ''
@@ -702,8 +763,8 @@ events:
     end: '16:00'
     location: Servicehus
     responsible: 'Lisa Lautrup '
-    description: null
-    link: null
+    description: "<p>Vi bakar Princess Mochi tillsammans efter inspiration från Ai Venturas bok ”Baka Kawaii” och liknande bakelser från Oolong Tea House i Uppsala.\_<br /><br />För mer info se bifogad Fb-länk.\_</p>"
+    link: https://www.facebook.com/share/p/14TCPJYFynM/?
     owner:
       name: ''
       email: ''
@@ -717,8 +778,8 @@ events:
     end: '16:00'
     location: Servicehus
     responsible: Lisa Lautrup
-    description: null
-    link: null
+    description: "<p>Vi bakar Princess Mochi tillsammans efter inspiration från Ai Venturas bok ”Baka Kawaii” och liknande bakelser från Oolong Tea House i Uppsala.\_</p>\n<p><br />För mer info se bifogad Fb-länk.\_</p>"
+    link: https://www.facebook.com/share/p/14TCPJYFynM/?
     owner:
       name: ''
       email: ''
@@ -732,7 +793,9 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Lisa Lautrup
-    description: null
+    description: |-
+      <p>Vi testar att virka African flower med 5-talig och 6-talig symmetri. Resultatet kan användas som applikation eller sammanfogas till större objekt som väskor, filtar eller gosedjur. Endast fantasin sätter gränserna!</p>
+      <p>Testmaterial kommer att finnas på plats men om du vill göra ett större arbete rekommenderar jag att du tar med eget garn.</p>
     link: null
     owner:
       name: ''
@@ -747,7 +810,7 @@ events:
     end: '09:45'
     location: Tält2
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Prova på frigörande dans med fokus på flödande rörelsemönster!</p>\n<p>Vi dansar barfota med slutna ögon och fokus inåt. Du bestämmer helt dina rörelser efter kroppens behov. Jag bidrar med musik och inspiration.</p>\n<p>Denna typ av meditation i rörelse har varit till stor hjälp för egen del när tankarna snurrar.\_</p>"
     link: null
     owner:
       name: ''
@@ -762,7 +825,7 @@ events:
     end: '11:15'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Prova på frigörande dans med fokus på rytmer!</p>\n<p>Vi dansar barfota med slutna ögon och fokus inåt. Du bestämmer helt dina rörelser efter kroppens behov. Jag bidrar med musik och inspiration.</p>\n<p>Denna typ av meditation i rörelse har varit till stor hjälp för egen del när tankarna snurrar.\_</p>"
     link: null
     owner:
       name: ''
@@ -771,13 +834,13 @@ events:
       created_at: '2025-07-27 23:33:40'
       updated_at: '2025-07-27 23:33:40'
   - id: frigorande-dans-lekfullhet-2025-08-08-1530
-    title: 'FRIGÖRANDE DANS:Lekfullhet'
+    title: FRIGÖRANDE DANS:Lekfullhet
     date: '2025-08-08'
     start: '15:30'
     end: '16:15'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Prova på frigörande dans med fokus på lekfullhet!</p>\n<p>Vi dansar barfota och utforskar olika rörelser med hjälp av musik och gruppövningar på tema lekfullhet. Du bestämmer själv vad du vill delta i och kan fritt välja dina egna rörelser. Jag bidrar med musik, inspiration och förslag på övningar.\_</p>\n<p>Denna klass är mer extrovert än de tidigare och passar den som har stort rörelsebehov och som har barnasinnet i behåll.\_</p>\n<p>Ta med vattenflaska och räkna med att få upp pulsen rejält!</p>"
     link: null
     owner:
       name: ''
@@ -792,7 +855,10 @@ events:
     end: '17:00'
     location: Fotbollsplan
     responsible: Lisel Næslund
-    description: null
+    description: |-
+      <p>Alla som vill samlas för att spela lite fotboll! Vi kommer överens om form när vi ser hur många vi blir!</p>
+      <p>&nbsp;</p>
+      <p>Ta med vattenflaska.</p>
     link: null
     owner:
       name: ''
@@ -807,7 +873,9 @@ events:
     end: '17:00'
     location: Fotbollsplan
     responsible: Lisel Næslund
-    description: null
+    description: |-
+      <p>Alla som vill samlas för att spela lite fotboll! Vi kommer överens om form när vi ser hur många vi blir!</p>
+      <p>Ta med vattenflaska.</p>
     link: null
     owner:
       name: ''
@@ -821,9 +889,9 @@ events:
     start: '16:00'
     end: '17:00'
     location: Fotbollsplan
-    responsible: 'Christina Johansson, Lisel Naeslund'
-    description: null
-    link: null
+    responsible: Christina Johansson, Lisel Naeslund
+    description: "<p>Kom alla som vill, vuxna som barn! Man behöver inte vara bra, ju fler desto bättre.</p>\n<p>Beroende på hur många vi blir kör vi 5mot5, möjligtvis 7mot7, och 12 minuters matcher.\_\_</p>\n<p>Vi kör en kort genomgång om fotbollsregler för de som är osäkra på dem, och delar in i lag på plats.</p>\n<p>Ta med vattenflaska!</p>"
+    link: https://www.facebook.com/share/p/1GPjiBeUN6/
     owner:
       name: ''
       email: ''
@@ -831,13 +899,13 @@ events:
       created_at: '2025-07-28 12:04:44'
       updated_at: '2025-07-28 12:04:44'
   - id: rollspel-viktor-dnd-session-2-rs-talt-1-2025-08-06-1000
-    title: 'Rollspel, Viktor, DnD, session 2, RS-tält 1'
+    title: Rollspel, Viktor, DnD, session 2, RS-tält 1
     date: '2025-08-06'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
+    description: '<p>Rollspel med Viktors DnD-grupp. Session 2. Rollspelstält 1. Viktor: 073-0714200. Föranmälan krävs.</p>'
     link: null
     owner:
       name: ''
@@ -846,13 +914,13 @@ events:
       created_at: '2025-07-28 14:25:43'
       updated_at: '2025-07-28 14:25:43'
   - id: rollspel-viktors-dh-grupp-session-3-2025-08-06-1430
-    title: 'Rollspel, Viktors DH-grupp, session 3'
+    title: Rollspel, Viktors DH-grupp, session 3
     date: '2025-08-06'
     start: '14:30'
     end: '18:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
+    description: '<p>Rollspel Viktors Dragonheart grupp. Session 3. Viktor: 073-0714200. Endast föranmälda.</p>'
     link: null
     owner:
       name: ''
@@ -861,13 +929,16 @@ events:
       created_at: '2025-07-28 14:28:49'
       updated_at: '2025-07-28 14:28:49'
   - id: rollspel-haralds-dh-kampanj-session-3-2025-08-06-1430
-    title: 'Rollspel, Haralds DH-kampanj, session 3'
+    title: Rollspel, Haralds DH-kampanj, session 3
     date: '2025-08-06'
     start: '14:30'
     end: '18:00'
     location: Rollspelstält2
     responsible: Harald Ängquist
-    description: null
+    description: |-
+      <p>Haralds Dragonheart-kampanj. Session 3. Endast föranmälda. Harald: 073-5045212</p>
+      <p><!--more--></p>
+      <p><!--more--></p>
     link: null
     owner:
       name: ''
@@ -876,14 +947,14 @@ events:
       created_at: '2025-07-28 14:32:53'
       updated_at: '2025-07-28 14:32:53'
   - id: fem-fakta-pa-fem-minuter-open-stage-amp-popcorn-2025-08-06-1900
-    title: 'Fem fakta på fem minuter - open stage&amp;popcorn!'
+    title: Fem fakta på fem minuter - open stage&amp;popcorn!
     date: '2025-08-06'
     start: '19:00'
     end: '20:00'
     location: GA Scen
-    responsible: 'Dante Naeslund, Lisel Naeslund'
-    description: null
-    link: null
+    responsible: Dante Naeslund, Lisel Naeslund
+    description: "<div><strong>För nyfikna i alla åldrar som älskar att upptäcka nya ämnen!</strong></div>\n<div>Kom som publik eller kom och dela med dig av kunskap om ett ämne som du gillar. Tänk som ett mini-Ted-talk blandat med en hiss-pitch. Vi ser fram emot inspireras av varandra!</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div>\_</div>\n</div>\n<div><em>Rekommenderade ramar för dig som vill berätta om ett ämne:</em></div>\n<div><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">- Presentera dig. Berätta fem fakta om ditt valda ämne. Avrunda gärna med tips om var vi kan lära oss mer om ämnet innan du avslutar och publiken applåderar :)</span></div>\n<div>- Max fem minuter på scenen, ingen undre gräns. Vi hjälper till att hålla tiden om du vill.</div>\n<div>- Alla åldrar är välkomna. Vill man vara flera personer på scenen går det självklart bra.</div>\n<div>- Det kommer att finnas en scen och troligen en mikrofon. Kanske möjlighet till att visa bildspel tex Powerpoint, säg till i god tid om du skulle vilja använda det så ska vi försöka lösa det!</div>\n<div>- Anmälan senast samma dag kl 17.00 på pm, i Facebooktråden eller direkt till Dante/Lisel. Den som blir sugen på att gå upp på scen spontant är också varmt välkommen och anmäler sig på plats, men vi är tacksamma för föranmälningar så att det går att få en uppfattning om ungefär hur många som kommer!</div>\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n<div>Popcorn till alla!</div>\n<div>\_</div>\n<div>\_</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><em><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Här är exempel på ämnen till </span>Fem fakta på fem minuter:</em></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens farligaste platser</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Typiska japanska maträtter</span></div>\n<div>Mest visade videor på Youtube</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Byggnadsvård</span></div>\n<div>Hur man bygger en låt</div>\n<div>Historiska händelser</div>\n<div>Svåraste sporterna</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens snabbaste tåg</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Hur man äter sushi på rätt sätt</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">De lyxigaste flygplanen</span></div>\n<div>Presidenter</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Vett och etikett</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens farligaste djur</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Djupast liggande vraken</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Svåra språk</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Giftiga ämnen</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Klockor</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Uppfinningar som förändrat världen</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Periodiska systemet</span></div>\n<div>AI</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Ord som böjs fel</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Misstag som ledde till uppfinningar</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Hur vi ska komma till Mars</span></div>\n</div>"
+    link: https://www.facebook.com/share/p/16vUReRU91/
     owner:
       name: ''
       email: ''
@@ -896,8 +967,8 @@ events:
     start: '15:00'
     end: '16:00'
     location: Servicehus
-    responsible: 'Eila Colling &amp; Kajsa Ögård'
-    description: null
+    responsible: Eila Colling &amp; Kajsa Ögård
+    description: <p>Kom med och gör härligt fluffigt slime i olika färger - vi har tillbehören och visar hur. Mindre barn bör ha med en vuxen som hjälper till. Vuxna är varmt välkomna att själva göra slime i mån om plats.</p>
     link: null
     owner:
       name: ''
@@ -906,13 +977,13 @@ events:
       created_at: '2025-07-29 12:53:52'
       updated_at: '2025-07-29 12:53:52'
   - id: rollspel-viktor-dnd-session-3-2025-08-07-1000
-    title: 'Rollspel, Viktor DnD, session 3'
+    title: Rollspel, Viktor DnD, session 3
     date: '2025-08-07'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält1
     responsible: 'Viktor Ängquist '
-    description: null
+    description: "<p>Rollspel, DnD Viktors kampanj.\_</p>"
     link: null
     owner:
       name: ''
@@ -921,13 +992,13 @@ events:
       created_at: '2025-07-30 12:24:36'
       updated_at: '2025-07-30 12:24:36'
   - id: rollspel-prova-pa-2025-08-07-1830
-    title: 'Rollspel, prova-på'
+    title: Rollspel, prova-på
     date: '2025-08-07'
     start: '18:30'
     end: '21:30'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
+    description: "<p>Prova-på-rollspel. Endast en session. Förenklade regler. DnD. Föranmälan.\_</p>"
     link: null
     owner:
       name: ''
@@ -936,13 +1007,13 @@ events:
       created_at: '2025-07-30 12:27:14'
       updated_at: '2025-07-30 12:27:14'
   - id: rollspel-viktor-dnd-session-4-2025-08-08-1000
-    title: 'Rollspel, Viktor DnD, session 4'
+    title: Rollspel, Viktor DnD, session 4
     date: '2025-08-08'
     start: '10:00'
     end: '13:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
+    description: <p>Rollspel, DnD, Sista sessionen.</p>
     link: null
     owner:
       name: ''
@@ -957,7 +1028,7 @@ events:
     end: '18:00'
     location: Rollspelstält1
     responsible: Viktor Ängquist
-    description: null
+    description: "<p style=\"text-align: left\">Sista sessionen.\_</p>"
     link: null
     owner:
       name: ''
@@ -966,13 +1037,13 @@ events:
       created_at: '2025-07-30 12:32:08'
       updated_at: '2025-07-30 12:32:08'
   - id: rollspel-haralds-dh-kampanj-2025-08-08-1430
-    title: 'Rollspel, Haralds DH-kampanj'
+    title: Rollspel, Haralds DH-kampanj
     date: '2025-08-08'
     start: '14:30'
     end: '18:00'
     location: Rollspelstält2
     responsible: Harald Ängquist
-    description: null
+    description: <p>Sista sessionen!</p>
     link: null
     owner:
       name: ''
@@ -987,7 +1058,7 @@ events:
     end: '08:00'
     location: GA Idrott
     responsible: Lisa Lautrup
-    description: null
+    description: "<p style=\"text-align: left\">För dig som kanske inte fick till den där törnrosasömnen som du hade tänkt dig börjar vi dagen med lite återhämtning i form av yoga nidra. Denna yogaform är en djupt avslappnande meditationsteknik där du guidas till ett tillstånd mellan vakenhet och sömn. Det leder till återhämtning, minskad stress och släpper ofta på spänningar i kroppen.</p>\n<p>Klassen utförs liggande och är 20 min lång. Ta med något att ligga på, mjuka kläder, gärna strumpor och en filt.\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1002,7 +1073,7 @@ events:
     end: '16:00'
     location: Tält1
     responsible: Petter Zonabend König
-    description: null
+    description: "<p>Du lär dig grunderna för att jonglera tre bollar. Har du egna bollar så ta med dem. Typ av boll spelar ingen roll. tennisbollar, golfbollar, innebandybollar, jonglerbollar. Bara de väger lika mycket.\_ ALLA kan lära sig jonglera, och självklart tar det lite olika lång tid. Det är lättare än du tror. Det finns vissa viktiga grunder som jag lär dig för att det ska sitta bra.\_<br />Petter Zonabend König, SMS: 070-69 59 49 7</p>"
     link: null
     owner:
       name: ''
@@ -1017,7 +1088,7 @@ events:
     end: '19:30'
     location: Tält1
     responsible: 'Petter Zonabend König, '
-    description: null
+    description: "<p>Tälja säkert, roligt och effektivt. Trä finns på plats, men du får gärna ta med eget. Ta gärna med egen kniv, det kommer även att finnas några knivar att låna. <br />Vi går igenom grunder och säkerhet. Olika täljgrepp. Vad är en bra kniv för barn/vuxna. Hur slipar jag min kniv? Lämna ev slö kniv vid stuga 1 på söndag em/kväll eller måndag, med namn och tel.numner så ska jag försöka hinna slipa den innan vi ses. Vass kniv = säker kniv. Har du ett bryne/slipsten så ta med det.\_<br />Petter Zonabend König. SMS: 070-69 59 49 7</p>"
     link: null
     owner:
       name: ''
@@ -1026,13 +1097,13 @@ events:
       created_at: '2025-08-01 10:07:48'
       updated_at: '2025-08-01 10:07:48'
   - id: rollspel-gora-karaktarer-haralds-daggerheart-kampanj-2025-08-04-1500
-    title: 'Rollspel, göra karaktärer, Haralds Daggerheart kampanj'
+    title: Rollspel, göra karaktärer, Haralds Daggerheart kampanj
     date: '2025-08-04'
     start: '15:00'
     end: '17:00'
     location: Rollspelstält2
     responsible: Harald Ängquist
-    description: null
+    description: '<p>Vi gör karaktärer tillsammans. Föranmälan krävs. Harald: 073-5045212</p>'
     link: null
     owner:
       name: ''
@@ -1046,8 +1117,8 @@ events:
     start: '16:00'
     end: '17:00'
     location: Annat
-    responsible: 'Jonas Colling, stuga 16'
-    description: null
+    responsible: Jonas Colling, stuga 16
+    description: "<p>Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan, med olika munstycken och hur man kan förstärka med pennor. Lite tips och tricks och måla på varsin kartongskiva (c:a 90x50 cm). Inte så mycket konstnärlig handledning som prova på mediet och uttrycka sig fritt. Vi samlas vid ingången till hallen och går till ett ställe i lä. Om ni har något särskilt ni vill måla på, t ex en pannå eller vepa är det bara att ta med det.\_</p>"
     link: null
     owner:
       name: ''
@@ -1061,8 +1132,8 @@ events:
     start: '10:00'
     end: '11:30'
     location: Annat
-    responsible: 'Jonas Colling, stuga 16'
-    description: null
+    responsible: Jonas Colling, stuga 16
+    description: "<p>Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan, med olika munstycken och hur man kan förstärka med pennor. Lite tips och tricks och måla på varsin kartongskiva (c:a 90x50 cm). Inte så mycket konstnärlig handledning som prova på mediet och uttrycka sig fritt. Vi samlas vid ingången till hallen och går till ett ställe i lä. Om ni har något särskilt ni vill måla på, t ex en pannå eller vepa är det bara att ta med det.\_</p>"
     link: null
     owner:
       name: ''
@@ -1071,13 +1142,13 @@ events:
       created_at: '2025-08-01 17:39:14'
       updated_at: '2025-08-01 17:39:14'
   - id: eld-grunderna-for-att-tanda-och-fa-elden-att-ta-sig-framst-med-tandstal-2025-08-06-1430
-    title: 'ELD ! Grunderna för att tända och få elden att ta sig. Främst med tändstål.'
+    title: ELD ! Grunderna för att tända och få elden att ta sig. Främst med tändstål.
     date: '2025-08-06'
     start: '14:30'
     end: '15:30'
     location: Grillplats
     responsible: 'Petter Zonabend König, Stuga 1. '
-    description: null
+    description: "<p>Vi lär oss tända eld med tändstål. Säkerhet och grunder i hur man startar en eld och hur man släcker den. Vad brinner bra och mindre bra. Eldtriangeln. \_Hur ska man tänka för att vara säker på att elden ”tar sig”? Med ett eldstål kan du alltid tända din eld. Det gör tex inget om det blivit blött.<br />//Petter Zonabend König, SMS: 070 - 69 59 49 7</p>"
     link: null
     owner:
       name: ''
@@ -1091,8 +1162,8 @@ events:
     start: '15:00'
     end: '16:00'
     location: GA Idrott
-    responsible: 'Petter Zonabend König, Stuga 1'
-    description: null
+    responsible: Petter Zonabend König, Stuga 1
+    description: "<p>Du lär dig grunderna för att jonglera med tre bollar. Har du egna bollar så ta med dem. Typ av boll spelar ingen roll. tennisbollar, golfbollar, innebandybollar, jonglerbollar. Bara de väger lika mycket.\_ Lånebollar finns.\_ ALLA kan lära sig jonglera, och självklart tar det lite olika lång tid. Det är lättare än du tror. Det finns vissa viktiga grunder som jag lär dig för att det ska sitta bra.\_<br />Petter Zonabend König,\_ SMS: 070-69 59 49 7</p>"
     link: null
     owner:
       name: ''
@@ -1107,7 +1178,7 @@ events:
     end: '13:25'
     location: GA Stilla hyllan
     responsible: Anna Björnson (070-2871415)
-    description: null
+    description: "<p>Föräldrar till rollspelarna samlas för att få information om rollspelsfikat samt för att bestämma vem som serverar fika när.\_</p>"
     link: null
     owner:
       name: ''
@@ -1116,14 +1187,14 @@ events:
       created_at: '2025-08-03 11:17:49'
       updated_at: '2025-08-03 11:17:49'
   - id: lar-kanna-varandra-lagret-och-campingen-2025-08-04-0915
-    title: 'Lär känna varandra, lägret och campingen!'
+    title: Lär känna varandra, lägret och campingen!
     date: '2025-08-04'
     start: '09:15'
     end: '09:45'
     location: Servicehus
-    responsible: 'Cecilia (ordf RFSB, Kaffestugan)'
-    description: null
-    link: null
+    responsible: Cecilia (ordf RFSB, Kaffestugan)
+    description: "<p>09:15-09:45 på måndag så kan alla gå en uppgifts-runda. Vi möts vid sittplatserna vid servicehusets kortsida.</p>\n<p>För alla innebär det en möjlighet att lära känna fler, för nya innebär det även en liten rundtur av campingen och lägret.</p>\n<p>Det är drop-in och målsättningen är att alla som deltar ska få chansen att lära känna andra på lägret. Därför vill vi gärna blanda grupperna med deltagare som är på lägret första gången och de som varit med förut. Vi tänker att alla hjälper till med det, föräldrar får gärna gå i en egen grupp och släppa iväg barnen.</p>\n<p>Tanken är att grupperna är \_3-7 personer och man får vänta vid servicehuset tills man har hittat en grupp att gå med – oroa er inte, vi hjälps alla åt för att försöka bilda grupper eftersom så att alla som vill har en grupp att gå med.</p>\n<p>Alla som deltar får tandtrollsföda efter genomförd uppgiftsrunda.</p>"
+    link: https://www.facebook.com/share/p/1Pt6BRSyxV/?
     owner:
       name: ''
       email: ''
@@ -1137,7 +1208,7 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: 'Karin och Fredrik '
-    description: null
+    description: "<p>Brädspel i kaffetältet. Trivial Pursuit, När då då m fl\_</p>"
     link: null
     owner:
       name: ''
@@ -1152,7 +1223,7 @@ events:
     end: '22:00'
     location: Kaffetält
     responsible: 'Karin och Fredrik '
-    description: null
+    description: <p><span>Brädspel i kaffetältet. TP , När då då m fl</span></p>
     link: null
     owner:
       name: ''
@@ -1167,7 +1238,7 @@ events:
     end: '19:00'
     location: KaffePaviljongen
     responsible: Pia Olsson
-    description: null
+    description: <p>Pokémon go Lucia 5-stjärnig raid.</p>
     link: null
     owner:
       name: ''
@@ -1182,7 +1253,7 @@ events:
     end: '19:00'
     location: KaffePaviljongen
     responsible: 'Pia Olsson '
-    description: null
+    description: <p>Ny dynamax som släpps på spot hour. Omanyte är det som laddas om flitigt under en timme och fortsätter vara ute sen under veckan. Men alla power spots laddas med bara Omanyte under den timmen. Finns det ingen i närheten på campingen så kan vi knata till en om vädret tillåter.</p>
     link: null
     owner:
       name: ''
@@ -1197,8 +1268,12 @@ events:
     end: '23:59'
     location: Grillplats
     responsible: Malin Isenfors
-    description: null
-    link: null
+    description: |-
+      <p>GRILLKVÄLL Onsdag 17.00.</p>
+      <p>Vi hoppas att vädergudarna är med oss och låter oss få ha en underbar grillkväll även i år.<br />Just nu ligger den bokad på onsdag, men det kan ändras.</p>
+      <p>Välkommen ner, ta med vad mat och dricka ni vill ha. Vi startar eldarna kl 17.00.<br />Ta gärna med instrument.</p>
+      <p>EFTER att de flesta hunnit få i sina barn mat, så bjuder vi på lite popcorn och marshmellows.</p>
+    link: https://www.facebook.com/share/p/1HcEQnq3RR/
     owner:
       name: ''
       email: ''
@@ -1212,7 +1287,7 @@ events:
     end: '11:00'
     location: Kaffetält
     responsible: Jonas Colling och Lisa Lautrup
-    description: null
+    description: <p>Vi ses, fikar och delar erfarenheter om frågor som rör regnbågsfamiljer och andra HBTQI+-frågor</p>
     link: null
     owner:
       name: ''
@@ -1226,8 +1301,8 @@ events:
     start: '20:00'
     end: '22:00'
     location: Grillplats
-    responsible: 'Anna Sohlman, Johan Sundell, Henrik Sohlman'
-    description: null
+    responsible: Anna Sohlman, Johan Sundell, Henrik Sohlman
+    description: "<p><strong>Gör egna facklor\_</strong></p>\n<p>Vi tillverkar facklor genom att smälta stearin och doppa remsor av lakan.\_</p>\n<p>Facklorna tänder vi i skymningen nere vid älven.</p>\n<p>cirka 15 platser, så först till kvarn. Är intresset stort ordnar vi ett till pass.\_</p>"
     link: null
     owner:
       name: ''
@@ -1242,7 +1317,7 @@ events:
     end: '15:30'
     location: Annat
     responsible: familjen Wejbrandt
-    description: null
+    description: "<p>Kom och spela kubb med oss, eller chilla med hunden Semlan.\_<br /><br />Samling kl. 14.00 vid Servicehuset.</p>"
     link: null
     owner:
       name: ''
@@ -1257,8 +1332,8 @@ events:
     end: '16:30'
     location: GA Stilla hyllan
     responsible: Petter Åström
-    description: null
-    link: null
+    description: "<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Vi träffas på hyllan i GA-hallen kring AI. Vi väljer innehåll och nivå beroende på intresse, och planerar troligen in fler tillfällen under veckan.</span></div>\n</div>\n<div>\_</div>\n<div>Ta med dator för att kunna labba.</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Möjligt innehåll:</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Vad är AI och hur funkar det?</span></div>\n</li>\n</ul>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Hur intelligent är AI? Vad är egentligen intelligens?</span></div>\n</li>\n</ul>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Etiska aspekter på AI</span></div>\n</li>\n</ul>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Labba med ChatGPT och dess olika verktyg</span></div>\n</li>\n</ul>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Använda verktyg från t ex Google för att utveckla med AI</span></div>\n</li>\n</ul>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<ul>\n<li class=\"html-li xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1n2onr6 x1sle589\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Träna egna modeller</span></div>\n</li>\n</ul>\n</div>"
+    link: https://www.facebook.com/groups/syssleback2025/permalink/1164087989082512/
     owner:
       name: ''
       email: ''
@@ -1272,8 +1347,8 @@ events:
     end: '20:00'
     location: Tält2
     responsible: Malin Isenfors
-    description: null
-    link: null
+    description: "<p>Prepping, hur och varför?</p>\n<p>En prepper är väl en galning som när katastrofen kommer sitter och kramar ett automatgevär i en bunker, omgiven av konservburkar? Eller?</p>\n<p>Var ska man börja? Vad kan jag peppa just utifrån mina förutsättningar.</p>\n<p>Kort föreläsning och sedan öppen diskussion.\_</p>\n<p>Malin och Ingimar Isenfors</p>\n<p>&nbsp;</p>"
+    link: https://www.facebook.com/share/p/14DxSQHBay3/
     owner:
       name: ''
       email: ''
@@ -1287,7 +1362,9 @@ events:
     end: '08:15'
     location: GA Idrott
     responsible: Lisa Lautrup
-    description: null
+    description: |-
+      <p>Vi startar dagen med två kortare klasser (15 + 15 min) med fokus på ökad energi. Du väljer själv om du vill köra en eller två klasser.</p>
+      <p>Ta gärna med yogamatta om du har, ha mjuka kläder på dig och var beredd på att jobba igenom hela kroppen.</p>
     link: null
     owner:
       name: ''
@@ -1302,7 +1379,7 @@ events:
     end: '08:00'
     location: GA Idrott
     responsible: Lisa Lautrup
-    description: null
+    description: "<p>Vi utforskar rörelser runt bröstryggen i ett friare flöde med syfte att mjuka upp och öka cirkulationen i området.</p>\n<p>Klassen är 20 min lång och börjar mjukt med fokus på nyfikenhet och utforskande.\_<br /><br /></p>\n<p>Ta gärna med yogamatta om du har!</p>"
     link: null
     owner:
       name: ''
@@ -1317,7 +1394,7 @@ events:
     end: '08:00'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Vi börjar dagen med en kraftfull klass med stora rörelser för att höja energin och skapa skärpa.\_<br /><br /></p>\n<p>Ta gärna med yogamatta om du har och var beredd på en ordentlig genomkörare.</p>"
     link: null
     owner:
       name: ''
@@ -1332,7 +1409,7 @@ events:
     end: '08:00'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Vi utforskar gäspar och suckar och deras påverkan på vårt välbefinnande.</p>\n<p>Klassen utförs sittande och bidrar till lugn och ro samt mjukar upp andningsmuskulaturen.\_</p>"
     link: null
     owner:
       name: ''
@@ -1346,9 +1423,9 @@ events:
     start: '11:00'
     end: '12:00'
     location: GA Kreativ hörna
-    responsible: 'Cecilia, RFSB'
-    description: null
-    link: null
+    responsible: Cecilia, RFSB
+    description: "<p style=\"font-weight: 400\">Geografisk / lokalföreningsträff</p>\n<p style=\"font-weight: 400\">\_</p>\n<p style=\"font-weight: 400\">Passa på att träffa personer som finns närmare samt fundera gärna över om det finns något ni kan och vill göra inom RFSB framåt. Tillsammans kan vi få mer lägerkänsla året runt.</p>\n<p style=\"font-weight: 400\">\_</p>\n<p style=\"font-weight: 400\">Stockholm Mälardalen träffas i Tält 1 (utanför GA Hallen)</p>\n<p style=\"font-weight: 400\">Väst träffas i Andreas tältet (servicehustältet)</p>\n<p style=\"font-weight: 400\">Syd träffas i Tält 2 (utanför GA Hallen)</p>\n<p style=\"font-weight: 400\">Övriga träffas i GA-hallen</p>\n<p style=\"font-weight: 400\">\_</p>\n<p style=\"font-weight: 400\">Nuvarande föreningar:</p>\n<ul>\n<li>Jämtland Härjedalen</li>\n<li>Dalarna Gävleborg</li>\n<li>Stockholm Mälardalen</li>\n<li>Väst (VGR + Värmland)</li>\n<li>Syd (Skåne + Blekinge)</li>\n</ul>\n<p style=\"font-weight: 400\">\_</p>\n<p style=\"font-weight: 400\">Naturliga framtida föreningar (kan gärna kombineras):</p>\n<ul>\n<li>Norrbotten</li>\n<li>Västerbotten</li>\n<li>Västernorrland</li>\n<li>Örebro</li>\n<li>Östergötland</li>\n<li>Jönköping</li>\n<li>Kronoberg</li>\n<li>Kalmar</li>\n<li>Blekinge</li>\n</ul>"
+    link: https://www.facebook.com/share/p/1BP2WNoJAa/
     owner:
       name: ''
       email: ''
@@ -1362,7 +1439,11 @@ events:
     end: '08:20'
     location: GA Idrott
     responsible: Lisa Lautrup
-    description: null
+    description: |-
+      <p>Vi börjar dagen med ett klassiskt hatha yoga flöde med fokus på fötterna.</p>
+      <p>Passar bäst för dig som har yogat ett tag eller för dig som inte är rädd för en utmaning!</p>
+      <p>Klassen ges på engelska.</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -1377,7 +1458,7 @@ events:
     end: '14:00'
     location: GA Kreativ hörna
     responsible: 'Alex och Rebecca Isenfors '
-    description: null
+    description: '<p>Varulvarna!<br />Kom och spela i GA-hallen mellan 14:30-16:30! <br />Ålder: Från 7 år<br />Ingen erfarenhet krävs, kom och gå hur ni vill, ha kul!<br />/Alex och Rebecca Isenfors</p>'
     link: null
     owner:
       name: ''
@@ -1392,7 +1473,12 @@ events:
     end: '15:00'
     location: GA Kreativ hörna
     responsible: 'Alex och Rebecca Isenfors '
-    description: null
+    description: |-
+      <p>Varulvarna!</p>
+      <p>Kom och spela i GA-hallen 14:00</p>
+      <p>Ålder: Från 7 år</p>
+      <p>Ingen erfarenhet krävs, kom och gå när ni vill, ha kul!</p>
+      <p>/Alex och Rebecca Isenfors</p>
     link: null
     owner:
       name: ''
@@ -1407,7 +1493,7 @@ events:
     end: '21:00'
     location: AndreasTältet
     responsible: Martina och Linn
-    description: null
+    description: "<p>Blandat musikquiz med äldre och nyare låtar. Försök blanda lagen, musikstil kanske är svårt att veta, men ålder kan vara lättare. Våga komma själv, du kommer hitta ett lag och antagligen bidra på något sätt.\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1422,7 +1508,9 @@ events:
     end: '11:00'
     location: Tält2
     responsible: Anna Björnson
-    description: null
+    description: |-
+      <p id="docs-internal-guid-aad8aeda-7fff-305e-afed-fac426c8d9dd" dir="ltr" style="line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt"><span style="font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline">Lägrets första föräldrafika, där vi delar erfarenheter och tips om 2e (npf i kombination med särskild begåvning), vi inkluderar dyslexi och PDA i diskussionen.</span></p>
+      <p dir="ltr" style="line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt"><span style="font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline">Du är välkommen både om ditt barn redan har en npf-diagnos eller om ni funderar på om barnet skulle vara 2e.</span></p>
     link: null
     owner:
       name: ''
@@ -1437,7 +1525,7 @@ events:
     end: '11:00'
     location: Tält2
     responsible: Malin och Ingimar Isenfors
-    description: null
+    description: "<p id=\"docs-internal-guid-2f833aa5-7fff-5314-ff3a-10365b234e56\" dir=\"ltr\" style=\"line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt\"><span style=\"font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline\">Diskussion om Radikalaccelation i praktiken. Hur går det till, hur gör man rent praktiskt, vad finns det för fallgropar.\_</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt\"><span style=\"font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline\">Radikalaccelation är när man flyttar upp 3 år eller mer i skolan, på en gång eller i steg.\_</span></p>\n<p dir=\"ltr\" style=\"line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt\"><span style=\"font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline\">Varmt välkomna!</span></p>"
     link: null
     owner:
       name: ''
@@ -1452,7 +1540,7 @@ events:
     end: '11:00'
     location: Tält2
     responsible: Anna Björnson
-    description: null
+    description: '<p id="docs-internal-guid-68cea460-7fff-b95c-7bbd-2d4ade20abdd" dir="ltr" style="line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt"><span style="font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline">Vi delar erfarenheter och tips om uppflytt, särskild prövning samt vad man kan göra när man tagit studenten som 16-åring.</span></p>'
     link: null
     owner:
       name: ''
@@ -1466,8 +1554,8 @@ events:
     start: '10:00'
     end: '11:00'
     location: Tält2
-    responsible: 'Maria AIfredsson och Susanna &amp; Niclas Nilsson'
-    description: null
+    responsible: Maria AIfredsson och Susanna &amp; Niclas Nilsson
+    description: '<p id="docs-internal-guid-af3366d4-7fff-e565-207b-2b2283953736" dir="ltr" style="line-height: 1.38;margin-top: 0.0pt;margin-bottom: 0.0pt"><span style="font-size: 11pt;font-family: Arial, sans-serif;color: #000000;background-color: transparent;vertical-align: baseline">Maria AIfredsson och Susanna &amp; Niclas Nilsson delar med sig av erfarenheter av att lämna Sverige för att undervisa på annat sätt när skolan i Sverige inte fungerar.</span></p>'
     link: null
     owner:
       name: ''
@@ -1482,7 +1570,7 @@ events:
     end: '11:30'
     location: AndreasTältet
     responsible: Malin Isenfors
-    description: null
+    description: "<p>Popup nagelstudio!</p>\n<p>I tältet vid servicehuset kl 10.00 - 11.30 på tisdag.\_</p>\n<p>Måla dina egna naglar, eller någon annans!</p>\n<p>Barn som inte kan klara sig själva behöver komma med vuxet sällskap!\_</p>\n<p>- Det kommer fler tillfällen under veckan.</p>"
     link: null
     owner:
       name: ''
@@ -1497,7 +1585,7 @@ events:
     end: '14:30'
     location: GA Stilla hyllan
     responsible: Niclas Nilsson
-    description: null
+    description: <p>En GPT är en sorts AI – en textbaserad samtalspartner som kan svara, förklara, föreslå och mycket mer. I den här sessionen bygger vi tillsammans en egen GPT med hjälp av ChatGPT:s inbyggda verktyg. Vi bestämmer vad den ska kunna, hur den ska uttrycka sig och vilken roll den ska ha. Vi gör det gemensamt på en projektor, men har ni en dator att ta med för att pröva själva också är det bara positivt.</p>
     link: null
     owner:
       name: ''
@@ -1512,7 +1600,7 @@ events:
     end: '16:00'
     location: GA Stilla hyllan
     responsible: Ingimar Isenfors
-    description: null
+    description: "<p><strong>Skapa med ChatGPT (och andra AI)</strong></p>\n<p>Kom och se hur man kan använda AI-verktyg som ChatGPT och Suno för att skapa texter, bilder och musik – utan att vara expert. Jag visar exempel, vi pratar om hur det funkar och delar tips med varandra. Nyfiken eller redan igång? Alla är välkomna!</p>\n<p>Valfritt: Ta med egen dator\_</p>"
     link: null
     owner:
       name: ''
@@ -1527,7 +1615,7 @@ events:
     end: '12:30'
     location: Servicehus
     responsible: Christina Falk
-    description: null
+    description: "<p>Leker röda vita rosen (anpassade regler för lägret)</p>\n<ul>\n<li>Hela lägerområdet får användas för att gömma stormumriken</li>\n<li>Poängräkning</li>\n</ul>\n<p>Ingen åldergräns men deltagarna ska kunna</p>\n<ul>\n<li>Leka självständigt utan föräldrar</li>\n<li>Kunna behålla hemlighet\_</li>\n<li>Följa regler och vara lojal med laget</li>\n</ul>\n<p>Samling vid servicehuset klockan 11 då vi börjar med regelgenomgång och lagindelning.</p>"
     link: null
     owner:
       name: ''
@@ -1542,7 +1630,16 @@ events:
     end: '20:00'
     location: AndreasTältet
     responsible: Malin Isenfors
-    description: null
+    description: |-
+      Popup nagelstudio!<br />
+      <br />
+      I tältet vid servicehuset kl 10.00 – 11.30 på tisdag. <br />
+      <br />
+      Måla dina egna naglar, eller någon annans!<br />
+      <br />
+      Barn som inte kan klara sig själva behöver komma med vuxet sällskap! <br />
+      <br />
+      – Det kommer fler tillfällen under veckan.
     link: null
     owner:
       name: ''
@@ -1557,7 +1654,14 @@ events:
     end: '17:00'
     location: AndreasTältet
     responsible: Christina Falk och Rikard Olofsson
-    description: null
+    description: |-
+      Det är ett mysterium för mig hur världens roligaste kortspel, som kräver mer intelligens och strategi än något annat, har fått det oförtjänta ryktet som en dammig pensionärsaktivitet.<br />
+      <br />
+      Bridge är kortspelens motsvarighet till schack.<br />
+      <br />
+      Kom och spela med oss. Inga förkunskaper krävs, vi lär ut reglerna.<br />
+      Om vi blir minst 8 st kan vi spela en kort lagtävling.<br />
+      <br />
     link: null
     owner:
       name: ''
@@ -1572,7 +1676,7 @@ events:
     end: '19:30'
     location: GA Stilla hyllan
     responsible: 'Elias '
-    description: null
+    description: "<p>Kom och spela YU-GI-O! Ingen erfarenhet behövs! /Elias Eellend\_</p>\n<p>&nbsp;</p>"
     link: null
     owner:
       name: ''
@@ -1586,8 +1690,8 @@ events:
     start: '14:00'
     end: '15:15'
     location: GA Stilla hyllan
-    responsible: 'Jinghong Sundell, Johan Sundell'
-    description: null
+    responsible: Jinghong Sundell, Johan Sundell
+    description: <p>Lär dig spela Mahjong. 4 pers kan spela per omgång. https://sv.wikipedia.org/wiki/Mahjong</p>
     link: null
     owner:
       name: ''
@@ -1601,8 +1705,8 @@ events:
     start: '19:30'
     end: '20:30'
     location: GA Kreativ hörna
-    responsible: 'Martina&amp;Linn'
-    description: null
+    responsible: Martina&amp;Linn
+    description: "<p>En speciell fläta med hjälp av garn och kartong.\_</p>"
     link: null
     owner:
       name: ''
@@ -1617,8 +1721,11 @@ events:
     end: '14:30'
     location: AndreasTältet
     responsible: Kajsa Ögård
-    description: null
-    link: null
+    description: |-
+      <p class="p1"><span class="s1">Drop-in pyssel med lufttorkande lera i tältet vid servicehuset.</span></p>
+      <p class="p1"><span class="s1">Lera finns i vitt, svart och terracotta. När leran torkat (1-2 dygn) kan den målas med akryl- eller hobbyfärg.</span></p>
+      <p class="p1"><span class="s1">Ta gärna med saker som du eller andra kan använda för att forma och dekorera leran – till exempel små skålar, sugrör, svampar, penslar, grillpinnar, gem, fiskelina, nålar, skrapor/stekspadar etc. Extra knivar (vassa) och släta glasflaskor/burkar som kan användas som brödkavel är också extra välkommet!</span></p>
+    link: https://www.facebook.com/share/p/19XiZX5fBE/?
     owner:
       name: ''
       email: ''
@@ -1632,7 +1739,7 @@ events:
     end: '12:30'
     location: GA Stilla hyllan
     responsible: Anna Björnson
-    description: null
+    description: "<p>Föräldrafika 2e fortsättning\_</p>\n<p>Vi fortsätter diskussionen från tisdagens föräldrafika.</p>"
     link: null
     owner:
       name: ''
@@ -1647,7 +1754,7 @@ events:
     end: '21:30'
     location: GA Stilla hyllan
     responsible: 'Alex Isenfors '
-    description: null
+    description: "<blockquote>\n<p>Kom till stilla hyllan och rita Manga tillsammans. Alex finns där, visar och ger tips.</p>\n<p>Ta med eget ritmaterial. Det går också bra att rita digitalt med en app om man vill.</p>\n</blockquote>\n<p>Det finns också möjlighet att låna lite material från pysselhörnan om man helt saknar.\_</p>"
     link: null
     owner:
       name: ''
@@ -1662,7 +1769,7 @@ events:
     end: '15:30'
     location: Tält2
     responsible: Anna Björnson
-    description: null
+    description: <p>Vi delar erfarenheter och tips kring "hemmasittare", eller som jag hellre säger, barn med problematisk skolnärvaro.</p>
     link: null
     owner:
       name: ''
@@ -1671,13 +1778,13 @@ events:
       created_at: '2025-08-05 12:33:14'
       updated_at: '2025-08-05 12:33:14'
   - id: braingame-funktionarsmote-2025-08-06-1430
-    title: 'Braingame, funktionärsmöte'
+    title: Braingame, funktionärsmöte
     date: '2025-08-06'
     start: '14:30'
     end: '15:10'
     location: GA Idrott
     responsible: Jenny von Bahr
-    description: null
+    description: "<p>Planeringsmöte för stationerna 1-6. Vi ses vid GA-idrott och sätter oss i något hörn.\_</p>"
     link: null
     owner:
       name: ''
@@ -1686,13 +1793,13 @@ events:
       created_at: '2025-08-05 15:38:22'
       updated_at: '2025-08-05 15:38:22'
   - id: braingame-funktionarsmote-2025-08-07-1115
-    title: 'Braingame, funktionärsmöte'
+    title: Braingame, funktionärsmöte
     date: '2025-08-07'
     start: '11:15'
     end: '12:00'
     location: GA Idrott
     responsible: Jenny von Bahr
-    description: null
+    description: <p>Planeringsmöte för station 7-12. Vi ses vid GA-hallen och sätter oss i något hörn.</p>
     link: null
     owner:
       name: ''
@@ -1701,13 +1808,13 @@ events:
       created_at: '2025-08-05 15:40:01'
       updated_at: '2025-08-05 15:40:01'
   - id: fem-fakta-pa-fem-minuter-open-stage-popcorn-2025-08-07-1245
-    title: 'Fem fakta på fem minuter – open stage&popcorn!'
+    title: Fem fakta på fem minuter – open stage&popcorn!
     date: '2025-08-07'
     start: '12:45'
     end: '13:45'
     location: AndreasTältet
-    responsible: 'Lisel Næslund, Dante Næslund'
-    description: null
+    responsible: Lisel Næslund, Dante Næslund
+    description: "<div><strong>För nyfikna i alla åldrar som älskar att upptäcka nya ämnen!</strong></div>\n<div>Kom som publik eller kom och dela med dig av kunskap om ett ämne som du gillar. Tänk som ett mini-Ted-talk blandat med en hiss-pitch. Vi ser fram emot att inspireras av varandra!</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div>\_</div>\n</div>\n<div><em>Rekommenderade ramar för dig som vill berätta om ett ämne:</em></div>\n<div><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">– Presentera dig. Berätta fem fakta om ditt valda ämne. Avrunda gärna med tips om var vi kan lära oss mer om ämnet innan du avslutar och publiken applåderar 🙂</span></div>\n<div>– Max fem minuter på scenen, ingen undre gräns. Vi hjälper till att hålla tiden om du vill.</div>\n<div>– Alla åldrar är välkomna. Vill man vara flera personer på scenen går det självklart bra.</div>\n<div>– Det kommer att finnas en plats att stå på och en mikrofon.\_</div>\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n<div>Popcorn till alla!</div>\n<div>\_</div>\n<div>\_</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><em><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Här är exempel på ämnen till\_</span>Fem fakta på fem minuter:</em></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\">\_</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens farligaste platser</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Typiska japanska maträtter</span></div>\n<div>Mest visade videor på Youtube</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Byggnadsvård</span></div>\n<div>Hur man bygger en låt</div>\n<div>Historiska händelser</div>\n<div>Svåraste sporterna</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens snabbaste tåg</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Hur man äter sushi på rätt sätt</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">De lyxigaste flygplanen</span></div>\n<div>Presidenter</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Vett och etikett</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Världens farligaste djur</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Djupast liggande vraken</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Svåra språk</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Giftiga ämnen</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Klockor</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Uppfinningar som förändrat världen</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Periodiska systemet</span></div>\n<div>AI</div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Ord som böjs fel</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Misstag som ledde till uppfinningar</span></div>\n</div>\n<div class=\"html-div xdj266r x14z9mp xat24cr x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl\">\n<div class=\"html-div xdj266r x14z9mp x1lziwak xexx8yu xyri2b x18d9i69 x1c1uobl x1e56ztr\"><span class=\"x193iq5w xeuugli x13faqbe x1vvkbs x1xmvt09 x6prxxf xvq8zen xo1l8bm xzsf02u\">Hur vi ska komma till Mars</span></div>\n</div>"
     link: null
     owner:
       name: ''
@@ -1722,7 +1829,10 @@ events:
     end: '12:00'
     location: Tält1
     responsible: Martina och Linn
-    description: null
+    description: |-
+      <blockquote>
+      <p>Diamond painting: pyssel med glitter, kan det bli bättre? Fungerar för yngre barn ta gärna med en förälder då. Flyttar borden i tält 1 inomhus till korridoren.</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -1737,8 +1847,8 @@ events:
     end: '15:00'
     location: Tält1
     responsible: Martina och Linn
-    description: null
-    link: null
+    description: "<p>Diamond painting. Pyssla med diamanter. Finns nyckelringar och klistermärken, boka till glasunderlägg\_</p>"
+    link: https://www.facebook.com/share/p/1CZWZcFnN7/
     owner:
       name: ''
       email: ''
@@ -1752,7 +1862,7 @@ events:
     end: '11:00'
     location: AndreasTältet
     responsible: Malin Isenfors
-    description: null
+    description: "<p style=\"text-align: left\">NYHET! Nagelmålning för fega föräldrar</p>\n<p style=\"text-align: left\">Nyhet! För första gången kör nagelstudion en speciell event - Nagelmålning för fega föräldrar!</p>\n<p style=\"text-align: left\">Vi riktar oss speciellt till DIG som inte riktigt vågat dig hit när alla coola kidsen är här.</p>\n<p style=\"text-align: left\">Måla dig själv, varandra eller ta med ett barn som kan stötta och hjälpa dig!!</p>\n<p style=\"text-align: left\">Vi kör 80-talshits.</p>\n<p style=\"text-align: left\">Låt din inre diva blomma ut, du vet att den finns där!!</p>\n<p style=\"text-align: left\">Servicehuset, Fredag kl 10-11.</p>\n<p style=\"text-align: left\">\_</p>"
     link: null
     owner:
       name: ''
@@ -1767,7 +1877,7 @@ events:
     end: '12:00'
     location: AndreasTältet
     responsible: Malin Isenfors
-    description: null
+    description: "<p>Popup nagelstudio</p>\n<p>I tältet vid servicehuset kl 11-12 på fredag.\_</p>\n<p>Måla dina egna naglar, eller någon annans!</p>\n<p>Barn som inte kan klara sig själva behöver komma med vuxet sällskap!\_</p>"
     link: null
     owner:
       name: ''
@@ -1782,7 +1892,7 @@ events:
     end: '14:30'
     location: GA Stilla hyllan
     responsible: Jonas o Petter
-    description: null
+    description: <p>Vi undersöker hur man kan använda olika AI-verktyg för skola och utbildning. Ta med dator för att labba!</p>
     link: null
     owner:
       name: ''
@@ -1797,7 +1907,9 @@ events:
     end: '08:00'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: |-
+      <p>Vi börjar dagen med en rutin för lymfsystemet med fokus på ökat flöde som bidrar till minskad svullnad och bättre immunförsvar.</p>
+      <p>Rutinen ”The Big 6” kan med fördel göras dagligen under hela året.</p>
     link: null
     owner:
       name: ''
@@ -1812,7 +1924,9 @@ events:
     end: '11:30'
     location: GA Kreativ hörna
     responsible: Julius Grassman
-    description: null
+    description: |-
+      <p>Hur skapas film, hur använder man olika filmiska språk och hur gör man för att skapa filmen med bara en mobiltelefon.</p>
+      <p>Det tänkte jag presentera med lite övning och knep för att komma igång. Sedan är tanken att gruppen skapar en kort film. På eftermiddagen ca kl 16-17:30 samlas vi igen och redigerar/sätter ihop filmen i mobilen.</p>
     link: null
     owner:
       name: ''
@@ -1827,8 +1941,8 @@ events:
     end: '18:00'
     location: AndreasTältet
     responsible: Kajsa Ögård
-    description: null
-    link: null
+    description: "<p class=\"p1\">Gör din egen slime i tältet vid servicehuset. Drop-in kl. 16:30-18. Mindre barn bör ha med en vuxen som hjälper till.</p>\n<p class=\"p1\"><span class=\"s2\">OBS! Ta med valfri skål och en matsked att blanda med - både ”riktiga” skålar och engångskärl som större yoghurtburkar i plast fungerar. (Engångsartiklarna som köptes in för omgång 1 är nästan slut och en stadig sked fungerar oavsett mycket bättre än en engångssked).\_</span></p>"
+    link: https://www.facebook.com/share/p/19Der1uQL8/?
     owner:
       name: ''
       email: ''
@@ -1842,7 +1956,7 @@ events:
     end: '20:00'
     location: Annat
     responsible: Torsby
-    description: null
+    description: Simhall öppen för alla. Se priser på deras hemsida.
     link: null
     owner:
       name: ''
@@ -1857,7 +1971,7 @@ events:
     end: '19:00'
     location: Annat
     responsible: Torsby
-    description: null
+    description: Simhall öppen för alla. Se priser på deras hemsida.
     link: null
     owner:
       name: ''
@@ -1872,7 +1986,7 @@ events:
     end: '20:00'
     location: Annat
     responsible: Torsby
-    description: null
+    description: Simhall öppen för alla. Se priser på deras hemsida.
     link: null
     owner:
       name: ''
@@ -1887,7 +2001,7 @@ events:
     end: '14:00'
     location: Annat
     responsible: Torsby
-    description: null
+    description: Simhall öppen för alla. Se priser på deras hemsida.
     link: null
     owner:
       name: ''
@@ -1901,8 +2015,13 @@ events:
     start: '11:00'
     end: '12:00'
     location: AndreasTältet
-    responsible: 'Maja & Ulrik'
-    description: null
+    responsible: Maja & Ulrik
+    description: |-
+      <p>För alla som vill leka med såpbubblor.</p>
+      <p>Vi är vid tältet utanför servicehuset.</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
     link: null
     owner:
       name: ''
@@ -1917,7 +2036,7 @@ events:
     end: '17:00'
     location: Annat
     responsible: Jonas Colling
-    description: null
+    description: "<p>Det är lite byigt och svårt att hitta lä, så vi kör bland buskarna bakom rollspelstälten där det är lite skydd och oöm omgivning\_</p>"
     link: null
     owner:
       name: ''
@@ -1932,7 +2051,7 @@ events:
     end: '17:15'
     location: Grillplats
     responsible: Morgan
-    description: null
+    description: Tända eldarna med eldstål för de som deltog tidigare
     link: null
     owner:
       name: ''
@@ -1947,8 +2066,8 @@ events:
     end: '17:30'
     location: GA Kreativ hörna
     responsible: Julius Grassman
-    description: null
-    link: null
+    description: <p>För de som deltagit i del 1 så samlas vi nu för redigering av filmat material i mobilen, sätter ihop en liten film av det man gjort med gruppen.</p>
+    link: https://www.facebook.com/share/p/1EpWBZPJCZ/?
     owner:
       name: ''
       email: ''
@@ -1956,13 +2075,13 @@ events:
       created_at: '2025-08-06 19:53:17'
       updated_at: '2025-08-06 19:53:17'
   - id: rollspel-johan-grupp-2-med-plats-for-lunch-2025-08-08-1100
-    title: 'Rollspel, Johan, grupp 2 ( med plats för lunch)'
+    title: Rollspel, Johan, grupp 2 ( med plats för lunch)
     date: '2025-08-08'
     start: '11:00'
     end: '14:00'
     location: Rollspelstält2
     responsible: 'Johan '
-    description: null
+    description: <p>Istället för onsdag kväll. Vi gör en kort paus för lunch för de som vill!</p>
     link: null
     owner:
       name: ''
@@ -1977,7 +2096,7 @@ events:
     end: '12:00'
     location: GA Stilla hyllan
     responsible: 'Jonas '
-    description: null
+    description: "<p>Upptäck hur du kan bygga kraftfulla appar med hjälp av Google AI Studio – utan att nödvändigtvis kunna koda! I denna praktiska workshop utforskar vi hur du kan använda AI för att skapa appar som i sig själva innehåller element av AI – snabbt, smart och enkelt. \_</p>"
     link: null
     owner:
       name: ''
@@ -1991,8 +2110,8 @@ events:
     start: '16:30'
     end: '18:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Karin'
-    description: null
+    responsible: Tilde, Karin
+    description: "<p>Drop in artstudio från ca 16.30 (efter brain games) till ca 18.</p>\n<p>Man kan komma och gå lite fritt, barn 12 år och yngre I vuxet sällskap.\_</p>\n<p>Vuxna varmt välkomna att delta (både med och utan barn)</p>"
     link: null
     owner:
       name: ''
@@ -2007,8 +2126,10 @@ events:
     end: '00:30'
     location: Tonårsstugan
     responsible: 'Antonia Ilke '
-    description: null
-    link: null
+    description: |-
+      <p>Kom och improvisera! Vi har några idéer på lekar, det blir precis vad vi gör det till. Ta gärna med en bok med lustiga repliker och någon rekvisita. Ses där!</p>
+      <p>För tonåringar.</p>
+    link: https://0723459487
     owner:
       name: ''
       email: ''
@@ -2021,8 +2142,10 @@ events:
     start: '23:00'
     end: '00:30'
     location: Tonårsstugan
-    responsible: 'Antonia Ilke, 072 543 9487'
-    description: null
+    responsible: Antonia Ilke, 072 543 9487
+    description: |-
+      <p>Kom och improvisera! Vi har några idéer på lekar, det blir precis vad vi gör det till. Ta gärna med en bok med lustiga repliker och någon rekvisita. Ses där!</p>
+      <p>För tonåringar.</p>
     link: null
     owner:
       name: ''
@@ -2037,7 +2160,7 @@ events:
     end: '11:30'
     location: Annat
     responsible: Jonas Colling
-    description: null
+    description: "<p>Vi kör spraymålningen bakom rollspelstälten\_</p>"
     link: null
     owner:
       name: ''
@@ -2046,13 +2169,16 @@ events:
       created_at: '2025-08-07 08:43:33'
       updated_at: '2025-08-07 08:43:33'
   - id: se-hit-alla-pappor-vilka-ar-pa-lagret-och-vad-tanker-vi-2025-08-08-1800
-    title: 'Se hit alla pappor - vilka är på lägret och vad tänker vi?'
+    title: Se hit alla pappor - vilka är på lägret och vad tänker vi?
     date: '2025-08-08'
     start: '18:00'
     end: '19:00'
     location: Kaffetält
     responsible: Morgan
-    description: null
+    description: |-
+      Vad tänker vi pappor kring barn, särskild begåvning och utbildning?<br>
+      <br>
+      Och framförallt. Vad heter alla? Vilka är här? Och hur är läget?
     link: null
     owner:
       name: ''
@@ -2067,7 +2193,7 @@ events:
     end: '21:00'
     location: AndreasTältet
     responsible: Christina Falk och Rikard Olofsson
-    description: null
+    description: "<p>Det är ett mysterium för mig hur världens roligaste kortspel, som kräver mer intelligens och strategi än något annat, har fått det oförtjänta ryktet som en dammig pensionärsaktivitet.</p>\n<p>Ett tillfälle till att lära sig bridge.\_</p>\n<p>Första 15 minutrarna ägnar vi åt introduktion, som man kan hoppa över om man kan grunderna.\_<br /><br />Bridge är kortspelens motsvarighet till schack.</p>\n<p>Kom och spela med oss. Inga förkunskaper krävs, vi lär ut reglerna.<br />Om vi blir minst 8 st kan vi spela en kort lagtävling.</p>"
     link: null
     owner:
       name: ''
@@ -2082,7 +2208,7 @@ events:
     end: '22:00'
     location: Servicehus
     responsible: Petter Å
-    description: null
+    description: <p>Kul om några vill o spela o sjunga! Jag tar med en djembe och ser om fler kommer :)</p>
     link: null
     owner:
       name: ''
@@ -2097,7 +2223,7 @@ events:
     end: '22:30'
     location: GA Stilla hyllan
     responsible: Cecilia (kaffestugan)
-    description: null
+    description: '<p><b>"A party game for horrible people".</b><br /><br />Cards Against Humanity är succespelet från USA och liknar inget annat! Ett partyspel för elaka personer. Till skillnad från andra partyspel så har detta mycket av svart humor, är elakt och verkligen udda för dig och dina vänner. Reglerna är enkla, i varje omgång ställer en spelare en fråga från svart kort och alla andra ska välja ord att svara med från de vita korten! På så vis fyller man i för att få ihopa en mening, och det kan blir riktigt galet. Garanterat många skratt på festen!<br /><br />Speltid: 30-90 min<br /><br />Antal spelare: 4-20<br /><br />Rekommenderad ålder: 17 och över</p>'
     link: null
     owner:
       name: ''
@@ -2112,7 +2238,7 @@ events:
     end: '11:15'
     location: GA Idrott
     responsible: 'Lisa Lautrup '
-    description: null
+    description: "<p>Vi dansar barfota med slutna ögon och fokus inåt. Du bestämmer helt dina rörelser efter kroppens behov. Jag bidrar med musik och inspiration.</p>\n<p>I denna klass utforskar vi alla 7 rörelserytmer som ingår i den frigörande dansen.\_</p>\n<p>Denna typ av meditation i rörelse har varit till stor hjälp för egen del när tankarna snurrar.\_</p>"
     link: null
     owner:
       name: ''
@@ -2126,8 +2252,8 @@ events:
     start: '15:15'
     end: '18:00'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Karin'
-    description: null
+    responsible: Tilde, Karin
+    description: "<p>Drop in artstudio från ca 15.15 till ca 18.</p>\n<p>&nbsp;</p>\n<p>Man kan komma och gå lite fritt, 12 år och yngre I vuxet sällskap.\_</p>\n<p>&nbsp;</p>\n<p>Lite material av olika sorter finns men man kan gärna ta med sig eget också :]</p>\n<p>&nbsp;</p>\n<p>Vuxna varmt välkomna att delta (både med och utan barn)</p>"
     link: null
     owner:
       name: ''
@@ -2142,7 +2268,13 @@ events:
     end: '14:00'
     location: GA Stilla hyllan
     responsible: Jonas
-    description: null
+    description: |-
+      <p>Delvis en uppföljning av en AI-workshop där vi tittade på uppsättning av chattbottar för lärande. <br />Tanken är att detta tillfälle ska kunna vara en möjlighet att fundera vidare över potentiella digitala (evt AI-stödda) verktyg:</p>
+      <ul>
+      <li>som stöd till föräldrar?</li>
+      <li>som stöd till barn?</li>
+      </ul>
+      <p>samt att diskutera ambition, nivå, etc kring eventuella sådana verktyg.</p>
     link: null
     owner:
       name: ''
@@ -2151,13 +2283,15 @@ events:
       created_at: '2025-08-08 09:34:14'
       updated_at: '2025-08-08 09:34:14'
   - id: fotboll-for-alla-2025-08-08-1600
-    title: 'Fotboll för alla!'
+    title: Fotboll för alla!
     date: '2025-08-08'
     start: '16:00'
     end: '17:00'
     location: Fotbollsplan
     responsible: Fredrik och Arvid
-    description: null
+    description: |-
+      <p>Vi kör ett fotbollspass idag också!</p>
+      <p>Alla, verkligen alla, kan vara med🙂</p>
     link: null
     owner:
       name: ''
@@ -2172,7 +2306,13 @@ events:
     end: '14:00'
     location: GA Stilla hyllan
     responsible: Jonas
-    description: null
+    description: |-
+      <p>Delvis en uppföljning av en AI-workshop där vi tittade på uppsättning av chattbottar för lärande.</p>
+      <p>Tanken är att detta tillfälle ska kunna vara en möjlighet att fundera vidare över potentiella digitala (evt AI-stödda) verktyg:</p>
+      <p>&nbsp;</p>
+      <p>som stöd till föräldrar?</p>
+      <p>som stöd till barn?</p>
+      <p>samt att diskutera ambition, nivå, etc kring eventuella sådana verktyg.</p>
     link: null
     owner:
       name: ''
@@ -2181,13 +2321,13 @@ events:
       created_at: '2025-08-08 11:16:37'
       updated_at: '2025-08-08 11:16:37'
   - id: ai-flyttade-till-lor-samma-tid-och-plats-2025-08-08-1300
-    title: 'AI flyttade till lör samma tid och plats!'
+    title: AI flyttade till lör samma tid och plats!
     date: '2025-08-08'
     start: '13:00'
     end: '14:00'
     location: GA Stilla hyllan
     responsible: Jonas
-    description: null
+    description: "<p>Flyttade till imorgon\_</p>"
     link: null
     owner:
       name: ''
@@ -2202,7 +2342,7 @@ events:
     end: '16:00'
     location: GA Kreativ hörna
     responsible: 'Alex och Rebecca Isenfors '
-    description: null
+    description: "<p>Varulvarna!</p>\n<p>Kom och spela i GA-hallen mellan 14:30-16:30!\_</p>\n<p>Ålder: Från 7 år</p>\n<p>Ingen erfarenhet krävs, kom och gå hur ni vill, ha kul!</p>\n<p>/Alex och Rebecca Isenfors</p>"
     link: null
     owner:
       name: ''
@@ -2217,7 +2357,10 @@ events:
     end: '15:30'
     location: Tält1
     responsible: Martina Linn
-    description: null
+    description: |-
+      <blockquote>
+      <p>Avsluta glasunderlägg eller gör något lite klistermärke</p>
+      </blockquote>
     link: null
     owner:
       name: ''
@@ -2232,7 +2375,7 @@ events:
     end: '04:00'
     location: Servicehus
     responsible: Calle o Tilde
-    description: null
+    description: Ungdomar bakar när vuxna sover...
     link: null
     owner:
       name: ''
@@ -2246,8 +2389,8 @@ events:
     start: '14:30'
     end: '17:30'
     location: GA Stilla hyllan
-    responsible: 'Tilde, Mida'
-    description: null
+    responsible: Tilde, Mida
+    description: "<p>Sista Artstudion för I år</p>\n<p>från ca 14.30 till ca 17.30</p>\n<p>Man kan komma och gå lite fritt,</p>\n<p>Är man 12 år eller yngre så behöver man vuxet sällskap.\_</p>\n<p>Lite material av olika sorter finns men man kan gärna ta med sig eget också :]</p>\n<p>Vuxna varmt välkomna att delta (både med och utan barn)</p>"
     link: null
     owner:
       name: ''
@@ -2262,7 +2405,7 @@ events:
     end: '16:20'
     location: Kaffetält
     responsible: Malin och Gabriel Isenfors
-    description: null
+    description: "<p>IB - International Baccalaureate</p>\n<p>Kort information om denna lite ovanliga gymnasielinje. Anses av många vara bra för SB, speciellt de som är högpresterande. Linnen är 100% på engelska. Är det någon som vill veta mer, kanske inför gymnasievalet?\_</p>"
     link: null
     owner:
       name: ''
@@ -2277,7 +2420,10 @@ events:
     end: '16:00'
     location: Servicehus
     responsible: Peter Jonsson
-    description: null
+    description: |-
+      <p>Skrädmjölsvåfflor med grädde och sylt vid servicehuset.</p>
+      <p>Laktosfri mjölk och grädde används och våfflorna är glutensnåla för den som är bara lite känslig, men dessvärre inte helt glutenfritt.</p>
+      <p>Ta med bestick om du inte vill få kladdiga fingrar. Några papptallrikar finns, men de kan ta slut så ta gärna med egen för säkerhets skull.</p>
     link: null
     owner:
       name: ''


### PR DESCRIPTION
## Summary
- Populated `description` and `link` fields for 2022–2025 event YAML files using data exported from the legacy system
- 751 descriptions and 205 links added across 768 events, matched on title+date+start
- 9 CSV events with invalid dates or test data were excluded

## Test plan
- [x] YAML files parse correctly after migration
- [x] Event counts verified against CSV source data
- [x] Lint, tests, and validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)