### PR TITLE
fix: auto-remove old WordPress cookies on first visit

### DIFF
--- a/source/assets/js/client/wp-cleanup.js
+++ b/source/assets/js/client/wp-cleanup.js
@@ -1,0 +1,25 @@
+(function () {
+  'use strict';
+
+  var FLAG = 'sb_wp_cleanup_done';
+  try { if (localStorage.getItem(FLAG)) return; } catch { return; }
+
+  // Known WordPress / Blocksy / EME cookie prefixes left over from the
+  // previous site.  These can interfere with the new session cookie.
+  var prefixes = ['PHPSESSID', 'wordpress_', 'wp_', 'wp-', 'eme_', 'blocksy_'];
+
+  document.cookie.split(';').forEach(function (pair) {
+    var name = pair.trim().split('=')[0];
+    for (var i = 0; i < prefixes.length; i++) {
+      if (name === prefixes[i] || name.indexOf(prefixes[i]) === 0) {
+        // Delete by setting Max-Age=0 for common path/domain combos.
+        document.cookie = name + '=; Path=/; Max-Age=0';
+        document.cookie = name + '=; Path=/; Max-Age=0; Domain=' + location.hostname;
+        document.cookie = name + '=; Path=/; Max-Age=0; Domain=.' + location.hostname;
+        break;
+      }
+    }
+  });
+
+  try { localStorage.setItem(FLAG, '1'); } catch { /* ignore */ }
+})();

--- a/source/build/render-add.js
+++ b/source/build/render-add.js
@@ -114,6 +114,7 @@ ${locationOptions}
     </div>
   </div>
 
+  <script src="wp-cleanup.js"></script>
   <script src="cookie-consent.js"></script>
   <script src="markdown-toolbar.js"></script>
   <script defer src="marked.umd.js"></script>

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -129,6 +129,7 @@ ${pageNav('schema.html', navSections)}
   <p class="intro">Lägret blir vad vi gör det till tillsammans, alla aktiviteter är deltagararrangerade. Känner man att det är någon aktivitet som man vill arrangera och behöver material till den, det kan vara allt ifrån bakingredienser till microbitar att programmera, kort sagt vad behöver ni som aktivitetsarrangör för att kunna hålla eran aktivitet? Kolla under <a href="lagg-till.html">Lägg till aktivitet</a>.</p>${guideHtml}
 
 ${daySections}
+  <script src="wp-cleanup.js"></script>
   <script src="session.js"></script>
   <script src="nav.js" defer></script>
 ${pageFooter(footerHtml)}

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -71,6 +71,7 @@
     </div>
     </div>
   </details>
+  <script src="wp-cleanup.js"></script>
   <script src="session.js"></script>
   <script src="nav.js" defer></script>
 


### PR DESCRIPTION
## Summary
- Adds `wp-cleanup.js` that runs once on first visit
- Removes stale WordPress cookies (`PHPSESSID`, `wordpress_*`, `wp_*`, `eme_*`, `blocksy_*`)
- Sets a localStorage flag so it never runs again
- Loaded before `session.js` and `cookie-consent.js`

## Test plan
- [x] Set fake WordPress cookies in browser, visit site, verify they're removed
- [x] Verify `sb_session` cookie is set after adding an event
- [x] Verify cleanup only runs once (localStorage flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)