### PR TITLE
chore(deps-dev): bump markdownlint-cli to 0.48 for smol-toml advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "^10.0.2",
         "globals": "^17.3.0",
         "html-validate": "^10.9.0",
-        "markdownlint-cli": "^0.47.0",
+        "markdownlint-cli": "^0.48.0",
         "stylelint": "^17.4.0",
         "stylelint-config-standard": "^40.0.0"
       }
@@ -2444,23 +2444,22 @@
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.47.0.tgz",
-      "integrity": "sha512-HOcxeKFAdDoldvoYDofd85vI8LgNWy8vmYpCwnlLV46PJcodmGzD7COSSBlhHwsfT4o9KrAStGodImVBus31Bg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "commander": "~14.0.2",
+        "commander": "~14.0.3",
         "deep-extend": "~0.6.0",
         "ignore": "~7.0.5",
         "js-yaml": "~4.1.1",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.1.0",
+        "markdown-it": "~14.1.1",
         "markdownlint": "~0.40.0",
-        "minimatch": "~10.1.1",
+        "minimatch": "~10.2.4",
         "run-con": "~1.3.2",
-        "smol-toml": "~1.5.2",
+        "smol-toml": "~1.6.0",
         "tinyglobby": "~0.2.15"
       },
       "bin": {
@@ -4055,11 +4054,10 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^10.0.2",
     "globals": "^17.3.0",
     "html-validate": "^10.9.0",
-    "markdownlint-cli": "^0.47.0",
+    "markdownlint-cli": "^0.48.0",
     "stylelint": "^17.4.0",
     "stylelint-config-standard": "^40.0.0"
   },


### PR DESCRIPTION
## Summary

- Resolves the last outstanding `npm audit` advisory: [GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq) (moderate, transitive via `smol-toml` in `markdownlint-cli`).
- Upgrades `markdownlint-cli` from `^0.47.0` to `^0.48.0`.

### Compatibility notes

- `markdownlint-cli` 0.48 is ESM-only (breaking from 0.44); we consume it as a CLI only, so this is transparent.
- Requires Node >= 20 (Node 18 was dropped in 0.45). CI already pins Node 20.
- New default rules between 0.41 and 0.48: MD055, MD056, MD058, MD059, MD060. Existing rules MD005/007/013/024-026/038 were also updated. Any violations in current markdown content will surface in CI; address them if they appear.

## Test plan

- [ ] CI `Lint, Test & Build` is green on Node 20. If `lint:md` surfaces new violations, fix markdown content or adjust `.markdownlint.json` accordingly.
- [ ] `npm audit` on `main` reports 0 vulnerabilities after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)