### PR TITLE
fix: limit full-bleed pseudo-elements on mobile

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2073,5 +2073,14 @@ body.modal-open {
     outline: 2px solid var(--color-white);
     outline-offset: 2px;
   }
+
+  /* On mobile the body is already viewport-wide; extend pseudo-elements
+     only past the body padding instead of 9999px to avoid horizontal
+     overflow that mobile browsers fail to clip. */
+  .page-nav::before,
+  .content section.section-alt::before,
+  .site-footer::before {
+    inset: 0 calc(-1 * var(--space-sm));
+  }
 }
 


### PR DESCRIPTION
## Summary
- Mobile browsers (Android Chrome) fail to clip `inset: 0 -9999px` pseudo-elements even with `overflow-x: clip` on `<html>`
- On mobile the body is already viewport-wide, so full-bleed backgrounds only need to extend past the body padding (`--space-sm` = 16px)
- Adds mobile media query that overrides `inset: 0 -9999px` → `inset: 0 calc(-1 * var(--space-sm))` for nav, section-alt, and footer pseudo-elements

## Test plan
- [ ] Open on Android Chrome — confirm no horizontal scroll
- [ ] Scroll down — confirm sticky nav stays visible
- [ ] Scroll 300 px+ — confirm scroll-to-top button in top-right
- [ ] Confirm full-bleed backgrounds (nav, alternating sections, footer) still stretch edge-to-edge
- [ ] Desktop: no visual change (media query only targets ≤767px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)