### PR TITLE
chore(deps): bump brace-expansion for GHSA-f886-m6hf-6m8v

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,11 +695,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },


### PR DESCRIPTION
## Summary

- Addresses the moderate-severity *Zero-step sequence causes process hang and memory exhaustion* advisory ([GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v)) in `brace-expansion`.
- Produced by `npm audit fix`. Only `package-lock.json` changes (`5.0.4` → `5.0.5`).

## Test plan

- [ ] CI (Node 20) passes lint, tests, and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)