### PR TITLE
test: enable QA camp for production API testing

### DIFF
--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -31,7 +31,7 @@ camps:
     information: ""
     file: qa-testcamp.yaml
     archived: false
-    qa: true
+    qa: false
   - id: 2025-08-syssleback
     name: SB sommar 2025 augusti
     start_date: '2025-08-03'


### PR DESCRIPTION
## Summary
- Temporarily sets `qa: false` on QA testcamp to test production API credentials
- **Revert immediately after testing**

## Test plan
- [ ] Deploy to production
- [ ] Test add-event via curl
- [ ] Revert this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)