### PR TITLE
fix: prevent server from caching sw.js

### DIFF
--- a/source/build/build.js
+++ b/source/build/build.js
@@ -417,6 +417,24 @@ async function main() {
   if (fs.existsSync(swSrc)) {
     fs.copyFileSync(swSrc, path.join(OUTPUT_DIR, 'sw.js'));
     console.log('Copied: source/static/sw.js → public/sw.js');
+
+    // Cache-bust sw.js registration so browsers fetch the latest version.
+    const swHash = crypto.createHash('md5')
+      .update(fs.readFileSync(path.join(OUTPUT_DIR, 'sw.js')))
+      .digest('hex')
+      .slice(0, 8);
+    const swRegPath = path.join(OUTPUT_DIR, 'sw-register.js');
+    if (fs.existsSync(swRegPath)) {
+      const swReg = fs.readFileSync(swRegPath, 'utf8');
+      const updated = swReg.replace(
+        "register('/sw.js')",
+        `register('/sw.js?v=${swHash}')`,
+      );
+      if (updated !== swReg) {
+        fs.writeFileSync(swRegPath, updated, 'utf8');
+        console.log(`Cache-bust: sw.js?v=${swHash}`);
+      }
+    }
   }
 
   // ── Post-process: CSS cache-busting (02-§69.1–69.3) ───────────────────

--- a/source/static/.htaccess
+++ b/source/static/.htaccess
@@ -15,6 +15,11 @@
     Header set Cache-Control "max-age=604800, public"
   </FilesMatch>
 
+  # Service worker — always revalidate (must come after the JS rule)
+  <FilesMatch "^sw\.js$">
+    Header set Cache-Control "no-cache"
+  </FilesMatch>
+
   # HTML — always revalidate
   <FilesMatch "\.html$">
     Header set Cache-Control "no-cache"


### PR DESCRIPTION
## Summary
- `.htaccess`: add `no-cache` rule specifically for `sw.js` (overrides the 7-day JS cache rule)
- `build.js`: cache-bust the `sw.js` registration URL with a content hash (`?v=<hash>`)

## Background
The `.htaccess` rule `<FilesMatch "\.(css|js)$">` set `max-age=604800` on all JS files including `sw.js`. This caused browsers to serve a stale service worker for up to 7 days, even after a new version was deployed.

## Test plan
- [ ] Build locally, verify `sw-register.js` contains `sw.js?v=<hash>`
- [ ] Deploy to qa, verify `sw.js` response header is `Cache-Control: no-cache`
- [ ] Verify service worker updates on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)