### PR TITLE
Fix: pass GOATCOUNTER_SITE_CODE to deploy build

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -45,6 +45,7 @@ jobs:
           BUILD_ENV: ${{ inputs.build_env || inputs.environment }}
           COOKIE_DOMAIN: ${{ secrets.COOKIE_DOMAIN }}
           BUILD_VERSION: ${{ inputs.build_version }}
+          GOATCOUNTER_SITE_CODE: ${{ secrets.GOATCOUNTER_SITE_CODE }}
 
       - name: Package site for upload
         run: tar -czf site.tar.gz -C public .


### PR DESCRIPTION
## Summary
- The deploy workflow was missing `GOATCOUNTER_SITE_CODE` in the build step's env vars
- Without it, `npm run build` never sees the site code and omits the analytics script
- One-line fix in `deploy-reusable.yml`

## Test plan
- [ ] Merge, trigger QA deploy, verify GoatCounter script appears in HTML source
- [ ] Check `qa-sbsommar.goatcounter.com` dashboard for page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)