### PR TITLE
fix: QA version shows full semver from git tags

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -24,19 +24,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Compute QA version string
         id: version
         run: |
           BASE=$(cat VERSION | tr -d '[:space:]')
+          # Resolve latest tag for full semver (e.g. 1.0.0 instead of 1.0)
+          LATEST=$(git tag --list "v${BASE}.*" --sort=-version:refname | head -1)
+          if [ -n "$LATEST" ]; then
+            FULL_VER=$(echo "$LATEST" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          else
+            FULL_VER="${BASE}.0"
+          fi
           # Extract PR number from merge commit message (e.g. "Merge pull request #212 from ...")
           PR_NUM=$(git log -1 --pretty=format:"%s" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
           if [ -n "$PR_NUM" ]; then
-            VERSION_STR="${BASE} – QA PR${PR_NUM}"
+            VERSION_STR="${FULL_VER} – QA PR${PR_NUM}"
           else
             SHA=$(git rev-parse --short HEAD)
-            VERSION_STR="${BASE} – QA ${SHA}"
+            VERSION_STR="${FULL_VER} – QA ${SHA}"
           fi
           echo "version_string=${VERSION_STR}" >> $GITHUB_OUTPUT
           echo "QA version: ${VERSION_STR}"


### PR DESCRIPTION
## Summary

- QA footer version showed `v1.0 – QA 3d316a9` instead of `v1.0.0 – QA PR213`
- Root cause: QA workflow used VERSION file directly (`1.0`) without resolving git tags
- Fix: resolve latest tag for full semver (same logic as deploy-prod)
- Changed `fetch-depth: 2` to `fetch-depth: 0` to access tags

## Test plan

- [ ] Merge and verify QA deploy shows `v1.0.0 – QA PR{N}` in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)