### PR TITLE
Update registration info and participant terms for 2026

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -94,6 +94,10 @@ The homepage must feel complete and trustworthy even when no camp is currently a
 When a camp is active or upcoming, the schedule and add-activity links are prominent. <!-- 02-§3.4 -->
 The upcoming-camps list renders each camp as a compact one-liner (icon, name, location, and dates on a single line) with no visual separators between items. <!-- 02-§3.5 -->
 
+The registration section must link to the external registration service at `event-friend-ai.lovable.app`, where families complete the full sign-up form. <!-- 02-§3.6 -->
+
+The pricing and rules sections must document the cancellation refund tiers and the organiser's right to refuse participation, matching the terms that bind participants at the point of registration. <!-- 02-§3.7 -->
+
 **Tone:** Warm, calm, and clear. Written in Swedish. Not corporate. Not promotional.
 The goal is that a parent visiting for the first time leaves thinking:
 *"I understand what this is. I know how it works. I feel comfortable taking the next step."*

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -126,8 +126,8 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 | `02-§3.3` | Homepage remains complete and usable even when no camp is active | 03-ARCHITECTURE.md §5 (Fallback rule) | COV-12..13 | `source/build/build.js` – falls back to most recent camp by `start_date` | covered |
 | `02-§3.4` | Schedule and add-activity links are prominent when a camp is active or upcoming | 03-ARCHITECTURE.md §3 | — | `source/build/layout.js` – nav always shows all links (not conditionally prominent based on camp state) | implemented |
 | `02-§3.5` | Upcoming-camps list renders each camp as a compact one-liner with no separators | 03-ARCHITECTURE.md §14.6 | CL-01, CL-02, CL-03 (CSS presence); manual: visual check | `source/assets/cs/style.css` – `.camp-item`, `.camp-body` flex layout | covered |
-| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | — | `source/content/registration.md` | gap |
-| `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | — | `source/content/pricing.md`, `source/content/rules.md` | gap |
+| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | REG-01 | `source/content/registration.md` | gap |
+| `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | REG-02..05 | `source/content/pricing.md`, `source/content/rules.md` | gap |
 | `02-§4.1` | Weekly schedule shows all activities for the full camp week, grouped by day | 03-ARCHITECTURE.md §5 | SNP-02, SNP-03 | `source/build/render.js` – `renderSchedulePage()`, `groupAndSortEvents()` | covered |
 | `02-§4.2` | Within each day, activities are listed in chronological order by start time | 03-ARCHITECTURE.md §5 | RND-28..32 | `source/build/render.js` – `groupAndSortEvents()` | covered |
 | `02-§4.3` | Each activity shows title, start time, end time, location, and responsible person | 05-DATA_CONTRACT.md §2, §3 | RND-39..45 | `source/build/render.js` – `renderEventRow()` | covered |
@@ -1506,6 +1506,8 @@ Matrix cleanup (2026-02-25):
 | DAC-01..07 | `tests/resolve-active-camp.test.js` | `resolveActiveCamp` |
 | LOC-01..10 | `tests/render-locations.test.js` | `renderLocationAccordions` |
 | COV-01..16 | `tests/coverage-index.test.js` | Homepage render tests (02-§2.1, 02-§3.1, CL-§3.1, CL-§3.3, 02-§2.9, 02-§14.1) |
+| REG-01 | `tests/registration-content.test.js` | Registration section links to external service (02-§3.6) |
+| REG-02..05 | `tests/registration-content.test.js` | Participation terms documented (02-§3.7) |
 | LAY-01..15 | `tests/coverage-layout.test.js` | Layout component tests (CL-§2.4, CL-§2.5, CL-§3.4, 02-§2.8, 02-§24.10) |
 | DIS-01..25 | `tests/coverage-today.test.js` | Display mode view tests (02-§2.4a, 02-§2.10, 02-§4.6, 02-§4.7, 02-§4.13, 02-§17.3) |
 | IDAG-01..18 | `tests/coverage-idag.test.js` | Today standard view tests (02-§2.4, 02-§4.5, 02-§4.13, 02-§14.1) |

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -126,8 +126,8 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 | `02-§3.3` | Homepage remains complete and usable even when no camp is active | 03-ARCHITECTURE.md §5 (Fallback rule) | COV-12..13 | `source/build/build.js` – falls back to most recent camp by `start_date` | covered |
 | `02-§3.4` | Schedule and add-activity links are prominent when a camp is active or upcoming | 03-ARCHITECTURE.md §3 | — | `source/build/layout.js` – nav always shows all links (not conditionally prominent based on camp state) | implemented |
 | `02-§3.5` | Upcoming-camps list renders each camp as a compact one-liner with no separators | 03-ARCHITECTURE.md §14.6 | CL-01, CL-02, CL-03 (CSS presence); manual: visual check | `source/assets/cs/style.css` – `.camp-item`, `.camp-body` flex layout | covered |
-| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | REG-01 | `source/content/registration.md` | gap |
-| `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | REG-02..05 | `source/content/pricing.md`, `source/content/rules.md` | gap |
+| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | REG-01 | `source/content/registration.md` | covered |
+| `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | REG-02..05 | `source/content/pricing.md`, `source/content/rules.md` | covered |
 | `02-§4.1` | Weekly schedule shows all activities for the full camp week, grouped by day | 03-ARCHITECTURE.md §5 | SNP-02, SNP-03 | `source/build/render.js` – `renderSchedulePage()`, `groupAndSortEvents()` | covered |
 | `02-§4.2` | Within each day, activities are listed in chronological order by start time | 03-ARCHITECTURE.md §5 | RND-28..32 | `source/build/render.js` – `groupAndSortEvents()` | covered |
 | `02-§4.3` | Each activity shows title, start time, end time, location, and responsible person | 05-DATA_CONTRACT.md §2, §3 | RND-39..45 | `source/build/render.js` – `renderEventRow()` | covered |
@@ -1103,9 +1103,9 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 
 ```text
 Total requirements:            1142
-Covered (implemented + tested): 583
+Covered (implemented + tested): 585
 Implemented, not tested:        557
-Gap (no implementation):          2
+Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -126,6 +126,8 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 | `02-§3.3` | Homepage remains complete and usable even when no camp is active | 03-ARCHITECTURE.md §5 (Fallback rule) | COV-12..13 | `source/build/build.js` – falls back to most recent camp by `start_date` | covered |
 | `02-§3.4` | Schedule and add-activity links are prominent when a camp is active or upcoming | 03-ARCHITECTURE.md §3 | — | `source/build/layout.js` – nav always shows all links (not conditionally prominent based on camp state) | implemented |
 | `02-§3.5` | Upcoming-camps list renders each camp as a compact one-liner with no separators | 03-ARCHITECTURE.md §14.6 | CL-01, CL-02, CL-03 (CSS presence); manual: visual check | `source/assets/cs/style.css` – `.camp-item`, `.camp-body` flex layout | covered |
+| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | — | `source/content/registration.md` | gap |
+| `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | — | `source/content/pricing.md`, `source/content/rules.md` | gap |
 | `02-§4.1` | Weekly schedule shows all activities for the full camp week, grouped by day | 03-ARCHITECTURE.md §5 | SNP-02, SNP-03 | `source/build/render.js` – `renderSchedulePage()`, `groupAndSortEvents()` | covered |
 | `02-§4.2` | Within each day, activities are listed in chronological order by start time | 03-ARCHITECTURE.md §5 | RND-28..32 | `source/build/render.js` – `groupAndSortEvents()` | covered |
 | `02-§4.3` | Each activity shows title, start time, end time, location, and responsible person | 05-DATA_CONTRACT.md §2, §3 | RND-39..45 | `source/build/render.js` – `renderEventRow()` | covered |
@@ -1100,10 +1102,10 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 ## Summary
 
 ```text
-Total requirements:            1140
+Total requirements:            1142
 Covered (implemented + tested): 583
 Implemented, not tested:        557
-Gap (no implementation):          0
+Gap (no implementation):          2
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).

--- a/source/content/pricing.md
+++ b/source/content/pricing.md
@@ -2,17 +2,23 @@
 
 ## Avgift för lägret
 
-Deltagaravgiften för 2025 är **400 kr per deltagare** för hela lägret. Definitionen av *deltagare* är alltså deltagande vuxna och barn, där de allra yngsta (ca 0-2 år) är undantagna. Man är deltagare oavsett man bor på lägerområdet eller inte.
+Deltagaravgiften för 2026 är **420 kr per deltagare** för hela lägret. Definitionen av *deltagare* är alltså deltagande vuxna och barn, där de allra yngsta (ca 0-2 år) är undantagna. Man är deltagare oavsett man bor på lägerområdet eller inte.
 
 ![Servicehus](images/servicehus.webp)
 
 ### Medlem RFSB
 
-Utöver deltagaravgiften så är det obligatoriskt med medlemskap i RFSB för deltagande på lägret. Kostnaden för medlemskap är **200 kr per vuxen** **(25+ år)** respektive **100 kr (18-25 år)** medan barn och ungdomar är medlemmar utan kostnad. Ni som redan är betalande medlemmar betalar naturligtvis inte för detta igen.
+Utöver deltagaravgiften så är det obligatoriskt med medlemskap i RFSB för deltagande på lägret. Kostnaden för medlemskap är **200 kr per vuxen** **(25+ år)** respektive **100 kr (18-25 år)** medan barn och ungdomar är medlemmar utan kostnad. Ni som redan är betalande medlemmar betalar naturligtvis inte för detta igen. Medlemskap tecknas på <https://rfsb.se>.
 
 ### Betalning
 
-Faktura skickas ut för lägeravgift och eventuellt nya medlemsavgifter. Kontrollera er epost inklusive skräppost (fakturan kommer från <mail@eaccounting.vismaonline.com>), och hör av er till <ekonomi@rfsb.se> om något skulle vara fel.
+Betalning av deltagaravgiften sker i samband med anmälan och kan göras på tre sätt:
+
+* **Kort**
+* **Swish**
+* **Faktura** – tillkommer 95 kr i fakturaavgift, betalas inom 10 dagar. Fakturaavgiften återbetalas inte vid avbokning.
+
+Vid frågor om betalning, kontakta <info@edq.se>. Avbokningsvillkor finns under [regler och villkor](#regler).
 
 ## Boende
 
@@ -22,7 +28,7 @@ Det finns lite olika boende-alternativ. Nedan listas de som är relaterade till 
 
 Lägerområdets tält- och husvagnsplatser har inte varit fulltecknade tidigare år.
 
-Lägerområdets centrala stug- och vandrarhemsplatser är få — de som anmäler sig på utsatt tid (se anmälan) och kommer vara med samtliga lägerdagar kan delta i fördelning av dessa. Besked om tilldelning av stuga/vandrarhemsplats på campingen skickas ut någon månad före lägret. Det går bra att avanmäla sig om man inte tilldelas boende. I sådana fall ordnar vi återbetalning av deltagaravgiften.
+Lägerområdets centrala stug- och vandrarhemsplatser är få — de som anmäler sig på utsatt tid (se anmälan) och kommer vara med samtliga lägerdagar kan delta i fördelning av dessa. Besked om tilldelning av stuga/vandrarhemsplats på campingen skickas ut någon månad före lägret. Det går bra att avanmäla sig om man inte tilldelas boende. I sådana fall ordnar vi återbetalning av hela deltagaravgiften, se även [avbokningsvillkoren](#regler).
 
 **Betalning sker direkt till campingen vid ankomst för de som har boende enligt nedan.**
 Extra dagar före/efter veckan kan bokas direkt med campingen efter att stuga/vandrarhem tilldelats. Detsamma gäller campingplats. Uppge alltid att du ska på sommarläger för att få lägerpris alla dygnen.

--- a/source/content/registration.md
+++ b/source/content/registration.md
@@ -1,18 +1,30 @@
 # Hur anmäler jag oss?
 
-> OBS! Anmälan för 2026 har inte öppnat ännu så ta det lugnt. Och ännu så har inget läger blivit fullt, men det kan ju ske någon gång i framtiden.
+Självklart är hela familjen välkommen. Alla räknas som deltagare. Barn i alla åldrar finns på lägret, från de minsta bebisar (oftast medföljande) till barn som vuxit upp och är 20 år.
 
-Självklart är hela familjen välkommen. Och alla räknas som deltagare. Barn i alla åldrar finns på lägret, från de minsta bebisar (oftast då medföljande) till barn som vuxit upp och är 20 år.
+Före anmälan, läs [regler och villkor](#regler).
 
-Före anmälan, läs [regler och villkor](#regler). För att delta i fördelning av boende, behövsa anmälan senast i regel på specifik datum i maj, detaljer om dag kommer när anmälan öppnas. För övriga så är sista dagen ungefär en vecka innan lägret börjar.
+**[Anmäl er här](https://event-friend-ai.lovable.app)**
 
-**Efterfrågad information vid anmälan för 2025**
+Anmälan sker på en separat sida som drivs av arrangören EDQ AB. Där fyller ni i anmälan steg för steg och väljer betalning i slutet. Vid frågor om anmälan, kontakta <info@edq.se>.
 
-* Godkänner att information lagras och används…
-* Vuxen 1 – Namn, personnummer, mailadress och mobilnummer.
-* Namn, personnummer, mailadress och mobilnummer för samtliga medföljande deltagare, vuxna som barn.
-  * Fyll i födelsedatum även för barnen, så kan vi ha åldersstatistik, det uppskattas av många.
-* RFSB lokalförening
-* Allergier, sjukdomar, etc.
-* Önskat boende
-* Medföljande husdjur
+## Viktiga datum
+
+* **Stugtilldelning:** för att delta i fördelning av stugor och vandrarhem på lägerområdet behöver anmälan vara inne senast 10 maj (juni-lägret) eller 30 juni (juli-lägret).
+* **Sista anmälningsdag:** 14 juni för juni-lägret, 12 juli för juli-lägret.
+
+## Vad efterfrågas vid anmälan?
+
+Formuläret leder er genom sju steg:
+
+1. **Kontaktuppgifter** – namn, e-post och telefon för den som anmäler, samt samtycke till integritetspolicyn.
+2. **Deltagare** – en eller flera personer med namn, födelsedatum (år/månad/dag), och valfria uppgifter om allergier, specialkost, sjukvårdsutbildning och medföljande husdjur.
+3. **Boende** – prioritetsordning mellan camping, stuga/vandrarhem på området, stuga utanför området (cirka 10 km), eller eget boende.
+4. **Medlemskap i RFSB** – medlemskap är ett krav för att delta. Ni kan slutföra anmälan innan medlemskap är tecknat, men det måste vara på plats före lägret. Tecknas på <https://rfsb.se>.
+5. **Övriga upplysningar** – valfritt fält för särskilda behov, frågor eller önskemål.
+6. **Sammanfattning** – kontroll av uppgifter och pris.
+7. **Betalning** – kort, Swish eller faktura.
+
+## Medlemskap i RFSB
+
+Deltagande på lägret kräver medlemskap i Riksförbundet för Särskild Begåvning. Medlemskap tecknas på <https://rfsb.se> och kan ordnas även efter anmälan — men senast före lägerstart. Alla anmälningar stäms av mot RFSB:s medlemslista innan lägret börjar.

--- a/source/content/rules.md
+++ b/source/content/rules.md
@@ -16,5 +16,12 @@
 
 * **Plats & betalning:** De som får plats betalar enligt de instruktioner som skickas ut. Anmälan garanterar inte plats förrän avgiften är erlagd.
 * **Föranmälan:** All närvaro måste föranmälas.
-* **Avstängning:** Vid allvarliga överträdelser kan familjer bli ombedda att lämna utan återbetalning.
+* **Rätten att neka:** Arrangören (EDQ AB) förbehåller sig rätten att neka deltagande för personer som arrangören bedömer som olämpliga att delta i lägret. Om en anmälan nekas återbetalas deltagaravgiften i sin helhet.
+* **Avbokning:** Återbetalning av deltagaravgiften sker enligt följande:
+  * Mer än 14 dagar före lägret: 100% återbetalning.
+  * 7–13 dagar före lägret: 50% återbetalning.
+  * Mindre än 7 dagar före lägret: ingen återbetalning.
+  * Vid medicinska eller andra särskilda skäl, kontakta <info@edq.se> och ange skäl för återbetalning.
+  * Eventuell fakturaavgift återbetalas inte.
+* **Avstängning under lägret:** Vid allvarliga överträdelser under pågående läger kan familjer bli ombedda att lämna utan återbetalning.
 * **Mat & boende:** Ingår inte i lägeravgiften – ordnas av varje familj själva.

--- a/tests/registration-content.test.js
+++ b/tests/registration-content.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const contentDir = path.join(__dirname, '..', 'source', 'content');
+const registrationMd = fs.readFileSync(path.join(contentDir, 'registration.md'), 'utf8');
+const pricingMd = fs.readFileSync(path.join(contentDir, 'pricing.md'), 'utf8');
+const rulesMd = fs.readFileSync(path.join(contentDir, 'rules.md'), 'utf8');
+
+// ── 02-§3.6  Registration section links to the external registration service ─
+
+describe('02-§3.6 — Registration section links to external service', () => {
+  it('REG-01: registration.md contains a link to event-friend-ai.lovable.app', () => {
+    assert.ok(
+      registrationMd.includes('event-friend-ai.lovable.app'),
+      'registration.md must link to the external registration service',
+    );
+  });
+});
+
+// ── 02-§3.7  Cancellation tiers and right to refuse documented ──────────────
+
+describe('02-§3.7 — Participation terms documented on the site', () => {
+  const combined = `${pricingMd}\n${rulesMd}`;
+
+  it('REG-02: 14-day refund tier (100%) is documented', () => {
+    assert.ok(
+      /14 dagar/i.test(combined) && /100\s*%/.test(combined),
+      'Site must document the >14-day full-refund tier',
+    );
+  });
+
+  it('REG-03: 7-day partial refund tier (50%) is documented', () => {
+    assert.ok(
+      /7[–-]13 dagar/i.test(combined) && /50\s*%/.test(combined),
+      'Site must document the 7–13-day 50%-refund tier',
+    );
+  });
+
+  it('REG-04: under-7-days no-refund tier is documented', () => {
+    assert.ok(
+      /7 dagar/i.test(combined) && /ingen återbetalning/i.test(combined),
+      'Site must document the <7-day no-refund tier',
+    );
+  });
+
+  it("REG-05: organiser's right to refuse is documented", () => {
+    assert.ok(
+      /neka|förbehåller sig rätten/i.test(combined),
+      "Site must document the organiser's right to refuse participation",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrite `registration.md` around the new external registration service at [event-friend-ai.lovable.app](https://event-friend-ai.lovable.app). Adds a clear CTA, per-camp deadlines (stugtilldelning 10 maj / 30 juni, anmälan 14 juni / 12 juli), and a 7-step field overview that matches the form. Removes the personnummer intake description (the new service only collects birth date).
- `pricing.md`: bump fee to **420 kr** for 2026, replace the old Visma/ekonomi@rfsb.se paragraph with the three new payment methods (kort, Swish, faktura with 95 kr fee + 10-day term), and link to rfsb.se for membership.
- `rules.md`: add the organiser's right to refuse (EDQ AB) and the full cancellation refund tiers (>14 d: 100%, 7–13 d: 50%, <7 d: 0%, fakturaavgift ej återbetalas). Clarifies that the existing *Avstängning* clause applies during the camp.
- New requirements `02-§3.6` and `02-§3.7` with `REG-01..05` tests in `tests/registration-content.test.js`. Traceability updated (gap → covered; total 1142, covered 585, gap 0).

`index.md` is deliberately left untouched — EDQ AB was already the arranger for 2025, so this is a quiet refresh, and the "helt ideellt" framing still applies (no salaries).

## Test plan

- [x] `node --test tests/registration-content.test.js` — all 5 REG tests pass
- [ ] CI: full test suite on Node 20 (local Node 18 hits a pre-existing `marked` ESM issue unrelated to this PR — same 43 failures on `main`)
- [ ] CI: `npm run lint:md`, `npm run build`
- [ ] Manual: open the homepage in a browser, confirm the *Anmälan* section shows the new text and the *Anmäl er här* link opens the registration service
- [ ] Manual: confirm *Kostnad* shows 420 kr and the three payment methods
- [ ] Manual: confirm *Regler* lists the new *Rätten att neka* and *Avbokning* clauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)