### PR TITLE
fix: add missing closing brace for GitHub class

### DIFF
--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -535,3 +535,4 @@ final class GitHub
 
         return 'Ett oväntat fel uppstod. Försök igen eller kontakta arrangören.';
     }
+}


### PR DESCRIPTION
ParseError on QA — classifyGitHubError was added without the closing class brace