### PR TITLE
fix: handle first deploy when public_html missing

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -85,7 +85,9 @@ jobs:
             fi
 
             # Swap (millisecond downtime)
-            mv "$PUBLIC_DIR" "$DEPLOY_DIR/public_html_old"
+            if [ -d "$PUBLIC_DIR" ]; then
+              mv "$PUBLIC_DIR" "$DEPLOY_DIR/public_html_old"
+            fi
             mv "$RELEASE_DIR" "$PUBLIC_DIR"
 
             # Cleanup


### PR DESCRIPTION
## Summary
- The zero-downtime swap in `deploy-reusable.yml` assumed `public_html` already existed
- On first deploy, `mv public_html public_html_old` fails with exit code 1
- Wraps the mv in an `if [ -d ]` check so first deploy works

## Test plan
- [x] Confirmed failure in run #22550881227
- [ ] Re-run production deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)