### PR TITLE
ci: add manual trigger to Deploy to QA

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,6 +1,7 @@
 name: Deploy to QA
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to deploy-qa.yml
- Allows manual QA deploys when data-only changes skip the automatic path

## Test plan
- [x] Workflow syntax is valid
- [ ] After merge, verify `gh workflow run "Deploy to QA"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)