### PR TITLE
fix: CTA på egen rad + RFSB-medlemslänk till /bli-medlem/

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4464,10 +4464,11 @@ inside the section itself that replaces the inline markdown link.
 - The "Hur anmäler jag oss?" section contains a visually prominent
   "Anmäl er här" button that opens the external registration service at
   `event-friend-ai.lovable.app` in a new tab. <!-- 02-§94.4 -->
-- On desktop (≥ 720 px), the "Anmäl er här" button sits to the right of
-  the section column, and surrounding text flows around it. <!-- 02-§94.5 -->
-- On mobile (< 720 px), the "Anmäl er här" button spans the full column
-  width and is centred. <!-- 02-§94.6 -->
+- The "Anmäl er här" button sits on its own line directly under the
+  "Hur anmäler jag oss?" heading, as an inline-block element sized to
+  its own content. <!-- 02-§94.5 -->
+- The button layout is identical on desktop and mobile — no float, no
+  breakpoint-dependent width change. <!-- 02-§94.6 -->
 - The registration section contains no inline bold markdown link labelled
   "Anmäl er här"; the CTA button is the single call-to-action. <!-- 02-§94.7 -->
 

--- a/docs/07-DESIGN.md
+++ b/docs/07-DESIGN.md
@@ -201,12 +201,13 @@ Base unit: `8px`. Spacing values are multiples of this. <!-- 07-§4.4 -->
   authored in markdown. <!-- 07-§6.98 -->
 - The button reuses `.btn-primary` styling (terracotta background, white
   text). <!-- 07-§6.99 -->
-- Wrapper `.registration-cta` — desktop (≥ 720 px): `float: right;
-  margin: 0 0 var(--space-sm) var(--space-md)` so the following
-  paragraph text flows around the button. <!-- 07-§6.100 -->
-- Mobile (< 720 px): `float: none`, `display: block`, `width: 100%`,
-  `text-align: center`; the button sits on its own row centred in the
-  column. <!-- 07-§6.101 -->
+- Wrapper `.registration-cta` — `display: block; margin: 0 0
+  var(--space-md) 0`: the button sits on its own line directly under
+  the "Hur anmäler jag oss?" heading. <!-- 07-§6.100 -->
+- `.registration-cta-btn` — `display: inline-block; text-decoration:
+  none`: the button is sized to its own content. Same layout on
+  desktop and mobile — no float, no breakpoint-dependent width
+  change. <!-- 07-§6.101 -->
 - The CTA opens the external registration service in a new tab
   (`target="_blank"`, `rel="noopener noreferrer"`). <!-- 07-§6.102 -->
 

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -2105,8 +2105,8 @@ Matrix cleanup (2026-02-25):
 | `02-§94.2` | covered | REGB-04: each banner's `<a>` carries `href="#anmalan"` |
 | `02-§94.3` | implemented | `source/build/build.js` sorts `registrationCamps` ascending by `start_date` before passing to `renderIndexPage`; verified in rendered HTML |
 | `02-§94.4` | covered | REGC-03, REGC-06: CTA `href` is `event-friend-ai.lovable.app`; label is "Anmäl er här" |
-| `02-§94.5` | implemented | `source/assets/cs/style.css` `.registration-cta { float: right; margin: 0 0 var(--space-sm) var(--space-md) }` — manual browser verification |
-| `02-§94.6` | implemented | `style.css` `@media (max-width: 719px) .registration-cta { float: none; width: 100%; text-align: center }` — manual browser verification |
+| `02-§94.5` | implemented | `source/assets/cs/style.css` `.registration-cta { display: block; margin: 0 0 var(--space-md) 0 }` + `.registration-cta-btn { display: inline-block }`; button sits on its own line under the section heading — manual browser verification |
+| `02-§94.6` | implemented | No media query; identical layout on desktop and mobile — manual browser verification |
 | `02-§94.7` | covered | REG-06: `source/content/registration.md` contains no bold `[Anmäl er här]` link |
 | `02-§94.8` | implemented | `source/data/camps.yaml` carries `registration_opens` / `registration_closes` for 2026-06, 2026-07, and qa-thisweek; validator enforces presence |
 | `02-§94.9` | covered | VCMP-38..43: `source/scripts/validate-camps.js` rejects missing / invalid / out-of-order values on non-archived camps |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -299,27 +299,13 @@ h3 {
 /* ── Registration CTA in anmälan section (02-§94, 07-§6.98–6.102) ── */
 
 .registration-cta {
-  float: right;
-  margin: 0 0 var(--space-sm) var(--space-md);
+  display: block;
+  margin: 0 0 var(--space-md) 0;
 }
 
 .registration-cta-btn {
+  display: inline-block;
   text-decoration: none;
-}
-
-@media (max-width: 719px) {
-  .registration-cta {
-    float: none;
-    display: block;
-    width: 100%;
-    text-align: center;
-    margin: 0 0 var(--space-sm) 0;
-  }
-
-  .registration-cta-btn {
-    display: inline-block;
-    min-width: 60%;
-  }
 }
 
 /* ── Camps row (camps list + countdown) ── */

--- a/source/content/registration.md
+++ b/source/content/registration.md
@@ -18,11 +18,11 @@ Formuläret leder er genom sju steg:
 1. **Kontaktuppgifter** – namn, e-post och telefon för den som anmäler, samt samtycke till integritetspolicyn.
 2. **Deltagare** – en eller flera personer med namn, födelsedatum (år/månad/dag), och valfria uppgifter om allergier, specialkost, sjukvårdsutbildning och medföljande husdjur.
 3. **Boende** – prioritetsordning mellan camping, stuga/vandrarhem på området, stuga utanför området (cirka 10 km), eller eget boende.
-4. **Medlemskap i RFSB** – medlemskap är ett krav för att delta. Ni kan slutföra anmälan innan medlemskap är tecknat, men det måste vara på plats före lägret. Tecknas på <https://rfsb.se>.
+4. **Medlemskap i RFSB** – medlemskap är ett krav för att delta. Ni kan slutföra anmälan innan medlemskap är tecknat, men det måste vara på plats före lägret. Tecknas på <https://rfsb.se/bli-medlem/>.
 5. **Övriga upplysningar** – valfritt fält för särskilda behov, frågor eller önskemål.
 6. **Sammanfattning** – kontroll av uppgifter och pris.
 7. **Betalning** – kort, Swish eller faktura.
 
 ## Medlemskap i RFSB
 
-Deltagande på lägret kräver medlemskap i Riksförbundet för Särskild Begåvning. Medlemskap tecknas på <https://rfsb.se> och kan ordnas även efter anmälan — men senast före lägerstart. Alla anmälningar stäms av mot RFSB:s medlemslista innan lägret börjar.
+Deltagande på lägret kräver medlemskap i Riksförbundet för Särskild Begåvning. Medlemskap tecknas på <https://rfsb.se/bli-medlem/> och kan ordnas även efter anmälan — men senast före lägerstart. Alla anmälningar stäms av mot RFSB:s medlemslista innan lägret börjar.


### PR DESCRIPTION
## Summary

- **CTA på egen rad.** `.registration-cta` blir `display: block; margin: 0 0 var(--space-md) 0` och `.registration-cta-btn` blir `display: inline-block`. Inget float, ingen media query. Knappen sitter på egen rad under "Hur anmäler jag oss?" — samma på desktop och mobil. Löser visuellt bug på QA där float-right-layouten gömde knapptexten.
- **RFSB-medlemslänk** pekar nu på `https://rfsb.se/bli-medlem/` istället för roten. Två förekomster i `registration.md` (steg 4 + Medlemskap-sektionen).

Uppdaterar 02-§94.5/94.6, 07-§6.100/6.101, 99-traceability-notes.

## Test plan

- [x] `npm test` — 1548 tester passerar
- [x] `npm run build` — `public/style.css` har `.registration-cta { display: block }` + `.registration-cta-btn { display: inline-block }`; `public/index.html` har /bli-medlem/-länkarna
- [ ] Öppna sidan i browser (hard refresh): knappen "Anmäl er här" syns med text på egen rad under rubriken, samma på desktop och mobil
- [ ] Klick på "Tecknas på https://rfsb.se/bli-medlem/" går till medlemsformuläret

🤖 Generated with [Claude Code](https://claude.com/claude-code)