### PR TITLE
fix: use overflow-x clip to prevent mobile horizontal scroll

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -31,7 +31,10 @@
 
 *, *::before, *::after { box-sizing: border-box; }
 
-html { overflow-x: hidden; }
+html {
+  overflow-x: hidden;
+  overflow-x: clip;
+}
 
 body {
   font-family: var(--font-sans);


### PR DESCRIPTION
## Summary
- On Android Chrome, `overflow-x: hidden` on `<html>` does not reliably prevent horizontal scrolling caused by full-bleed pseudo-elements (`inset: 0 -9999px`)
- This made the page ~20 000 px wide on mobile, pushing the scroll-to-top button and footer off-screen and breaking `position: sticky` on the nav bar
- Changed to `overflow-x: clip` (with `hidden` as fallback) which clips content without creating a scroll container

## Test plan
- [ ] Open the site on Android Chrome — confirm no horizontal scroll
- [ ] Scroll down — confirm sticky nav stays visible
- [ ] Scroll 300 px+ — confirm scroll-to-top button appears in top-right corner
- [ ] Resize desktop browser to ≤767 px — confirm hamburger menu still works
- [ ] Verify full-bleed section backgrounds still stretch edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)