### PR TITLE
style: change menu hover/active color from navy to sage-hover green

### DIFF
--- a/docs/07-DESIGN.md
+++ b/docs/07-DESIGN.md
@@ -109,13 +109,13 @@ Base unit: `8px`. Spacing values are multiples of this. <!-- 07-§4.4 -->
 - Background: white or cream, with a subtle bottom border or shadow. <!-- 07-§6.3 -->
 - Logo on the left. Navigation links on the right. <!-- 07-§6.4 -->
 - Nav links: uppercase, `12px`, `700` weight, spaced with `letter-spacing: 0.08em`. <!-- 07-§6.5 -->
-- Active/hover: navy (`var(--color-navy)`) color shift. <!-- 07-§6.6 -->
+- Active/hover: sage-hover green (`var(--color-sage-hover)`) color shift. <!-- 07-§6.6 -->
 - Mobile: hamburger button toggles a dropdown panel containing all links. <!-- 07-§6.7 -->
 - Desktop (≥ 768 px): hamburger hidden, all links visible in two rows. <!-- 07-§6.16-impl -->
 - Row 1: main page links (uppercase, `13px`, `700`, `letter-spacing: 0.06em`,
-  `color: var(--color-terracotta)`, navy on active/hover). <!-- 07-§6.17-impl -->
+  `color: var(--color-terracotta)`, sage-hover green on active/hover). <!-- 07-§6.17-impl -->
 - Row 2: section anchor links (no text-transform, `11px`, `700`,
-  `color: var(--color-terracotta)`, navy on hover). <!-- 07-§6.18-impl -->
+  `color: var(--color-terracotta)`, sage-hover green on hover). <!-- 07-§6.18-impl -->
 - Two rows separated by a `1px` rule in `rgba(0,0,0,0.06)`. <!-- 07-§6.19-impl -->
 - Mobile panel: `background: var(--color-terracotta)`, white text,
   `z-index: 100`. Fully rounded corners (`--radius-lg`), horizontal inset

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -480,7 +480,7 @@ details.day > summary::after {
 
 details.day[open] > summary::after { content: '−'; }
 
-details.day > summary:hover { background: #243d56; }
+details.day > summary:hover { background: var(--color-sage-hover); }
 
 details.day > summary:focus-visible {
   outline: 2px solid var(--color-terracotta);
@@ -736,7 +736,7 @@ details.event-row[open] > summary .ev-title {
 
 .nav-link:hover,
 .nav-link.active {
-  color: var(--color-navy);
+  color: var(--color-sage-hover);
 }
 
 .nav-link:focus-visible {
@@ -865,7 +865,7 @@ details.event-row[open] > summary .ev-title {
 }
 
 .nav-link--top:hover {
-  color: var(--color-navy);
+  color: var(--color-sage-hover);
 }
 
 .nav-link--top:focus-visible {


### PR DESCRIPTION
Replace navy (#192A3D) with --color-sage-hover (#9aad6a) for:
- Desktop nav-link hover and active states
- "Till toppen" link hover
- Day/summary row hover background

Updates 07-DESIGN.md to reflect the new hover color.

https://claude.ai/code/session_01MJusmhozR6S9fd91TwWDJv