### PR TITLE
fix: server-side cleanup of HttpOnly WordPress cookies

### DIFF
--- a/source/assets/js/client/wp-cleanup.js
+++ b/source/assets/js/client/wp-cleanup.js
@@ -2,17 +2,17 @@
   'use strict';
 
   var FLAG = 'sb_wp_cleanup_done';
-  try { if (localStorage.getItem(FLAG)) return; } catch { return; }
+  try { if (localStorage.getItem(FLAG) === '2') return; } catch { return; }
 
   // Known WordPress / Blocksy / EME cookie prefixes left over from the
   // previous site.  These can interfere with the new session cookie.
   var prefixes = ['PHPSESSID', 'wordpress_', 'wp_', 'wp-', 'eme_', 'blocksy_'];
 
+  // Phase 1: delete non-HttpOnly cookies via JavaScript.
   document.cookie.split(';').forEach(function (pair) {
     var name = pair.trim().split('=')[0];
     for (var i = 0; i < prefixes.length; i++) {
       if (name === prefixes[i] || name.indexOf(prefixes[i]) === 0) {
-        // Delete by setting Max-Age=0 for common path/domain combos.
         document.cookie = name + '=; Path=/; Max-Age=0';
         document.cookie = name + '=; Path=/; Max-Age=0; Domain=' + location.hostname;
         document.cookie = name + '=; Path=/; Max-Age=0; Domain=.' + location.hostname;
@@ -21,5 +21,13 @@
     }
   });
 
-  try { localStorage.setItem(FLAG, '1'); } catch { /* ignore */ }
+  // Phase 2: ask the server to expire HttpOnly cookies that JS cannot touch.
+  fetch('/api/cleanup-cookies', { credentials: 'include' })
+    .then(function () {
+      try { localStorage.setItem(FLAG, '2'); } catch { /* ignore */ }
+    })
+    .catch(function () {
+      // Mark as done even on failure to avoid repeated requests.
+      try { localStorage.setItem(FLAG, '2'); } catch { /* ignore */ }
+    });
 })();


### PR DESCRIPTION
## Summary
- Adds `GET /api/cleanup-cookies` endpoint that expires HttpOnly WordPress cookies
- Updates `wp-cleanup.js` to call the server endpoint after JS cleanup
- Bumps localStorage flag to `2` so existing users get the server-side pass

## Test plan
- [ ] Set WordPress cookies in browser, visit site, verify all removed (including HttpOnly)
- [ ] Verify `sb_session` works after cleanup
- [ ] Verify cleanup only runs once

🤖 Generated with [Claude Code](https://claude.com/claude-code)