### PR TITLE
fix: use error classifier in outer catch block

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -93,7 +93,7 @@ try {
     };
 } catch (\Throwable $e) {
     error_log('PHP API error: ' . $e->getMessage());
-    jsonResponse(['success' => false, 'error' => 'Internt serverfel.'], 500);
+    jsonResponse(['success' => false, 'error' => GitHub::classifyGitHubError($e)], 500);
 }
 
 // ── Route handlers ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The outer try/catch in `api/index.php` was still returning generic "Internt serverfel" instead of using `classifyGitHubError()`
- Now all error paths use the classifier, so the user always sees a specific message

## Test plan
- [ ] Deploy to QA and submit an activity — verify the error message is specific (not "Internt serverfel")

🤖 Generated with [Claude Code](https://claude.com/claude-code)