### PR TITLE
fix: content ol max-width + synlig CTA-knapptext

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -303,8 +303,12 @@ h3 {
   margin: 0 0 var(--space-md) 0;
 }
 
-.registration-cta-btn {
+/* Prefix with .content so we outrank the generic content-link rule
+   (specificity 0,1,1) — without this the button text renders as
+   terracotta-on-terracotta and is invisible. */
+.content .registration-cta-btn {
   display: inline-block;
+  color: var(--color-white);
   text-decoration: none;
 }
 
@@ -1638,12 +1642,14 @@ details.accordion > summary:focus-visible {
 /* ── Content (prose pages) ── */
 
 .content p,
-.content ul {
+.content ul,
+.content ol {
   max-width: 750px;
   margin: 0 0 var(--space-sm);
 }
 
-.content ul {
+.content ul,
+.content ol {
   padding-left: var(--space-lg);
 }
 


### PR DESCRIPTION
## Summary

Två små layoutbuggar som blev synliga efter PR #326:

1. **Numrerad lista stretchade hela bredden.** `.content ol` saknade `max-width: 750px` (bara `.content p` och `.content ul` hade den). När URL:en i steg 4 förlängdes till `/bli-medlem/` blev det uppenbart att hela "Vad efterfrågas vid anmälan?"-listan gick utanför den normala brödtextbredden.

2. **"Anmäl er här"-knappen hade osynlig text.** `.content a { color: terracotta }` (specificitet 0,1,1) vann över `.btn-primary { color: white }` (0,1,0), så texten blev terracotta-på-terracotta. Scopad override `.content .registration-cta-btn` höjer specificiteten till 0,2,0.

## Test plan

- [x] `npm test` — 1580 tester passerar
- [x] `npm run build` — ny CSS innehåller `.content ol` i max-width-regeln och `.content .registration-cta-btn`-blocket
- [ ] Hard refresh i browser: knappen "Anmäl er här" har vit text och ingen underline; numrerad lista i anmälan-sektionen slutar vid samma höger-kant som punktlistan "Viktiga datum" och brödtexten runt

🤖 Generated with [Claude Code](https://claude.com/claude-code)