### PR TITLE
fix: use escHtml consistently in confirmation modal

### DIFF
--- a/source/assets/js/client/lagg-till.js
+++ b/source/assets/js/client/lagg-till.js
@@ -621,11 +621,11 @@
     // Truncate long descriptions in the summary.
     var shortDesc = desc.length > 120 ? desc.slice(0, 120) + '…' : desc;
     var descRow = shortDesc
-      ? '<tr class="desc-row"><td>📝</td><td>' + shortDesc.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</td></tr>'
+      ? '<tr class="desc-row"><td>📝</td><td>' + escHtml(shortDesc) + '</td></tr>'
       : '';
     var linkVal = els.link.value.trim();
     var linkRow = linkVal
-      ? '<tr><td>🔗</td><td>' + linkVal.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</td></tr>'
+      ? '<tr><td>🔗</td><td>' + escHtml(linkVal) + '</td></tr>'
       : '';
 
     var summary =
@@ -633,9 +633,9 @@
       '<table class="confirm-summary">' +
         '<tr><td>📌</td><td><strong>' + escHtml(title) + '</strong></td></tr>' +
         (isBatch
-          ? '<tr><td>📅</td><td><strong>' + selectedDates.length + ' dagar:</strong> ' + dateList + '</td></tr>'
-          : '<tr><td>📅</td><td>' + dateList + '</td></tr>') +
-        '<tr><td>🕐</td><td>' + start + '–' + end + '</td></tr>' +
+          ? '<tr><td>📅</td><td><strong>' + selectedDates.length + ' dagar:</strong> ' + escHtml(dateList) + '</td></tr>'
+          : '<tr><td>📅</td><td>' + escHtml(dateList) + '</td></tr>') +
+        '<tr><td>🕐</td><td>' + escHtml(start) + '–' + escHtml(end) + '</td></tr>' +
         '<tr><td>📍</td><td>' + escHtml(location) + '</td></tr>' +
         '<tr><td>👤</td><td>' + escHtml(responsible) + '</td></tr>' +
         descRow +


### PR DESCRIPTION
## Summary
- Replace manual `.replace()` escaping with the existing `escHtml()` helper for all user-derived values in the confirmation modal (`dateList`, `start`, `end`, `shortDesc`, `linkVal`)
- Resolves CodeQL alert #39 (`js/xss-through-dom` — DOM text reinterpreted as HTML)

## Test plan
- [x] All existing tests pass
- [x] Lint passes
- [ ] Verify confirmation modal still renders correctly in browser
- [ ] Verify CodeQL alert #39 is resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)