### PR TITLE
fix: direct backgrounds on mobile instead of full-bleed pseudo-elements

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -145,6 +145,7 @@ h3 {
 
 .hero-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-sm);
   margin-bottom: var(--space-sm);
@@ -2074,13 +2075,35 @@ body.modal-open {
     outline-offset: 2px;
   }
 
-  /* On mobile the body is already viewport-wide; extend pseudo-elements
-     only past the body padding instead of 9999px to avoid horizontal
-     overflow that mobile browsers fail to clip. */
+  /* On mobile the body is already viewport-wide, so the full-bleed
+     pseudo-elements (inset: 0 -9999px) are not needed. Hide them and
+     set the background directly on the elements instead. */
   .page-nav::before,
   .content section.section-alt::before,
   .site-footer::before {
-    inset: 0 calc(-1 * var(--space-sm));
+    display: none;
+  }
+
+  .page-nav {
+    background: var(--color-cream);
+    margin: 0 calc(-1 * var(--space-sm));
+    padding-left: var(--space-sm);
+    padding-right: var(--space-sm);
+  }
+
+  .content section.section-alt {
+    background: var(--color-cream-light);
+    margin-left: calc(-1 * var(--space-sm));
+    margin-right: calc(-1 * var(--space-sm));
+    padding-left: var(--space-sm);
+    padding-right: var(--space-sm);
+  }
+
+  .site-footer {
+    background: color-mix(in srgb, var(--color-sage) 15%, var(--color-cream));
+    margin: 0 calc(-1 * var(--space-sm));
+    padding-left: var(--space-sm);
+    padding-right: var(--space-sm);
   }
 }
 


### PR DESCRIPTION
## Summary
- Full-bleed pseudo-elements (`inset: 0 -9999px`) on nav, section-alt, and footer cause horizontal overflow on Android Chrome — the browser ignores `overflow-x: clip` on `<html>`
- On mobile, hide the pseudo-elements entirely and set backgrounds directly on the elements using negative margins (`calc(-1 * var(--space-sm))`) to span past the body padding
- Also adds `flex-wrap: wrap` to `.hero-header` to prevent the title + social icons from overflowing on narrow phones

## Test plan
- [x] Android Chrome: no horizontal scroll on index page
- [x] Sticky nav stays visible when scrolling
- [x] Scroll-to-top button appears after 300px scroll
- [x] Full-bleed backgrounds (nav, alternating sections, footer) stretch edge-to-edge
- [x] Desktop: no visual change (mobile-only media query)
- [x] Hero title + social icons wrap gracefully on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)