### PR TITLE
feat: anmälan-banner och tydlig CTA-knapp

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4435,3 +4435,92 @@ reusable implementation per runtime.
   `X-Forwarded-For` spoof protection; trust boundaries are deferred to
   reverse-proxy configuration, consistent with the existing feedback
   handler. <!-- 02-§93.15 -->
+
+---
+
+## 94. Registration Banner and CTA Button
+
+### 94.1 Context
+
+The homepage must signal, at a glance, that registration is open for each
+upcoming camp. The "Hur anmäler jag oss?" section contains an inline bold
+markdown link that first-time visitors easily miss, and nothing else on the
+page communicates whether registration is currently open or when it closes.
+Two changes address this: a banner below the hero that announces the open
+registration window and links to the section, and a prominent CTA button
+inside the section itself that replaces the inline markdown link.
+
+### 94.2 User requirements
+
+- A prospective family visiting the homepage during an open registration
+  period for a camp sees a banner directly below the hero image announcing
+  that registration for that camp is open, together with the last
+  registration date. <!-- 02-§94.1 -->
+- Clicking the banner navigates to the `#anmalan` section on the same
+  page. <!-- 02-§94.2 -->
+- One banner is rendered per non-archived camp that has a registration
+  window, ordered by the camp's `start_date` ascending (closest camp
+  first). <!-- 02-§94.3 -->
+- The "Hur anmäler jag oss?" section contains a visually prominent
+  "Anmäl er här" button that opens the external registration service at
+  `event-friend-ai.lovable.app` in a new tab. <!-- 02-§94.4 -->
+- On desktop (≥ 720 px), the "Anmäl er här" button sits to the right of
+  the section column, and surrounding text flows around it. <!-- 02-§94.5 -->
+- On mobile (< 720 px), the "Anmäl er här" button spans the full column
+  width and is centred. <!-- 02-§94.6 -->
+- The registration section contains no inline bold markdown link labelled
+  "Anmäl er här"; the CTA button is the single call-to-action. <!-- 02-§94.7 -->
+
+### 94.3 Data requirements
+
+- Each non-archived camp in `camps.yaml` declares the fields
+  `registration_opens` and `registration_closes`, both as ISO dates
+  (`YYYY-MM-DD`, inclusive). <!-- 02-§94.8 -->
+- The data validator rejects a non-archived camp that is missing either
+  field, has a non-ISO date, has `registration_opens > registration_closes`,
+  or has `registration_closes >= start_date`. <!-- 02-§94.9 -->
+- Archived camps may omit the registration fields; the validator does not
+  require them. <!-- 02-§94.10 -->
+
+### 94.4 Banner visibility rules
+
+- Each banner is rendered in the static HTML at build time with the
+  `hidden` attribute and the data attributes `data-opens` and
+  `data-closes` carrying the camp's registration window. <!-- 02-§94.11 -->
+- A client-side script removes `hidden` only when the current
+  Europe/Stockholm date satisfies
+  `data-opens <= today <= data-closes`. <!-- 02-§94.12 -->
+- Outside the registration window the banner remains hidden; it does not
+  briefly flash visible, and its container reserves no visible space when
+  empty. <!-- 02-§94.13 -->
+- Banners are only rendered for non-archived camps. <!-- 02-§94.14 -->
+
+### 94.5 CTA button placement and behaviour
+
+- The CTA button is injected by the homepage renderer into the `anmalan`
+  section, not authored in the markdown source, following the same
+  injection pattern as `wrapTestimonialCards` in
+  `source/build/render-index.js`. <!-- 02-§94.15 -->
+- The button opens in a new browser tab with `target="_blank"` and
+  `rel="noopener noreferrer"`, consistent with other external links on
+  the site. <!-- 02-§94.16 -->
+- The button reuses the existing `.btn-primary` class from
+  `source/assets/cs/style.css`; no new colour, typography, or spacing
+  tokens are introduced. <!-- 02-§94.17 -->
+
+### 94.6 Analytics
+
+- Each banner carries
+  `data-goatcounter-click="click-register-banner-<camp-id>"`, where
+  `<camp-id>` is the camp's `id` from `camps.yaml`. <!-- 02-§94.18 -->
+- The CTA button carries
+  `data-goatcounter-click="click-register-section"`. <!-- 02-§94.19 -->
+
+### 94.7 Constraints
+
+- All user-facing text is in Swedish. <!-- 02-§94.20 -->
+- CSS uses existing design tokens from `07-DESIGN.md §7`; no hardcoded
+  colours, spacing, or typography. <!-- 02-§94.21 -->
+- No new JavaScript files are added; the visibility script is inline in
+  the generated `index.html`, consistent with §71.11. <!-- 02-§94.22 -->
+- No new npm or Composer dependencies. <!-- 02-§94.23 -->

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -2223,6 +2223,125 @@ status `429` and no `valid` key.
 
 ---
 
+## 32. Registration Banner and CTA Button
+
+### 32.1 Overview
+
+Two coordinated UI elements make registration status and the entry point
+visible on the homepage:
+
+1. **Hero banners** — one per non-archived camp, rendered directly below
+   the hero image, each announcing that registration is open for that
+   specific camp and linking to the `#anmalan` section.
+2. **CTA button in the `anmalan` section** — a prominent `.btn-primary`
+   "Anmäl er här" call-to-action injected by the renderer, replacing the
+   inline bold markdown link in `source/content/registration.md`.
+
+Both elements share the "render always, hide via client-side JS when the
+relevant date window is inactive" pattern already used for hero action
+buttons (§15, §71) and hero countdown (§15.3). Nothing is ever
+server-rendered based on the current date, so the static HTML remains
+cache-friendly.
+
+### 32.2 Data source
+
+`source/data/camps.yaml` carries two new date fields per camp —
+`registration_opens` and `registration_closes`, inclusive — described in
+`05-DATA_CONTRACT.md §1.7`. `source/scripts/validate-camps.js` rejects
+non-archived camps with missing, malformed, or out-of-order values, and
+treats the fields as optional for archived camps.
+
+### 32.3 Build-time rendering
+
+`source/build/render-index.js`:
+
+- `renderIndexPage(...)` accepts a new parameter `registrationCamps`: an
+  array of `{ id, name, registrationOpens, registrationCloses,
+  lastRegistrationLabel }` objects. The array is already sorted ascending
+  by `start_date` by the caller.
+- Directly after the hero `<img>` (before the existing `hero-actions`
+  block), a `<div class="hero-registration-banners">` wraps one
+  `<a class="hero-registration-banner" hidden data-opens="..."
+  data-closes="..." href="#anmalan" data-goatcounter-click="click-register-banner-<id>">`
+  per camp. Each banner contains a title span and a meta span with the
+  last-registration date.
+- The `anmalan` section is post-processed (same pattern as
+  `wrapTestimonialCards`): the renderer wraps the section body in a flex
+  container and prepends a `.registration-cta` element holding a
+  `.btn-primary` with `href` to the external registration URL,
+  `target="_blank"`, `rel="noopener noreferrer"`, and
+  `data-goatcounter-click="click-register-section"`. The markdown source
+  no longer contains the inline bold link.
+- The external registration URL lives as a module-level constant in
+  `render-index.js` so a future move to a YAML-driven URL is a small
+  refactor, not a schema change.
+
+`source/build/build.js` computes `registrationCamps` by filtering
+`camps.yaml` to entries where `archived !== true`, reading the two new
+fields, and sorting ascending by `start_date`. Entries missing the fields
+(already validated away in non-archived camps) are dropped defensively.
+
+### 32.4 Client-side visibility
+
+The inline `<script>` at the end of `index.html` that currently toggles
+`.hero-actions` based on `data-opens`/`data-closes` is generalised to
+also toggle every `.hero-registration-banner[data-opens]`. The script
+uses the same Europe/Stockholm-anchored "today" string comparison as
+§71.5 — no timezone library, no `Date` arithmetic.
+
+Outside the registration window, each banner keeps its `hidden`
+attribute and the container `.hero-registration-banners` collapses to
+zero visible height because the banners stack vertically with no
+surrounding padding of their own.
+
+### 32.5 Styling
+
+`source/assets/cs/style.css` gains:
+
+- `.hero-registration-banners` — vertical flex column, `gap:
+  var(--space-sm)`, centred within the hero container, hidden from
+  layout when all children are `[hidden]` (achieved by letting each
+  banner own its own vertical spacing).
+- `.hero-registration-banner` — full-width card with cream background
+  (`--color-cream-light`), terracotta left-border accent, `padding:
+  var(--space-sm) var(--space-md)`, `border-radius: var(--radius-md)`.
+- `.hero-registration-banner-title` — bold, terracotta text, slightly
+  larger than body.
+- `.hero-registration-banner-meta` — smaller, charcoal text on a new
+  line.
+- `.registration-cta` — wrapper: desktop floats the CTA right of the
+  text flow (`float: right; margin: 0 0 var(--space-sm) var(--space-md)`),
+  mobile (< 720 px) sets `float: none`, full width, centred.
+- `.registration-cta-btn` — a modifier on `.btn-primary` that only
+  widens the button on mobile.
+
+All values come from existing tokens in `07-DESIGN.md §7`.
+
+### 32.6 Accessibility
+
+- Banners are `<a>` elements so they are reachable via the tab sequence
+  and clickable as a single target.
+- Title and meta spans are inside the anchor; screen readers read the
+  concatenated text.
+- The CTA button inherits `.btn-primary`'s `:focus-visible` rule from
+  `07-§9.2`.
+- Color contrast of cream background + terracotta title meets WCAG AA,
+  verified against the existing testimonial-card pattern that uses the
+  same palette.
+
+### 32.7 Files changed
+
+| File                                  | Change                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `source/data/camps.yaml`              | Add `registration_opens` + `registration_closes` to non-archived camps   |
+| `source/scripts/validate-camps.js`    | Validate new fields (presence, ISO format, ordering, before `start_date`) |
+| `source/build/build.js`               | Compute `registrationCamps` array, pass to `renderIndexPage`             |
+| `source/build/render-index.js`        | Render banner block; inject `.registration-cta` into `anmalan` section   |
+| `source/content/registration.md`      | Remove the inline `**[Anmäl er här](...)**` line                         |
+| `source/assets/cs/style.css`          | New classes for banner and CTA wrapper                                   |
+
+---
+
 ## 10. Decided Against
 
 Decisions evaluated and deliberately rejected. Kept here so they are not re-proposed.

--- a/docs/05-DATA_CONTRACT.md
+++ b/docs/05-DATA_CONTRACT.md
@@ -18,6 +18,8 @@ camps:
     start_date: YYYY-MM-DD
     end_date: YYYY-MM-DD
     opens_for_editing: YYYY-MM-DD  # first date participants can add/edit activities
+    registration_opens: YYYY-MM-DD  # first date the homepage registration banner is shown
+    registration_closes: YYYY-MM-DD # last date the banner is shown (inclusive)
     location: string     # place name displayed on the archive page
     file: string         # filename in source/data/ (e.g. 2026-06-syssleback.yaml)
     archived: boolean    # true once the camp has ended
@@ -26,11 +28,18 @@ camps:
     link: string | null          # optional URL (e.g. Facebook group) shown on archive page
 ```
 
-All fields except `information`, `link`, and `qa` are required for each entry. <!-- 05-§1.1 -->
+All fields except `information`, `link`, `qa`, `registration_opens`, and
+`registration_closes` are required for each entry. <!-- 05-§1.1 -->
 
 The `opens_for_editing` field defines the first date on which the add-activity and
 edit-activity forms are available. The submission period closes at the end of
 `end_date + 1 day`. Typical default: `start_date − 7 days`. <!-- 05-§1.6 -->
+
+The `registration_opens` and `registration_closes` fields define the inclusive
+date range during which the homepage displays a banner linking to the
+registration section for that camp. Both fields are required for non-archived
+camps and optional for archived camps (where they are ignored). The range must
+satisfy `registration_opens <= registration_closes < start_date`. <!-- 05-§1.7 -->
 
 Rules:
 

--- a/docs/05-DATA_CONTRACT.md
+++ b/docs/05-DATA_CONTRACT.md
@@ -28,8 +28,9 @@ camps:
     link: string | null          # optional URL (e.g. Facebook group) shown on archive page
 ```
 
-All fields except `information`, `link`, `qa`, `registration_opens`, and
-`registration_closes` are required for each entry. <!-- 05-§1.1 -->
+All fields except `information`, `link`, and `qa` are required for each
+entry. `registration_opens` and `registration_closes` are conditionally
+required — see §1.7. <!-- 05-§1.1 -->
 
 The `opens_for_editing` field defines the first date on which the add-activity and
 edit-activity forms are available. The submission period closes at the end of

--- a/docs/07-DESIGN.md
+++ b/docs/07-DESIGN.md
@@ -167,6 +167,49 @@ Base unit: `8px`. Spacing values are multiples of this. <!-- 07-§4.4 -->
   `data-opens` / `data-closes` attributes and toggles the `hidden`
   attribute. <!-- 07-§6.84 -->
 
+### Registration Banners
+
+- A vertical stack of banners appears directly below the hero image when
+  one or more non-archived camps have an active registration window. <!-- 07-§6.89 -->
+- One banner per camp, ordered by `start_date` ascending (closest camp
+  on top). <!-- 07-§6.90 -->
+- Each banner is a full-width `<a>` card with a terracotta left border
+  accent (`border-left: 4px solid var(--color-terracotta)`), background
+  `var(--color-cream-light)`, `border-radius: var(--radius-md)`,
+  `padding: var(--space-sm) var(--space-md)`. <!-- 07-§6.91 -->
+- Banner title: `700` weight, `color: var(--color-terracotta)`,
+  `font-size: var(--font-size-base)`. <!-- 07-§6.92 -->
+- Banner meta line: `font-size: var(--font-size-small)`,
+  `color: var(--color-charcoal)`, displayed on its own line beneath the
+  title. <!-- 07-§6.93 -->
+- Container (`.hero-registration-banners`): `display: flex;
+  flex-direction: column; gap: var(--space-sm)`, centred within the hero
+  container width. <!-- 07-§6.94 -->
+- Hover: background shifts to
+  `color-mix(in srgb, var(--color-terracotta) 6%, var(--color-cream-light))`,
+  `200ms ease`, no scale transform. <!-- 07-§6.95 -->
+- Focus-visible: standard outline
+  (`2px solid var(--color-terracotta); outline-offset: 2px`). <!-- 07-§6.96 -->
+- Visibility is controlled by the same inline client-side JS as Hero
+  Action Buttons: banners stay `hidden` outside the window defined by
+  `data-opens` / `data-closes`. <!-- 07-§6.97 -->
+
+### Registration CTA (in the anmälan section)
+
+- The "Hur anmäler jag oss?" section carries a single prominent "Anmäl
+  er här" call-to-action button injected by the build-time renderer, not
+  authored in markdown. <!-- 07-§6.98 -->
+- The button reuses `.btn-primary` styling (terracotta background, white
+  text). <!-- 07-§6.99 -->
+- Wrapper `.registration-cta` — desktop (≥ 720 px): `float: right;
+  margin: 0 0 var(--space-sm) var(--space-md)` so the following
+  paragraph text flows around the button. <!-- 07-§6.100 -->
+- Mobile (< 720 px): `float: none`, `display: block`, `width: 100%`,
+  `text-align: center`; the button sits on its own row centred in the
+  column. <!-- 07-§6.101 -->
+- The CTA opens the external registration service in a new tab
+  (`target="_blank"`, `rel="noopener noreferrer"`). <!-- 07-§6.102 -->
+
 ### Buttons
 
 - Min height: `40px`. <!-- 07-§6.12 -->

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -2096,3 +2096,37 @@ Matrix cleanup (2026-02-25):
 | `02-§93.13` | implemented | `package.json` unchanged by this feature |
 | `02-§93.14` | implemented | `api/composer.json` unchanged by this feature |
 | `02-§93.15` | implemented | Documented in 03-ARCHITECTURE.md §31.7; matches existing §73.14 trust model |
+
+### §94 — Registration Banner and CTA Button
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§94.1` | gap | Hero banner per non-archived camp announcing open registration + last date — pending implementation in `source/build/render-index.js` and `source/assets/cs/style.css` |
+| `02-§94.2` | gap | Banner `<a>` element has `href="#anmalan"` — pending render-index.js change |
+| `02-§94.3` | gap | `build.js` must sort `registrationCamps` ascending by `start_date` — pending |
+| `02-§94.4` | gap | CTA button injected into `anmalan` section with external registration URL — pending render-index.js change |
+| `02-§94.5` | gap | Desktop float-right styling for CTA — pending CSS |
+| `02-§94.6` | gap | Mobile full-width/centred styling for CTA — pending CSS + manual browser check |
+| `02-§94.7` | gap | Remove `**[Anmäl er här](...)**` line from `source/content/registration.md` — pending |
+| `02-§94.8` | gap | New `registration_opens` / `registration_closes` fields in `camps.yaml` — pending data edit |
+| `02-§94.9` | gap | Validator rejects invalid / missing / out-of-order values on non-archived camps — pending `source/scripts/validate-camps.js` change + VLD-REG-01..NN tests |
+| `02-§94.10` | gap | Validator treats fields as optional on archived camps — pending `validate-camps.js` change + VLD-REG test |
+| `02-§94.11` | gap | Build-time HTML emits banners with `hidden` + `data-opens` / `data-closes` — pending + REGB-01..NN tests |
+| `02-§94.12` | gap | Inline client script toggles `hidden` based on Europe/Stockholm `today` — pending render-index.js + manual browser check |
+| `02-§94.13` | gap | No flicker; no visible space when container is empty — pending CSS + manual browser check |
+| `02-§94.14` | gap | Only non-archived camps receive banners — pending `build.js` filter + REGB test |
+| `02-§94.15` | gap | CTA injected by renderer (not authored in markdown), mirroring `wrapTestimonialCards` — pending REGC-01..NN tests |
+| `02-§94.16` | gap | CTA has `target="_blank"` + `rel="noopener noreferrer"` — pending REGC test |
+| `02-§94.17` | gap | CTA uses existing `.btn-primary` class — pending REGC test |
+| `02-§94.18` | gap | Banner `data-goatcounter-click="click-register-banner-<camp-id>"` — pending REGB test |
+| `02-§94.19` | gap | CTA `data-goatcounter-click="click-register-section"` — pending REGC test |
+| `02-§94.20` | gap | All banner and CTA text in Swedish — pending REGB / REGC text assertions |
+| `02-§94.21` | gap | CSS uses only tokens from `07-DESIGN.md §7` — pending CSS + manual token audit |
+| `02-§94.22` | gap | No new JavaScript files; inline script in generated `index.html` — pending REGB / manual inspection of HTML output |
+| `02-§94.23` | gap | No new npm/Composer dependencies — pending manual review of `package.json` / `api/composer.json` |
+
+### §1 — Camp registry fields (camps.yaml)
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `05-§1.7` | gap | `registration_opens` + `registration_closes` required on non-archived camps; inclusive range < `start_date` — pending `validate-camps.js` change + VLD-REG tests |

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -1102,9 +1102,9 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 ## Summary
 
 ```text
-Total requirements:            1157
-Covered (implemented + tested): 590
-Implemented, not tested:        567
+Total requirements:            1181
+Covered (implemented + tested): 605
+Implemented, not tested:        576
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
@@ -2101,32 +2101,32 @@ Matrix cleanup (2026-02-25):
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§94.1` | gap | Hero banner per non-archived camp announcing open registration + last date — pending implementation in `source/build/render-index.js` and `source/assets/cs/style.css` |
-| `02-§94.2` | gap | Banner `<a>` element has `href="#anmalan"` — pending render-index.js change |
-| `02-§94.3` | gap | `build.js` must sort `registrationCamps` ascending by `start_date` — pending |
-| `02-§94.4` | gap | CTA button injected into `anmalan` section with external registration URL — pending render-index.js change |
-| `02-§94.5` | gap | Desktop float-right styling for CTA — pending CSS |
-| `02-§94.6` | gap | Mobile full-width/centred styling for CTA — pending CSS + manual browser check |
-| `02-§94.7` | gap | Remove `**[Anmäl er här](...)**` line from `source/content/registration.md` — pending |
-| `02-§94.8` | gap | New `registration_opens` / `registration_closes` fields in `camps.yaml` — pending data edit |
-| `02-§94.9` | gap | Validator rejects invalid / missing / out-of-order values on non-archived camps — pending `source/scripts/validate-camps.js` change + VLD-REG-01..NN tests |
-| `02-§94.10` | gap | Validator treats fields as optional on archived camps — pending `validate-camps.js` change + VLD-REG test |
-| `02-§94.11` | gap | Build-time HTML emits banners with `hidden` + `data-opens` / `data-closes` — pending + REGB-01..NN tests |
-| `02-§94.12` | gap | Inline client script toggles `hidden` based on Europe/Stockholm `today` — pending render-index.js + manual browser check |
-| `02-§94.13` | gap | No flicker; no visible space when container is empty — pending CSS + manual browser check |
-| `02-§94.14` | gap | Only non-archived camps receive banners — pending `build.js` filter + REGB test |
-| `02-§94.15` | gap | CTA injected by renderer (not authored in markdown), mirroring `wrapTestimonialCards` — pending REGC-01..NN tests |
-| `02-§94.16` | gap | CTA has `target="_blank"` + `rel="noopener noreferrer"` — pending REGC test |
-| `02-§94.17` | gap | CTA uses existing `.btn-primary` class — pending REGC test |
-| `02-§94.18` | gap | Banner `data-goatcounter-click="click-register-banner-<camp-id>"` — pending REGB test |
-| `02-§94.19` | gap | CTA `data-goatcounter-click="click-register-section"` — pending REGC test |
-| `02-§94.20` | gap | All banner and CTA text in Swedish — pending REGB / REGC text assertions |
-| `02-§94.21` | gap | CSS uses only tokens from `07-DESIGN.md §7` — pending CSS + manual token audit |
-| `02-§94.22` | gap | No new JavaScript files; inline script in generated `index.html` — pending REGB / manual inspection of HTML output |
-| `02-§94.23` | gap | No new npm/Composer dependencies — pending manual review of `package.json` / `api/composer.json` |
+| `02-§94.1` | covered | REGB-08, REGB-10: `renderRegistrationBannersHtml` emits a banner per non-archived camp with title + meta; rendered inside hero area |
+| `02-§94.2` | covered | REGB-04: each banner's `<a>` carries `href="#anmalan"` |
+| `02-§94.3` | implemented | `source/build/build.js` sorts `registrationCamps` ascending by `start_date` before passing to `renderIndexPage`; verified in rendered HTML |
+| `02-§94.4` | covered | REGC-03, REGC-06: CTA `href` is `event-friend-ai.lovable.app`; label is "Anmäl er här" |
+| `02-§94.5` | implemented | `source/assets/cs/style.css` `.registration-cta { float: right; margin: 0 0 var(--space-sm) var(--space-md) }` — manual browser verification |
+| `02-§94.6` | implemented | `style.css` `@media (max-width: 719px) .registration-cta { float: none; width: 100%; text-align: center }` — manual browser verification |
+| `02-§94.7` | covered | REG-06: `source/content/registration.md` contains no bold `[Anmäl er här]` link |
+| `02-§94.8` | implemented | `source/data/camps.yaml` carries `registration_opens` / `registration_closes` for 2026-06, 2026-07, and qa-thisweek; validator enforces presence |
+| `02-§94.9` | covered | VCMP-38..43: `source/scripts/validate-camps.js` rejects missing / invalid / out-of-order values on non-archived camps |
+| `02-§94.10` | covered | VCMP-45: archived camp without the fields is accepted |
+| `02-§94.11` | covered | REGB-05, REGB-06: banners emit `hidden` + `data-opens` / `data-closes` |
+| `02-§94.12` | implemented | `render-index.js` inline script toggles `hidden` via Stockholm-anchored `today` string compare — REGB-11 verifies script presence; manual browser date-window check |
+| `02-§94.13` | implemented | `.hero-registration-banner[hidden] { display: none }` in `style.css`; banners start hidden in HTML so no flicker — manual browser verification |
+| `02-§94.14` | implemented | `build.js` filters `archived !== true` before building `registrationCamps`; archived camps never produce banners |
+| `02-§94.15` | covered | REGC-01: `.registration-cta` wrapper is injected into the `anmalan` section by `injectRegistrationCta()` (same post-process pattern as `wrapTestimonialCards`); not authored in markdown |
+| `02-§94.16` | covered | REGC-04: CTA anchor carries `target="_blank"` + `rel="noopener noreferrer"` |
+| `02-§94.17` | covered | REGC-02: CTA anchor has the `btn-primary` class |
+| `02-§94.18` | covered | REGB-07: each banner carries `data-goatcounter-click="click-register-banner-<camp.id>"` |
+| `02-§94.19` | covered | REGC-05: CTA carries `data-goatcounter-click="click-register-section"` |
+| `02-§94.20` | covered | REGB-08 asserts "Anmälan"/"öppen"; REGB-09 asserts "Sista anmälningsdag"; REGC-06 asserts "Anmäl er här" |
+| `02-§94.21` | implemented | `style.css` new rules use only `--color-*`, `--space-*`, `--radius-*`, `--font-size-*` tokens from `07-DESIGN.md §7` |
+| `02-§94.22` | covered | REGB-11 / REGB-12: inline banner visibility script is emitted only when banners are present; no new JS files |
+| `02-§94.23` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
 
 ### §1 — Camp registry fields (camps.yaml)
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `05-§1.7` | gap | `registration_opens` + `registration_closes` required on non-archived camps; inclusive range < `start_date` — pending `validate-camps.js` change + VLD-REG tests |
+| `05-§1.7` | covered | VCMP-37..45: validator enforces ISO format, ordering (`registration_opens <= registration_closes`), and `registration_closes < start_date` on non-archived camps; archived camps may omit the fields |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -246,6 +246,82 @@ h3 {
   outline-offset: 2px;
 }
 
+/* ── Hero registration banners (02-§94, 07-§6.89–6.97) ── */
+
+.hero-registration-banners {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+  max-width: 750px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero-registration-banner {
+  display: block;
+  background: var(--color-cream-light);
+  border-left: 4px solid var(--color-terracotta);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  text-decoration: none;
+  color: var(--color-charcoal);
+  transition: background 200ms ease;
+}
+
+.hero-registration-banner[hidden] {
+  display: none;
+}
+
+.hero-registration-banner:hover {
+  background: color-mix(in srgb, var(--color-terracotta) 6%, var(--color-cream-light));
+}
+
+.hero-registration-banner:focus-visible {
+  outline: 2px solid var(--color-terracotta);
+  outline-offset: 2px;
+}
+
+.hero-registration-banner-title {
+  display: block;
+  font-weight: 700;
+  color: var(--color-terracotta);
+  font-size: var(--font-size-base);
+}
+
+.hero-registration-banner-meta {
+  display: block;
+  font-size: var(--font-size-small);
+  color: var(--color-charcoal);
+  margin-top: 2px;
+}
+
+/* ── Registration CTA in anmälan section (02-§94, 07-§6.98–6.102) ── */
+
+.registration-cta {
+  float: right;
+  margin: 0 0 var(--space-sm) var(--space-md);
+}
+
+.registration-cta-btn {
+  text-decoration: none;
+}
+
+@media (max-width: 719px) {
+  .registration-cta {
+    float: none;
+    display: block;
+    width: 100%;
+    text-align: center;
+    margin: 0 0 var(--space-sm) 0;
+  }
+
+  .registration-cta-btn {
+    display: inline-block;
+    min-width: 60%;
+  }
+}
+
 /* ── Camps row (camps list + countdown) ── */
 
 .camps-row {

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -10,7 +10,7 @@ const { renderAddPage } = require('./render-add');
 const { renderEditPage, editApiUrl } = require('./render-edit');
 const { renderTodayPage, renderRedirectPage } = require('./render-today');
 const { renderIdagPage } = require('./render-idag');
-const { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions } = require('./render-index');
+const { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, formatLongSvDate } = require('./render-index');
 const { renderArkivPage } = require('./render-arkiv');
 const { renderRssFeed } = require('./render-rss');
 const { renderEventPage } = require('./render-event');
@@ -360,8 +360,22 @@ async function main() {
     ? addOneDay(toDateString(activeCamp.end_date))
     : null;
 
+  // ── Registration banners (02-§94.1–94.14) ────────────────────────────────
+  // One banner per non-archived camp that has both registration window fields.
+  // build-time ordering is ascending by start_date (closest camp on top).
+  const registrationCamps = camps
+    .filter((c) => c.archived !== true && c.registration_opens && c.registration_closes)
+    .sort((a, b) => toDateString(a.start_date).localeCompare(toDateString(b.start_date)))
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      registrationOpens: toDateString(c.registration_opens),
+      registrationCloses: toDateString(c.registration_closes),
+      lastRegistrationLabel: formatLongSvDate(c.registration_closes),
+    }));
+
   const heroDims = heroSrc ? getImageDimensions(path.join(CONTENT_DIR, heroSrc)) : null;
-  const indexHtml = renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses }, footerWithVersion, navSections, GOATCOUNTER_CODE);
+  const indexHtml = renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerWithVersion, navSections, GOATCOUNTER_CODE);
   fs.writeFileSync(path.join(OUTPUT_DIR, 'index.html'), indexHtml, 'utf8');
   console.log(`Built: public/index.html  (${sections.length} sections)`);
 

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -142,8 +142,9 @@ function convertMarkdown(input, headingOffset = 0, collapsible = false, contentD
  * @param {string|null} opts.opensForEditing - YYYY-MM-DD first editing date
  * @param {string|null} opts.editingCloses  - YYYY-MM-DD last editing date (end_date + 1)
  * @param {Array<{id: string, navLabel: string, html: string}>} opts.sections
+ * @param {Array<{id: string, name: string, registrationOpens: string, registrationCloses: string}>} [opts.registrationCamps]
  */
-function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses }, footerHtml = '', navSections = [], goatcounterCode = '') {
+function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerHtml = '', navSections = [], goatcounterCode = '') {
   const countdownHtml = countdownTarget
     ? `<div class="hero-countdown" data-target="${countdownTarget}">\n        <span class="hero-countdown-number">00</span>\n        <span class="hero-countdown-label">Dagar kvar</span>\n      </div>`
     : '';
@@ -162,8 +163,10 @@ function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, fac
     ? `\n    <div class="hero-actions" hidden data-opens="${opensForEditing}" data-closes="${editingCloses}">\n      <a href="idag.html" class="hero-actions-btn">Idag</a>\n      <a href="schema.html" class="hero-actions-btn">Schema</a>\n      <a href="lagg-till.html" class="hero-actions-btn">Lägg till</a>\n    </div>`
     : '';
 
+  const registrationBannersHtml = renderRegistrationBannersHtml(registrationCamps);
+
   const heroHtml = heroSrc
-    ? `\n  <div class="hero">\n    <div class="hero-header">\n      <h1 class="hero-title">Sommarläger i Sysslebäck</h1>${socialLinks}\n    </div>\n    <img src="${heroSrc}" alt="${heroAlt || ''}" class="hero-img"${heroDimAttrs} fetchpriority="high">${actionButtonsHtml}\n  </div>`
+    ? `\n  <div class="hero">\n    <div class="hero-header">\n      <h1 class="hero-title">Sommarläger i Sysslebäck</h1>${socialLinks}\n    </div>\n    <img src="${heroSrc}" alt="${heroAlt || ''}" class="hero-img"${heroDimAttrs} fetchpriority="high">${actionButtonsHtml}${registrationBannersHtml}\n  </div>`
     : '';
 
   const contentSections = sections
@@ -189,6 +192,11 @@ function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, fac
       // Wrap testimonial cards for the röster section
       if (s.id === 'roster') {
         sectionHtml = wrapTestimonialCards(sectionHtml);
+      }
+
+      // Inject the registration CTA button into the anmälan section (02-§94.15)
+      if (s.id === 'anmalan') {
+        sectionHtml = injectRegistrationCta(sectionHtml);
       }
 
       const inner = sectionHtml
@@ -249,6 +257,19 @@ ${contentSections}
     var today = p.find(function (x) { return x.type === 'year'; }).value + '-' + p.find(function (x) { return x.type === 'month'; }).value + '-' + p.find(function (x) { return x.type === 'day'; }).value;
     if (today >= opens && today <= closes) el.removeAttribute('hidden');
   })();
+  </script>` : ''}${(registrationCamps && registrationCamps.length > 0) ? `
+  <script>
+  (function () {
+    var banners = document.querySelectorAll('.hero-registration-banner[data-opens]');
+    if (!banners.length) return;
+    var p = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Stockholm', year: 'numeric', month: '2-digit', day: '2-digit' }).formatToParts(new Date());
+    var today = p.find(function (x) { return x.type === 'year'; }).value + '-' + p.find(function (x) { return x.type === 'month'; }).value + '-' + p.find(function (x) { return x.type === 'day'; }).value;
+    banners.forEach(function (el) {
+      var opens = el.getAttribute('data-opens');
+      var closes = el.getAttribute('data-closes');
+      if (today >= opens && today <= closes) el.removeAttribute('hidden');
+    });
+  })();
   </script>` : ''}
   <script src="sw-register.js" defer></script>
   <script src="pwa-install.js" defer></script>
@@ -264,9 +285,19 @@ const MONTHS_SV_SHORT = [
   'jul', 'aug', 'sep', 'okt', 'nov', 'dec',
 ];
 
+const MONTHS_SV_LONG = [
+  'januari', 'februari', 'mars', 'april', 'maj', 'juni',
+  'juli', 'augusti', 'september', 'oktober', 'november', 'december',
+];
+
 function formatShortDate(dateStr) {
   const d = new Date(toDateString(dateStr) + 'T12:00:00');
   return `${d.getDate()} ${MONTHS_SV_SHORT[d.getMonth()]}`;
+}
+
+function formatLongSvDate(dateStr) {
+  const d = new Date(toDateString(dateStr) + 'T12:00:00');
+  return `${d.getDate()} ${MONTHS_SV_LONG[d.getMonth()]}`;
 }
 
 function formatCampDateRange(startStr, endStr) {
@@ -402,4 +433,51 @@ function wrapTestimonialCards(html) {
   }).join('\n');
 }
 
-module.exports = { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, wrapTestimonialCards };
+// ── Registration banner and CTA (02-§94) ────────────────────────────────────
+
+const REGISTRATION_URL = 'https://event-friend-ai.lovable.app';
+
+/**
+ * Renders the hero registration banners — one per camp with an active
+ * registration window. Returns an empty string when `registrationCamps` is
+ * absent or empty so no container is emitted.
+ *
+ * @param {Array<{id: string, name: string, registrationOpens: string, registrationCloses: string}>} registrationCamps
+ */
+function renderRegistrationBannersHtml(registrationCamps) {
+  if (!registrationCamps || registrationCamps.length === 0) return '';
+
+  const items = registrationCamps.map((c) => {
+    const lastLabel = escapeHtml(c.lastRegistrationLabel || formatLongSvDate(c.registrationCloses));
+    const id = escapeHtml(c.id);
+    const name = escapeHtml(c.name);
+    return `      <a href="#anmalan" class="hero-registration-banner" hidden data-opens="${c.registrationOpens}" data-closes="${c.registrationCloses}" data-goatcounter-click="click-register-banner-${id}">
+        <span class="hero-registration-banner-title">Anmälan till ${name} är öppen</span>
+        <span class="hero-registration-banner-meta">Sista anmälningsdag ${lastLabel}</span>
+      </a>`;
+  }).join('\n');
+
+  return `\n    <div class="hero-registration-banners">\n${items}\n    </div>`;
+}
+
+/**
+ * Injects the "Anmäl er här" CTA button into the `anmalan` section HTML.
+ * The CTA is inserted immediately after the first heading so that on desktop
+ * the `float: right` layout lets the following paragraph text flow around it.
+ * On mobile the CTA styling (07-§6.101) sets `float: none` and full width.
+ *
+ * @param {string} sectionHtml - rendered HTML of the anmälan section body
+ * @returns {string} the section HTML with the CTA injected
+ */
+function injectRegistrationCta(sectionHtml) {
+  const cta = `<div class="registration-cta">\n  <a href="${REGISTRATION_URL}" class="btn-primary registration-cta-btn" target="_blank" rel="noopener noreferrer" data-goatcounter-click="click-register-section">Anmäl er här</a>\n</div>`;
+
+  const headingMatch = sectionHtml.match(/<\/h[1-6]>\s*/);
+  if (!headingMatch) {
+    return cta + '\n' + sectionHtml;
+  }
+  const insertPoint = headingMatch.index + headingMatch[0].length;
+  return sectionHtml.slice(0, insertPoint) + cta + '\n' + sectionHtml.slice(insertPoint);
+}
+
+module.exports = { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, wrapTestimonialCards, renderRegistrationBannersHtml, injectRegistrationCta, formatLongSvDate, REGISTRATION_URL };

--- a/source/content/registration.md
+++ b/source/content/registration.md
@@ -4,8 +4,6 @@ Självklart är hela familjen välkommen. Alla räknas som deltagare. Barn i all
 
 Före anmälan, läs [regler och villkor](#regler).
 
-**[Anmäl er här](https://event-friend-ai.lovable.app)**
-
 Anmälan sker på en separat sida som drivs av arrangören EDQ AB. Där fyller ni i anmälan steg för steg och väljer betalning i slutet. Vid frågor om anmälan, kontakta <info@edq.se>.
 
 ## Viktiga datum

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -4,6 +4,8 @@ camps:
     start_date: '2026-07-26'
     end_date: '2026-08-02'
     opens_for_editing: '2026-07-18'
+    registration_opens: '2026-04-15'
+    registration_closes: '2026-07-12'
     location: Sysslebäck
     link: "https://www.facebook.com/groups/syssleback2026"
     information: |
@@ -15,6 +17,8 @@ camps:
     start_date: '2026-06-21'
     end_date: '2026-06-28'
     opens_for_editing: '2026-06-17'
+    registration_opens: '2026-04-15'
+    registration_closes: '2026-06-14'
     location: Sysslebäck
     link: "https://www.facebook.com/groups/syssleback2026"
     information: |
@@ -37,6 +41,8 @@ camps:
     start_date: '2026-03-10'
     end_date: '2026-03-17'
     opens_for_editing: '2026-03-02'
+    registration_opens: '2026-02-15'
+    registration_closes: '2026-03-01'
     location: Sysslebäck
     link: ""
     information: |

--- a/source/scripts/validate-camps.js
+++ b/source/scripts/validate-camps.js
@@ -46,8 +46,8 @@ function validateCamps(camps, files) {
       }
     }
 
-    // ── Date format (02-§37.2) ────────────────────────────────────────────
-    for (const dateField of ['start_date', 'end_date', 'opens_for_editing']) {
+    // ── Date format (02-§37.2, 02-§94.9) ──────────────────────────────────
+    for (const dateField of ['start_date', 'end_date', 'opens_for_editing', 'registration_opens', 'registration_closes']) {
       const val = camp[dateField];
       if (val !== undefined && val !== null && val !== '') {
         const str = String(val);
@@ -62,6 +62,28 @@ function validateCamps(camps, files) {
     const endStr = String(camp.end_date || '');
     if (DATE_RE.test(startStr) && DATE_RE.test(endStr) && endStr < startStr) {
       errors.push(`${ref}: end_date (${endStr}) must be on or after start_date (${startStr})`);
+    }
+
+    // ── Registration window (02-§94.8, §94.9, §94.10; 05-§1.7) ────────────
+    const isArchived = camp.archived === true;
+    const regOpens = String(camp.registration_opens || '');
+    const regCloses = String(camp.registration_closes || '');
+
+    if (!isArchived) {
+      if (!regOpens) {
+        errors.push(`${ref}: registration_opens is required for non-archived camps`);
+      }
+      if (!regCloses) {
+        errors.push(`${ref}: registration_closes is required for non-archived camps`);
+      }
+    }
+
+    if (DATE_RE.test(regOpens) && DATE_RE.test(regCloses) && regOpens > regCloses) {
+      errors.push(`${ref}: registration_opens (${regOpens}) must be on or before registration_closes (${regCloses})`);
+    }
+
+    if (DATE_RE.test(regCloses) && DATE_RE.test(startStr) && regCloses >= startStr) {
+      errors.push(`${ref}: registration_closes (${regCloses}) must be before start_date (${startStr})`);
     }
 
     // ── archived is boolean (02-§37.4) ────────────────────────────────────

--- a/tests/registration-banner.test.js
+++ b/tests/registration-banner.test.js
@@ -1,0 +1,256 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { renderIndexPage } = require('../source/build/render-index');
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildPage(overrides = {}) {
+  return {
+    heroSrc: 'images/klaralven.webp',
+    heroAlt: 'Klarälven',
+    sections: [
+      { id: 'start', navLabel: 'Om lägret', html: '<p>Intro</p>' },
+      { id: 'anmalan', navLabel: 'Anmälan', html: '<h2>Hur anmäler jag oss?</h2>\n<p>Läs reglerna.</p>' },
+    ],
+    discordUrl: 'https://discord.com/t',
+    facebookUrl: 'https://fb.com/t',
+    countdownTarget: '2026-06-21',
+    registrationCamps: [],
+    ...overrides,
+  };
+}
+
+function makeRegCamp(overrides = {}) {
+  return {
+    id: '2026-06-syssleback',
+    name: 'SB sommar 2026 juni',
+    registrationOpens: '2026-04-15',
+    registrationCloses: '2026-06-14',
+    lastRegistrationLabel: '14 juni',
+    ...overrides,
+  };
+}
+
+// ── REGB: Hero registration banner rendering (02-§94.1–94.14, §94.18, §94.20) ─
+
+describe('renderIndexPage – registration banners (02-§94.1–94.14, §94.18, §94.20)', () => {
+  it('REGB-01: no banner container when registrationCamps is empty', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [] }));
+    assert.ok(
+      !html.includes('class="hero-registration-banners"'),
+      'Expected no banner container when no registration camps',
+    );
+  });
+
+  it('REGB-02: renders .hero-registration-banners container when camps present', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [makeRegCamp()] }));
+    assert.ok(
+      html.includes('class="hero-registration-banners"'),
+      'Expected .hero-registration-banners container',
+    );
+  });
+
+  it('REGB-03: renders one .hero-registration-banner per registrationCamp', () => {
+    const html = renderIndexPage(buildPage({
+      registrationCamps: [
+        makeRegCamp({ id: '2026-06-syssleback', name: 'SB juni' }),
+        makeRegCamp({ id: '2026-07-syssleback', name: 'SB juli', registrationOpens: '2026-05-01', registrationCloses: '2026-07-12', lastRegistrationLabel: '12 juli' }),
+      ],
+    }));
+    const banners = html.match(/class="hero-registration-banner"/g) || [];
+    assert.equal(banners.length, 2, `Expected 2 banners, got ${banners.length}`);
+  });
+
+  it('REGB-04: each banner links to #anmalan', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [makeRegCamp()] }));
+    assert.ok(
+      /<a[^>]*class="hero-registration-banner"[^>]*href="#anmalan"/.test(html) ||
+      /<a[^>]*href="#anmalan"[^>]*class="hero-registration-banner"/.test(html),
+      'Expected banner anchor with href="#anmalan"',
+    );
+  });
+
+  it('REGB-05: each banner starts hidden', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [makeRegCamp()] }));
+    const bannerMatch = html.match(/<a[^>]*class="hero-registration-banner"[^>]*>/);
+    assert.ok(bannerMatch, 'Expected banner anchor element');
+    assert.ok(
+      bannerMatch[0].includes('hidden'),
+      `Expected 'hidden' attribute on banner, got: ${bannerMatch[0]}`,
+    );
+  });
+
+  it('REGB-06: banner carries data-opens and data-closes matching the camp window', () => {
+    const html = renderIndexPage(buildPage({
+      registrationCamps: [makeRegCamp({ registrationOpens: '2026-04-15', registrationCloses: '2026-06-14' })],
+    }));
+    assert.ok(html.includes('data-opens="2026-04-15"'), 'Expected data-opens');
+    assert.ok(html.includes('data-closes="2026-06-14"'), 'Expected data-closes');
+  });
+
+  it('REGB-07: banner carries data-goatcounter-click with camp id', () => {
+    const html = renderIndexPage(buildPage({
+      registrationCamps: [makeRegCamp({ id: '2026-06-syssleback' })],
+    }));
+    assert.ok(
+      html.includes('data-goatcounter-click="click-register-banner-2026-06-syssleback"'),
+      'Expected per-camp goatcounter click attribute',
+    );
+  });
+
+  it('REGB-08: banner title mentions the camp name and registration being open', () => {
+    const html = renderIndexPage(buildPage({
+      registrationCamps: [makeRegCamp({ name: 'SB sommar 2026 juni' })],
+    }));
+    assert.ok(html.includes('SB sommar 2026 juni'), 'Expected camp name in banner');
+    assert.ok(/[Aa]nmälan/.test(html), 'Expected Swedish word "Anmälan" in banner');
+    assert.ok(/öppen/i.test(html), 'Expected Swedish word "öppen" in banner');
+  });
+
+  it('REGB-09: banner meta line shows the last registration date label', () => {
+    const html = renderIndexPage(buildPage({
+      registrationCamps: [makeRegCamp({ lastRegistrationLabel: '14 juni' })],
+    }));
+    assert.ok(html.includes('14 juni'), 'Expected last-registration date in banner meta');
+    assert.ok(
+      /[Ss]ista anm/.test(html),
+      'Expected Swedish "Sista anmälningsdag" (or similar) prefix',
+    );
+  });
+
+  it('REGB-10: banners are rendered inside the hero area (before <main>\'s content div)', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [makeRegCamp()] }));
+    const heroEnd = html.indexOf('<div class="content">');
+    const bannerStart = html.indexOf('hero-registration-banners');
+    assert.ok(bannerStart !== -1, 'Expected banners in output');
+    assert.ok(heroEnd !== -1, 'Expected content div in output');
+    assert.ok(
+      bannerStart < heroEnd,
+      'Banners must appear before the main content section',
+    );
+  });
+
+  it('REGB-11: inline visibility script is emitted when banners are present', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [makeRegCamp()] }));
+    assert.ok(
+      html.includes('.hero-registration-banner[data-opens]'),
+      'Expected inline script to query banner elements',
+    );
+  });
+
+  it('REGB-12: no inline banner script when registrationCamps is empty', () => {
+    const html = renderIndexPage(buildPage({ registrationCamps: [] }));
+    assert.ok(
+      !html.includes('.hero-registration-banner[data-opens]'),
+      'Expected no banner script when no banners',
+    );
+  });
+});
+
+// ── REGC: Registration CTA injection (02-§94.4–94.7, §94.15–94.17, §94.19) ──
+
+describe('renderIndexPage – registration CTA in anmalan section (02-§94.4–94.7, §94.15–94.17, §94.19)', () => {
+  function pageWithAnmalan() {
+    return buildPage({
+      sections: [
+        { id: 'start', navLabel: 'Om lägret', html: '<p>Intro</p>' },
+        { id: 'anmalan', navLabel: 'Anmälan', html: '<h2>Hur anmäler jag oss?</h2>\n<p>Läs reglerna.</p>' },
+      ],
+    });
+  }
+
+  it('REGC-01: anmalan section contains a .registration-cta wrapper', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    assert.ok(anmalanMatch, 'Expected anmalan section in output');
+    assert.ok(
+      anmalanMatch[0].includes('class="registration-cta"'),
+      'Expected .registration-cta wrapper inside anmalan section',
+    );
+  });
+
+  it('REGC-02: CTA button uses .btn-primary class', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    assert.ok(
+      /class="[^"]*btn-primary[^"]*"/.test(anmalanMatch[0]),
+      'Expected .btn-primary CTA inside anmalan section',
+    );
+  });
+
+  it('REGC-03: CTA href points to event-friend-ai.lovable.app', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    assert.ok(
+      /href="https:\/\/event-friend-ai\.lovable\.app"/.test(anmalanMatch[0]),
+      'Expected external registration URL in CTA href',
+    );
+  });
+
+  it('REGC-04: CTA opens in a new tab with rel="noopener noreferrer"', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    const ctaMatch = anmalanMatch[0].match(/<a[^>]*btn-primary[^>]*>/);
+    assert.ok(ctaMatch, 'Expected CTA anchor');
+    assert.ok(ctaMatch[0].includes('target="_blank"'), `Expected target="_blank", got: ${ctaMatch[0]}`);
+    assert.ok(ctaMatch[0].includes('rel="noopener noreferrer"'), `Expected rel="noopener noreferrer", got: ${ctaMatch[0]}`);
+  });
+
+  it('REGC-05: CTA carries data-goatcounter-click="click-register-section"', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    assert.ok(
+      anmalanMatch[0].includes('data-goatcounter-click="click-register-section"'),
+      'Expected CTA goatcounter attribute',
+    );
+  });
+
+  it('REGC-06: CTA label is "Anmäl er här"', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    const ctaMatch = anmalanMatch[0].match(/<a[^>]*btn-primary[^>]*>([^<]*)<\/a>/);
+    assert.ok(ctaMatch, 'Expected CTA anchor with inner text');
+    assert.equal(ctaMatch[1].trim(), 'Anmäl er här', `Expected "Anmäl er här", got: "${ctaMatch[1]}"`);
+  });
+
+  it('REGC-07: other sections do not carry the CTA wrapper', () => {
+    const html = renderIndexPage(pageWithAnmalan());
+    const startMatch = html.match(/<section id="start"[\s\S]*?<\/section>/);
+    assert.ok(startMatch, 'Expected start section');
+    assert.ok(
+      !startMatch[0].includes('registration-cta'),
+      'CTA wrapper must not appear in start section',
+    );
+  });
+
+  it('REGC-08: CTA is omitted when the page has no anmalan section', () => {
+    const html = renderIndexPage(buildPage({
+      sections: [{ id: 'start', navLabel: 'Om lägret', html: '<p>Intro</p>' }],
+    }));
+    assert.ok(
+      !html.includes('registration-cta'),
+      'CTA must not render when no anmalan section exists',
+    );
+  });
+});
+
+// ── REG-06: Markdown source no longer carries the bold inline link (02-§94.7) ─
+
+describe('registration.md — markdown source (02-§94.7)', () => {
+  const registrationMd = fs.readFileSync(
+    path.join(__dirname, '..', 'source', 'content', 'registration.md'),
+    'utf8',
+  );
+
+  it('REG-06: registration.md does not contain the bold inline "Anmäl er här" link', () => {
+    assert.ok(
+      !/\*\*\[Anmäl er här\]/.test(registrationMd),
+      'registration.md must not contain the bold markdown link; the CTA is injected by the renderer',
+    );
+  });
+});

--- a/tests/registration-content.test.js
+++ b/tests/registration-content.test.js
@@ -5,18 +5,30 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
+const { renderIndexPage } = require('../source/build/render-index');
+
 const contentDir = path.join(__dirname, '..', 'source', 'content');
-const registrationMd = fs.readFileSync(path.join(contentDir, 'registration.md'), 'utf8');
 const pricingMd = fs.readFileSync(path.join(contentDir, 'pricing.md'), 'utf8');
 const rulesMd = fs.readFileSync(path.join(contentDir, 'rules.md'), 'utf8');
 
 // ── 02-§3.6  Registration section links to the external registration service ─
 
 describe('02-§3.6 — Registration section links to external service', () => {
-  it('REG-01: registration.md contains a link to event-friend-ai.lovable.app', () => {
+  it('REG-01: rendered anmalan section links to event-friend-ai.lovable.app', () => {
+    const html = renderIndexPage({
+      heroSrc: 'images/k.webp',
+      heroAlt: '',
+      sections: [{ id: 'anmalan', navLabel: 'Anmälan', html: '<p>Text</p>' }],
+      discordUrl: null,
+      facebookUrl: null,
+      countdownTarget: null,
+      registrationCamps: [],
+    });
+    const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
+    assert.ok(anmalanMatch, 'Expected anmalan section in rendered output');
     assert.ok(
-      registrationMd.includes('event-friend-ai.lovable.app'),
-      'registration.md must link to the external registration service',
+      anmalanMatch[0].includes('event-friend-ai.lovable.app'),
+      'Rendered anmalan section must link to the external registration service',
     );
   });
 });

--- a/tests/validate-camps.test.js
+++ b/tests/validate-camps.test.js
@@ -15,6 +15,8 @@ function makeCamp(overrides = {}) {
     start_date: '2026-08-01',
     end_date: '2026-08-07',
     opens_for_editing: '2026-07-25',
+    registration_opens: '2026-05-01',
+    registration_closes: '2026-07-15',
     location: 'Testville',
     file: '2026-08-test.yaml',
     archived: false,
@@ -368,5 +370,92 @@ describe('validateCamps – edge cases', () => {
     assert.equal(result.ok, false);
     // Error should reference camp-b, not camp-a
     assert.ok(result.errors.some(e => e.includes('camp-b')));
+  });
+});
+
+// ── Registration window (02-§94.8, §94.9, §94.10; 05-§1.7) ──────────────────
+
+function makeRegCamp(overrides = {}) {
+  return makeCamp({
+    registration_opens: '2026-05-01',
+    registration_closes: '2026-07-15',
+    ...overrides,
+  });
+}
+
+describe('validateCamps – registration window fields (02-§94.8–94.10, 05-§1.7)', () => {
+  it('VCMP-37: non-archived camp accepts valid registration window', () => {
+    const result = run([makeRegCamp()]);
+    assert.equal(result.ok, true, `errors: ${result.errors.join('; ')}`);
+  });
+
+  it('VCMP-38: non-archived camp missing registration_opens fails', () => {
+    const camp = makeRegCamp();
+    delete camp.registration_opens;
+    const result = run([camp]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('registration_opens')),
+      `Expected error about registration_opens, got: ${result.errors.join('; ')}`);
+  });
+
+  it('VCMP-39: non-archived camp missing registration_closes fails', () => {
+    const camp = makeRegCamp();
+    delete camp.registration_closes;
+    const result = run([camp]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('registration_closes')),
+      `Expected error about registration_closes, got: ${result.errors.join('; ')}`);
+  });
+
+  it('VCMP-40: rejects invalid registration_opens date format', () => {
+    const result = run([makeRegCamp({ registration_opens: '2026/05/01' })]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('registration_opens')));
+  });
+
+  it('VCMP-41: rejects invalid registration_closes date format', () => {
+    const result = run([makeRegCamp({ registration_closes: 'July' })]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('registration_closes')));
+  });
+
+  it('VCMP-42: rejects registration_opens after registration_closes', () => {
+    const result = run([makeRegCamp({
+      registration_opens: '2026-06-20',
+      registration_closes: '2026-05-01',
+    })]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e =>
+      e.includes('registration_opens') || e.includes('registration_closes')
+    ));
+  });
+
+  it('VCMP-43: rejects registration_closes on or after start_date', () => {
+    const result = run([makeRegCamp({
+      start_date: '2026-08-01',
+      end_date: '2026-08-07',
+      registration_opens: '2026-05-01',
+      registration_closes: '2026-08-01',
+    })]);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e =>
+      e.includes('registration_closes') && e.includes('start_date')
+    ), `Expected error tying registration_closes to start_date, got: ${result.errors.join('; ')}`);
+  });
+
+  it('VCMP-44: accepts registration_opens equal to registration_closes', () => {
+    const result = run([makeRegCamp({
+      registration_opens: '2026-07-15',
+      registration_closes: '2026-07-15',
+    })]);
+    assert.equal(result.ok, true, `errors: ${result.errors.join('; ')}`);
+  });
+
+  it('VCMP-45: archived camp without registration fields is accepted', () => {
+    const camp = makeCamp({ archived: true });
+    delete camp.registration_opens;
+    delete camp.registration_closes;
+    const result = run([camp]);
+    assert.equal(result.ok, true, `errors: ${result.errors.join('; ')}`);
   });
 });


### PR DESCRIPTION
## Summary

- **Hero-banner per öppen anmälningsperiod.** Varje icke-arkiverat läger får en banner direkt under hero-bilden som säger "Anmälan till X är öppen" + "Sista anmälningsdag Y". Bannern länkar till #anmalan och döljs automatiskt utanför anmälningsfönstret via samma datumstyrda inline-script som hero-actions.
- **Tydlig "Anmäl er här"-CTA-knapp i anmälan-sektionen.** Injiceras av renderern (samma mönster som `wrapTestimonialCards`). Float-right på desktop så texten flödar runt, full bredd och centrerad på mobil. Ersätter den tidigare fetstilta markdown-länken.
- **Nya camps.yaml-fält** `registration_opens` + `registration_closes` med valideringsregler (ISO-format, `opens <= closes < start_date`, required på icke-arkiverade camps). Seedat för 2026-06, 2026-07 och qa-thisweek.

Implementerat enligt feature-lifecycle (§11): requirements → docs + traceability → tester (TDD) → implementation → traceability update → final-check pass.

02-REQUIREMENTS.md §94 (23 krav) + 05-§1.7 (1 krav). Alla 24 nu `covered` eller `implemented` — inga gaps.

## Test plan

- [x] `npm test` — 1548 tester passerar
- [x] `SITE_URL=https://sbsommar.se npm run build` — `public/index.html` innehåller 3 banners (qa-thisweek, juni, juli, sorterade) och `.registration-cta` i anmälan-sektionen
- [ ] Öppna `public/index.html` i browser — verifiera:
  - [ ] Juni-banner och juli-banner syns i hero (qa-thisweek är förbi `registration_closes` 2026-03-01 och stannar dold i dev; filtreras bort i prod)
  - [ ] Klick på banner scrollar till #anmalan-sektionen
  - [ ] "Anmäl er här"-knappen står till höger i kolumnen på desktop (≥ 720 px), texten flödar runt
  - [ ] På mobil (< 720 px) sträcker sig CTA-knappen centrerad över full bredd
  - [ ] Tab-navigering når banners och CTA; `:focus-visible`-outline syns
  - [ ] Markdown-länken `**[Anmäl er här](...)**` finns inte längre i brödtexten
- [ ] Ändra tillfälligt `registration_closes` bakåt i tiden i `camps.yaml` och kör om build — banner för det lägret försvinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)