### PR TITLE
perf: compress testimonial and hero images

### DIFF
--- a/source/content/images/familjen-nilsson.webp
+++ b/source/content/images/familjen-nilsson.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0374bd6b9e071ebe4d49961829e4268958ae74bb91140381203b5c6c73c23b9
-size 22796
+oid sha256:db985de669134fe483e26f21692c8bfeed8ed5dbf3696ecf84ada6d9cacb7421
+size 2916

--- a/source/content/images/familjen-sommerfeld.webp
+++ b/source/content/images/familjen-sommerfeld.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:173c4d3e4c723e5c932250810e4d0378baaeb21a7b477f1b10a999cbcaf96ba4
-size 10448
+oid sha256:bc92721a3185449dcf4b0e5a96fd133c14053f1e4850041451a6c289efcdec9c
+size 3172

--- a/source/content/images/klaralven.webp
+++ b/source/content/images/klaralven.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8abfd11f6ee675c9ed6d15a74c0499597ccb0cb1a8cef2f7e5bbabd815de05a
-size 47752
+oid sha256:a3b59199e3d49dc1d45602eb54bed83fef882cc4e4858a132d56710c216311f6
+size 42532

--- a/source/content/images/malin-isenfors.webp
+++ b/source/content/images/malin-isenfors.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ae65f6f8c9ddcac906aa34b4d963ae081faca5bd2616cad17bd25bb75df7686
-size 10684
+oid sha256:7703a471a90d99afff11feabcad6e4e5ae8108de6a393056a8cdd8735015bcdb
+size 2628

--- a/source/content/images/marie-johansson.webp
+++ b/source/content/images/marie-johansson.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f49857d0dd0e836547b8ceafec16d9e44f069d35f8bbcb8496e775e98d45387
-size 8754
+oid sha256:7c7e11d9d5901a90046ae156e70686ca8454d2f4b9b1afa065915584895b37a0
+size 2116


### PR DESCRIPTION
## Summary
- Resize familjen-nilsson.webp to correct 120x120 dimensions
- Increase compression on all 4 testimonial portraits
- Compress hero image (klaralven.webp)
- Per PageSpeed Insights recommendations (~58 KB savings)

## Test plan
- [ ] Build passes
- [ ] Images render correctly on index page
- [ ] No visual degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)