### PR TITLE
fix(ci): read SITE_URL from repo variable so Dependabot PRs can build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.changes.outputs.has_code == 'true'
         run: npm run build
         env:
-          SITE_URL: ${{ secrets.SITE_URL }}
+          SITE_URL: ${{ vars.SITE_URL }}
 
       - name: Validate HTML
         if: steps.changes.outputs.has_code == 'true'


### PR DESCRIPTION
## Summary

- Dependabot PRs cannot access repository secrets, so `secrets.SITE_URL` resolved to an empty string and the build step failed for every Dependabot PR (317, 318, 319).
- CI now reads `SITE_URL` from a repo-level variable (`vars.SITE_URL`), which is available to Dependabot and fork PRs.
- Deploy workflows (`deploy-reusable.yml`, `event-data-deploy-post-merge.yml`) continue to use `secrets.SITE_URL`, which is resolved per GitHub Environment — QA/production values remain independent.

The repo variable `SITE_URL=https://sbsommar.se` is configured in repo settings.

## Test plan

- [ ] CI runs on this PR and the Build step succeeds (confirms the variable resolves correctly).
- [ ] After merge, rebase PR 317 / 318 / 319 and confirm their CI turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)