### PR TITLE
Security: fix ReDoS in slugify and incomplete regex-escape in tests

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4525,3 +4525,57 @@ inside the section itself that replaces the inline markdown link.
 - No new JavaScript files are added; the visibility script is inline in
   the generated `index.html`, consistent with §71.11. <!-- 02-§94.22 -->
 - No new npm or Composer dependencies. <!-- 02-§94.23 -->
+
+---
+
+## 95. Security Hygiene: Regex Performance and Escaping
+
+### 95.1 Context
+
+CodeQL flagged four regex-related issues in the codebase:
+
+- Alert #17 (`js/polynomial-redos`) in `source/api/github.js` at the
+  `slugify()` helper — the two-step `.replace(/^-+/, '').replace(/-+$/, '')`
+  pass depends on user-provided input and can backtrack polynomially on
+  `-`-heavy strings.
+- Alerts #30, #31, #32 (`js/incomplete-sanitization`) in
+  `tests/scoped-headings.test.js` — the ad-hoc escape
+  `.replace(/\./g, '\\.').replace(/\s+/g, '\\s+')` does not cover `\`,
+  `*`, `+`, `?`, `^`, `$`, `{`, `}`, `(`, `)`, `|`, `[`, `]`, so a
+  selector containing any of those characters would produce a malformed
+  pattern.
+
+Neither alert represents an active vulnerability — slug inputs come from
+authored camp data and the flagged test selectors are hardcoded — but
+both should be eliminated so the CodeQL queue stays actionable and future
+changes do not silently inherit the unsafe pattern.
+
+### 95.2 Slugify performance (site requirements)
+
+- `slugify()` in `source/api/github.js` strips leading and trailing `-`
+  characters in a single linear-time pass so its worst-case time on any
+  input is O(n). <!-- 02-§95.1 -->
+- `slugify(s)` produces output identical to the previous implementation
+  for every input: lowercase, `å`/`ä` → `a`, `ö` → `o`, non-alphanumerics
+  collapsed to `-`, leading and trailing `-` removed, truncated to 48
+  characters. <!-- 02-§95.2 -->
+
+### 95.3 Regex escape helper (test infrastructure requirements)
+
+- `tests/helpers/regex-escape.js` exports `escapeRegExp(str)` which
+  returns `str` with every regex metacharacter in the set
+  `. * + ? ^ $ { } ( ) | [ ] \` prefixed by `\`, so the resulting
+  pattern matches only the literal input string. <!-- 02-§95.3 -->
+- `tests/scoped-headings.test.js` uses `escapeRegExp()` at every site
+  where a `container` or `heading` value is interpolated into a
+  `RegExp`; the file contains no hand-rolled `\.`/`\s+` substitution for
+  regex construction. <!-- 02-§95.4 -->
+
+### 95.4 Constraints
+
+- No new npm or Composer dependencies. <!-- 02-§95.5 -->
+- No user-visible behaviour change: slugs generated for new activities
+  remain identical to the previous output, so existing event IDs and
+  URLs continue to resolve. <!-- 02-§95.6 -->
+- CodeQL alerts #17, #30, #31, and #32 reach state `fixed` on the next
+  scan after merge. <!-- 02-§95.7 -->

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -2342,6 +2342,75 @@ All values come from existing tokens in `07-DESIGN.md §7`.
 
 ---
 
+## 33. Regex Performance and Escape Hygiene
+
+### 33.1 Goal
+
+Close CodeQL alerts #17 (`js/polynomial-redos`) and #30–#32
+(`js/incomplete-sanitization`) and remove two regex patterns that invite
+future bugs: a polynomial-time trim in the slug builder and an
+incomplete ad-hoc escape in a test file. The fixes are behaviour-
+preserving; nothing user-facing or data-facing changes.
+
+### 33.2 `slugify()` — linear-time trim
+
+`slugify()` in `source/api/github.js` runs on user-supplied activity
+titles. Before this change the trim step used two separate passes:
+
+```js
+.replace(/^-+/, '')
+.replace(/-+$/, '')
+```
+
+`/^-+/` is linear (anchored at start), but `/-+$/` without a start
+anchor can be O(n²) when the input contains a long run of `-`
+characters: the engine retries the `-+$` match at every position. After
+the earlier collapse `[^a-z0-9]+/g → '-'`, runs of `-` already cannot
+exceed length 1, so `+` in the trim regexes is redundant. The fix is a
+single combined pass:
+
+```js
+.replace(/^-|-$/g, '')
+```
+
+Linear, matches at most two characters (one leading, one trailing), and
+produces identical output for every input.
+
+### 33.3 `tests/helpers/regex-escape.js` — shared `escapeRegExp`
+
+`tests/scoped-headings.test.js` built a `RegExp` from a CSS selector
+string by escaping only `.` and `\s`, which is fine for the current
+literals (`.md-preview`, `.event-desc`, `.event-description`) but
+malformed as soon as any callsite passes a selector with `*`, `+`, `?`,
+`^`, `$`, `{`, `}`, `(`, `)`, `|`, `[`, `]`, or `\`. CodeQL's
+`js/incomplete-sanitization` correctly flags this pattern.
+
+A single helper at `tests/helpers/regex-escape.js` exports the canonical
+escape:
+
+```js
+function escapeRegExp(str) {
+  return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+```
+
+`tests/scoped-headings.test.js` imports this helper at each site where a
+`container` or `heading` value is interpolated into a `RegExp`. No
+other test file currently builds a pattern from a variable string, so
+no broader refactor is needed.
+
+### 33.4 Files changed
+
+| File                                  | Change                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `source/api/github.js`                | Collapse two-step trim in `slugify()` into `/^-\|-$/g`                    |
+| `tests/helpers/regex-escape.js`       | New helper exporting `escapeRegExp(str)`                                 |
+| `tests/scoped-headings.test.js`       | Replace hand-rolled selector escape with `escapeRegExp()`                |
+| `tests/slugify-redos.test.js`         | New test — verifies ReDoS-safe runtime and output equivalence            |
+| `tests/regex-escape.test.js`          | New test — verifies helper covers every metacharacter                    |
+
+---
+
 ## 10. Decided Against
 
 Decisions evaluated and deliberately rejected. Kept here so they are not re-proposed.

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -2125,6 +2125,18 @@ Matrix cleanup (2026-02-25):
 | `02-§94.22` | covered | REGB-11 / REGB-12: inline banner visibility script is emitted only when banners are present; no new JS files |
 | `02-§94.23` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
 
+### §95 — Security Hygiene: Regex Performance and Escaping
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§95.1` | gap | Linear-time trim in `slugify()` — pending Phase 4 |
+| `02-§95.2` | gap | Output-equivalence proof for `slugify()` — pending Phase 4 |
+| `02-§95.3` | gap | `tests/helpers/regex-escape.js` `escapeRegExp()` — pending Phase 4 |
+| `02-§95.4` | gap | `tests/scoped-headings.test.js` uses shared helper — pending Phase 4 |
+| `02-§95.5` | gap | No new dependencies — pending Phase 4 |
+| `02-§95.6` | gap | Output preserved — pending Phase 4 |
+| `02-§95.7` | gap | CodeQL alerts #17, #30, #31, #32 reach `fixed` — pending CodeQL re-scan |
+
 ### §1 — Camp registry fields (camps.yaml)
 
 | ID | Status | Notes |

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -2132,7 +2132,7 @@ Matrix cleanup (2026-02-25):
 | `02-§95.1` | covered | SLUG-RD-01, SLUG-RD-02: `slugify()` trim collapsed to `/^-\|-$/g`; pathological `-`-heavy input returns under 50 ms |
 | `02-§95.2` | covered | SLUG-RD-03..14: `slugify(s)` matches reference implementation and honours 48-char cap, no leading/trailing dash |
 | `02-§95.3` | covered | RE-01..18: `tests/helpers/regex-escape.js` escapes `. * + ? ^ $ { } ( ) \| [ ] \` and coerces non-string input |
-| `02-§95.4` | implemented | `tests/scoped-headings.test.js` imports `escapeRegExp` and uses it at lines 49, 135, 157; no hand-rolled `\.`/`\s+` escape remains — all 22 SH-* tests still pass |
+| `02-§95.4` | implemented | `tests/scoped-headings.test.js` imports `escapeRegExp` and uses it at lines 50, 134, 156; no hand-rolled `\.`/`\s+` escape remains — all 22 SH-* tests still pass |
 | `02-§95.5` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
 | `02-§95.6` | covered | SLUG-RD-03..12 prove output equivalence; SLUG-RD-14 guarantees no leading/trailing dash regression |
 | `02-§95.7` | implemented | Code changes in place; CodeQL re-scan after merge must show #17, #30, #31, #32 in state `fixed` (external verification) |

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -1102,9 +1102,9 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 ## Summary
 
 ```text
-Total requirements:            1181
-Covered (implemented + tested): 605
-Implemented, not tested:        576
+Total requirements:            1188
+Covered (implemented + tested): 609
+Implemented, not tested:        579
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
@@ -2129,13 +2129,13 @@ Matrix cleanup (2026-02-25):
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§95.1` | gap | Linear-time trim in `slugify()` — pending Phase 4 |
-| `02-§95.2` | gap | Output-equivalence proof for `slugify()` — pending Phase 4 |
-| `02-§95.3` | gap | `tests/helpers/regex-escape.js` `escapeRegExp()` — pending Phase 4 |
-| `02-§95.4` | gap | `tests/scoped-headings.test.js` uses shared helper — pending Phase 4 |
-| `02-§95.5` | gap | No new dependencies — pending Phase 4 |
-| `02-§95.6` | gap | Output preserved — pending Phase 4 |
-| `02-§95.7` | gap | CodeQL alerts #17, #30, #31, #32 reach `fixed` — pending CodeQL re-scan |
+| `02-§95.1` | covered | SLUG-RD-01, SLUG-RD-02: `slugify()` trim collapsed to `/^-\|-$/g`; pathological `-`-heavy input returns under 50 ms |
+| `02-§95.2` | covered | SLUG-RD-03..14: `slugify(s)` matches reference implementation and honours 48-char cap, no leading/trailing dash |
+| `02-§95.3` | covered | RE-01..18: `tests/helpers/regex-escape.js` escapes `. * + ? ^ $ { } ( ) \| [ ] \` and coerces non-string input |
+| `02-§95.4` | implemented | `tests/scoped-headings.test.js` imports `escapeRegExp` and uses it at lines 49, 135, 157; no hand-rolled `\.`/`\s+` escape remains — all 22 SH-* tests still pass |
+| `02-§95.5` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
+| `02-§95.6` | covered | SLUG-RD-03..12 prove output equivalence; SLUG-RD-14 guarantees no leading/trailing dash regression |
+| `02-§95.7` | implemented | Code changes in place; CodeQL re-scan after merge must show #17, #30, #31, #32 in state `fixed` (external verification) |
 
 ### §1 — Camp registry fields (camps.yaml)
 

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -15,8 +15,7 @@ function slugify(str) {
     .replace(/[åä]/g, 'a')
     .replace(/ö/g, 'o')
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '')
+    .replace(/^-|-$/g, '')
     .slice(0, 48);
 }
 

--- a/tests/helpers/regex-escape.js
+++ b/tests/helpers/regex-escape.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Escape every RegExp metacharacter so `new RegExp(escapeRegExp(s))`
+// matches only the literal string s. See 02-§95.3.
+//
+// The character class covers the full set defined by the JavaScript
+// specification: `. * + ? ^ $ { } ( ) | [ ] \`.
+
+function escapeRegExp(str) {
+  return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { escapeRegExp };

--- a/tests/regex-escape.test.js
+++ b/tests/regex-escape.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Tests for the shared escapeRegExp() helper (02-§95.3).
+//
+// The helper must escape every RegExp metacharacter so that
+// `new RegExp(escapeRegExp(s))` matches the literal string s — and
+// nothing else — even when s contains `.`, `*`, `+`, `?`, `^`, `$`,
+// `{`, `}`, `(`, `)`, `|`, `[`, `]`, or `\`.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { escapeRegExp } = require('./helpers/regex-escape.js');
+
+describe('02-§95.3 — escapeRegExp covers all metacharacters (RE-01..15)', () => {
+  const metachars = ['.', '*', '+', '?', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\'];
+
+  metachars.forEach((ch, i) => {
+    const id = `RE-${String(i + 1).padStart(2, '0')}`;
+    it(`${id}: escaped '${ch}' matches the literal character`, () => {
+      const re = new RegExp('^' + escapeRegExp(ch) + '$');
+      assert.ok(re.test(ch), `${JSON.stringify(ch)} must match escaped pattern`);
+    });
+  });
+
+  it('RE-15: composite selector is matched exactly and nothing else', () => {
+    const selector = '.md-preview h1';
+    const re = new RegExp(escapeRegExp(selector));
+    assert.ok(re.test('.md-preview h1'));
+    // Without escaping, `.` would match any char — verify it no longer does.
+    assert.ok(!re.test('xmd-preview h1'));
+  });
+});
+
+describe('02-§95.3 — escapeRegExp leaves normal strings unchanged (RE-16..18)', () => {
+  it('RE-16: alphanumerics are not escaped', () => {
+    assert.equal(escapeRegExp('abc123'), 'abc123');
+  });
+
+  it('RE-17: empty string is returned as empty', () => {
+    assert.equal(escapeRegExp(''), '');
+  });
+
+  it('RE-18: non-string input is coerced via String()', () => {
+    assert.equal(escapeRegExp(42), '42');
+  });
+});

--- a/tests/scoped-headings.test.js
+++ b/tests/scoped-headings.test.js
@@ -23,6 +23,7 @@ const path = require('node:path');
 
 const { renderAddPage } = require('../source/build/render-add');
 const { renderEditPage } = require('../source/build/render-edit');
+const { escapeRegExp } = require('./helpers/regex-escape.js');
 
 const css = fs.readFileSync(
   path.join(__dirname, '..', 'source', 'assets', 'cs', 'style.css'),
@@ -44,7 +45,9 @@ const editHtml = renderEditPage(dummyCamp, ['Servicehus'], '/api');
 function extractEmSize(cssText, selector) {
   // Match grouped selectors like ".md-preview h1,\n.event-desc h1,\n... {"
   // Find any rule block whose selector list includes our target selector.
-  const escaped = selector.replace(/\./g, '\\.').replace(/\s+/g, '\\s+');
+  // Collapse any run of literal spaces in the selector to `\s+` so the
+  // pattern tolerates arbitrary whitespace between selector parts in CSS.
+  const escaped = escapeRegExp(selector).replace(/ +/g, '\\s+');
   const re = new RegExp(
     '(?:^|[},])\\s*(?:[^{}]*,\\s*)*' + escaped +
     '\\s*(?:,[^{]*)?\\{([^}]*)',
@@ -128,10 +131,10 @@ describe('02-§59.3 — h4 is body size, bold (SH-19..21)', () => {
       assert.equal(size, 1, `${container} h4 must be 1em`);
 
       // Verify bold via extracting the rule block
-      const escaped = container.replace(/\./g, '\\.').replace(/\s+/g, '\\s+');
+      const escaped = escapeRegExp(container);
       const re = new RegExp(
         '(?:^|[},])\\s*(?:[^{}]*,\\s*)*' + escaped +
-        ' h4\\s*(?:,[^{]*)?\\{([^}]*)', 'm',
+        '\\s+h4\\s*(?:,[^{]*)?\\{([^}]*)', 'm',
       );
       const m = css.match(re);
       assert.ok(m, `${container} h4 rule block must exist`);
@@ -150,7 +153,7 @@ describe('02-§59.4 — No hardcoded px in scoped headings (SH-22)', () => {
     for (const container of containers) {
       for (const heading of headings) {
         const re = new RegExp(
-          container.replace(/\./g, '\\.') + ' ' + heading +
+          escapeRegExp(container) + '\\s+' + escapeRegExp(heading) +
           '\\s*\\{[^}]*font-size:\\s*\\d+px',
         );
         assert.ok(

--- a/tests/slugify-redos.test.js
+++ b/tests/slugify-redos.test.js
@@ -13,8 +13,11 @@ const assert = require('node:assert/strict');
 
 const { slugify } = require('../source/api/github.js');
 
-// Baseline reference implementation that mirrors the documented output
-// contract of slugify(). Used to prove output equivalence.
+// Baseline reference: a deliberate snapshot of the PREVIOUS slugify()
+// implementation (two-step trim). Used as an oracle so SLUG-RD-03..12
+// can prove that the new /^-|-$/g single-pass trim is output-equivalent.
+// Do not "refactor" this to call slugify() — the point is to compare
+// against the old behaviour.
 function referenceSlug(str) {
   return String(str)
     .toLowerCase()

--- a/tests/slugify-redos.test.js
+++ b/tests/slugify-redos.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Tests for slugify() ReDoS safety and output stability (02-§95.1, 02-§95.2).
+//
+// The old implementation used two separate trim passes (`/^-+/` then
+// `/-+$/`) where the trailing pass can backtrack polynomially on
+// `-`-heavy inputs. The fixed implementation combines both trims into a
+// single linear-time pass and must produce bit-for-bit identical output
+// for every input.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { slugify } = require('../source/api/github.js');
+
+// Baseline reference implementation that mirrors the documented output
+// contract of slugify(). Used to prove output equivalence.
+function referenceSlug(str) {
+  return String(str)
+    .toLowerCase()
+    .replace(/[åä]/g, 'a')
+    .replace(/ö/g, 'o')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
+    .slice(0, 48);
+}
+
+describe('02-§95.1 — slugify runs in linear time (SLUG-RD-01..02)', () => {
+  it('SLUG-RD-01: pathological dash-heavy input returns under 50 ms', () => {
+    const pathological = '-'.repeat(100_000);
+    const start = process.hrtime.bigint();
+    const out = slugify(pathological);
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.equal(out, '');
+    assert.ok(
+      durationMs < 50,
+      `slugify(${pathological.length} dashes) took ${durationMs.toFixed(2)}ms — expected < 50ms`,
+    );
+  });
+
+  it('SLUG-RD-02: mixed dash/alphanum pathological input returns under 50 ms', () => {
+    const mixed = ('a' + '-'.repeat(1000)).repeat(100);
+    const start = process.hrtime.bigint();
+    slugify(mixed);
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.ok(
+      durationMs < 50,
+      `slugify mixed-pathological took ${durationMs.toFixed(2)}ms — expected < 50ms`,
+    );
+  });
+});
+
+describe('02-§95.2 — slugify output matches reference for every input (SLUG-RD-03..12)', () => {
+  const cases = [
+    ['Frukost',              'frukost'],
+    ['Å och Ö',              'a-och-o'],
+    ['Grillkväll vid sjön',  'grillkvall-vid-sjon'],
+    ['---trim-leading',      'trim-leading'],
+    ['trim-trailing---',     'trim-trailing'],
+    ['---both-ends---',      'both-ends'],
+    ['',                     ''],
+    ['!!!???!!!',            ''],
+    ['multiple   spaces',    'multiple-spaces'],
+    ['abc'.repeat(40),       'abc'.repeat(40).slice(0, 48)],
+  ];
+
+  cases.forEach(([input, expected], i) => {
+    const id = `SLUG-RD-${String(i + 3).padStart(2, '0')}`;
+    it(`${id}: ${JSON.stringify(input).slice(0, 40)} → ${JSON.stringify(expected)}`, () => {
+      assert.equal(slugify(input), expected);
+      assert.equal(slugify(input), referenceSlug(input));
+    });
+  });
+
+  it('SLUG-RD-13: output never exceeds 48 characters', () => {
+    const longInput = 'a'.repeat(1000);
+    assert.ok(slugify(longInput).length <= 48);
+  });
+
+  it('SLUG-RD-14: output contains no leading or trailing dash', () => {
+    const inputs = ['-foo', 'foo-', '-foo-', '--foo--bar--', '  hej  '];
+    for (const input of inputs) {
+      const out = slugify(input);
+      assert.ok(!out.startsWith('-'), `leading dash in output for ${JSON.stringify(input)}`);
+      assert.ok(!out.endsWith('-'), `trailing dash in output for ${JSON.stringify(input)}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes CodeQL alerts #17 (`js/polynomial-redos`) and #30, #31, #32
(`js/incomplete-sanitization`). Behaviour-preserving hygiene fixes — no
user-visible change.

- `source/api/github.js` — `slugify()` collapses the two separate trim
  passes (`/^-+/` + `/-+$/`) into a single linear-time pass
  (`/^-|-$/g`). Because the preceding step collapses runs of
  non-alphanumerics to single `-`, this is bit-for-bit output-
  equivalent.
- `tests/helpers/regex-escape.js` — new shared `escapeRegExp(str)`
  helper escaping every JavaScript regex metacharacter.
- `tests/scoped-headings.test.js` — imports the helper at each
  RegExp-construction site; the hand-rolled `.replace(/\./g, '\\.')`
  escape is gone.

Requirements, architecture docs, and traceability all updated.

## Test plan

- [x] `npm test` — 1580 / 1580 pass (including 14 new SLUG-RD-* and
      18 new RE-* tests; 22 existing SH-* tests still green)
- [x] `npm run lint` — clean
- [x] `npm run lint:md` — clean
- [ ] Post-merge: CodeQL re-scan marks alerts #17, #30, #31, #32 as
      `fixed` (§95.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)