### PR TITLE
fix: self-healing service worker upgrade (§96)

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4669,11 +4669,15 @@ from a stale cache.
   equal to the current `CACHE_NAME` and then calls
   `self.clients.claim()` so that the new worker immediately controls
   every open tab without requiring a reload. <!-- 02-§96.4 -->
-- The `cacheFirstThenNetwork` strategy matches cache entries **without**
-  `ignoreSearch`, so a request for `style.css?v=<newHash>` does not
-  satisfy from a cache entry keyed at `style.css?v=<oldHash>` or
-  `style.css`. When no match exists, the request falls through to the
-  network and the fresh response is stored in the cache. <!-- 02-§96.5 -->
+- The `cacheFirstThenNetwork` strategy's **primary** cache lookup
+  matches without `ignoreSearch`, so a request for
+  `style.css?v=<newHash>` does not satisfy from a cache entry keyed at
+  `style.css?v=<oldHash>` or `style.css`. When no exact match exists,
+  the request falls through to the network and the fresh response is
+  stored in the cache. A secondary `ignoreSearch` match is only
+  performed as an **offline fallback** when the network fetch itself
+  fails, so that pre-cached `/style.css` still serves when the user is
+  offline on a new hash. <!-- 02-§96.5 -->
 - The `networkFirstThenCache` and `networkFirstWithOfflineFallback`
   strategies continue to use `{ ignoreSearch: true }` when falling back
   to the cache, so that a cache-busted HTML or `events.json` URL still

--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4625,3 +4625,93 @@ changes do not silently inherit the unsafe pattern.
   URLs continue to resolve. <!-- 02-§95.6 -->
 - CodeQL alerts #17, #30, #31, and #32 reach state `fixed` on the next
   scan after merge. <!-- 02-§95.7 -->
+
+---
+
+## 96. Self-Healing Service Worker Upgrade
+
+### 96.1 Context
+
+Clients that had visited the site before a deploy could end up serving
+a stale `/style.css` from the service worker's Cache Storage even after
+a new service worker activated. Two factors combined to cause this:
+
+1. The pre-cache step used `cache.addAll(PRE_CACHE_URLS)` with default
+   `fetch` semantics, which respects the browser's HTTP cache. When the
+   HTTP cache held a `style.css` copy from before the deploy (served
+   with `Cache-Control: max-age=604800`), that stale copy was pulled
+   directly into the new `sb-sommar-v<N>` cache.
+2. The service worker never called `self.skipWaiting()` or
+   `self.clients.claim()`, so a freshly installed worker stayed in the
+   waiting state until every existing client was closed. Users who kept
+   the site open (especially as an installed PWA) never saw the new
+   worker activate.
+
+The result was that CSS changes landed on the server but did not reach
+existing clients — the banners added in §94 rendered as unstyled
+inline links on devices that had visited the site within the last week.
+
+This section defines the service-worker upgrade behaviour that removes
+the need for any user action (no "clear cache and data") to recover
+from a stale cache.
+
+### 96.2 Service worker (site requirements)
+
+- The service worker cache name is `sb-sommar-v6`. <!-- 02-§96.1 -->
+- The `install` event handler calls `self.skipWaiting()` so that a new
+  worker moves straight from `installed` to `activating` without
+  waiting for all existing clients to close. <!-- 02-§96.2 -->
+- The `install` handler pre-caches every URL in `PRE_CACHE_URLS` using
+  `new Request(url, { cache: 'reload' })`, which bypasses the browser's
+  HTTP cache and fetches each asset directly from the network, so a
+  stale HTTP-cache entry cannot be copied into the service-worker
+  cache. <!-- 02-§96.3 -->
+- The `activate` event handler deletes every cache whose name is not
+  equal to the current `CACHE_NAME` and then calls
+  `self.clients.claim()` so that the new worker immediately controls
+  every open tab without requiring a reload. <!-- 02-§96.4 -->
+- The `cacheFirstThenNetwork` strategy matches cache entries **without**
+  `ignoreSearch`, so a request for `style.css?v=<newHash>` does not
+  satisfy from a cache entry keyed at `style.css?v=<oldHash>` or
+  `style.css`. When no match exists, the request falls through to the
+  network and the fresh response is stored in the cache. <!-- 02-§96.5 -->
+- The `networkFirstThenCache` and `networkFirstWithOfflineFallback`
+  strategies continue to use `{ ignoreSearch: true }` when falling back
+  to the cache, so that a cache-busted HTML or `events.json` URL still
+  matches the previously stored entry during an offline fallback. <!-- 02-§96.6 -->
+
+### 96.3 Pre-cache URL list (site requirements)
+
+- The build-generated `PRE_CACHE_URLS` list continues to contain
+  root-relative paths without the cache-busting query string
+  (e.g. `/style.css`, not `/style.css?v=abc`). <!-- 02-§96.7 -->
+- The cache-first handler, with `ignoreSearch` removed, stores fetched
+  `style.css?v=<hash>` responses as separate entries. The pre-cached
+  `/style.css` entry continues to serve as an offline fallback when the
+  hashed URL is not yet cached. <!-- 02-§96.8 -->
+
+### 96.4 Self-healing behaviour (user requirements)
+
+- A user whose browser has an active service worker from before this
+  release receives the new service worker on the next visit to
+  `sbsommar.se` (or `qa.sbsommar.se`): the browser fetches `sw.js`
+  bypassing its HTTP cache, installs the new worker, applies
+  `skipWaiting`, and claims the open tab. <!-- 02-§96.9 -->
+- The new worker deletes the old `sb-sommar-v5` cache and rebuilds
+  `sb-sommar-v6` from fresh network responses. <!-- 02-§96.10 -->
+- After at most one reload following the first post-deploy visit, every
+  client sees the same assets that the server serves, including the
+  current `style.css` with the §94 registration-banner rules. <!-- 02-§96.11 -->
+- No user action (clearing site data, uninstalling the PWA,
+  unregistering the service worker) is required to recover from the
+  stale-cache state. <!-- 02-§96.12 -->
+
+### 96.5 Constraints
+
+- The service worker remains vanilla JavaScript with no external
+  libraries. <!-- 02-§96.13 -->
+- No new npm dependencies are added. <!-- 02-§96.14 -->
+- The offline behaviour defined in §92 is preserved: form pages and the
+  feedback modal continue to show the offline guard when
+  `navigator.onLine` is false, and `offline.html` remains the last-resort
+  fallback for navigation requests that are not in the cache. <!-- 02-§96.15 -->

--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -4356,18 +4356,17 @@ an internet connection.
 
 - The `PRE_CACHE_URLS` array in `sw.js` is populated by the build-time
   injection. There is no hand-maintained list. <!-- 02-§92.6 -->
-- The service worker cache name is `sb-sommar-v5`. <!-- 02-§92.7 -->
+- The service worker cache name is defined in §96.1. <!-- 02-§92.7 -->
 - The service worker pre-caches all site pages, including
   `lagg-till.html` and `redigera.html`. <!-- 02-§92.8 -->
 - The `NO_CACHE_PATTERNS` list contains only API and submission
   endpoints: `/add-event`, `/edit-event`, `/delete-event`,
   `/verify-admin`, `/api/`. It does not contain any `.html`
   pages. <!-- 02-§92.9 -->
-- The `cacheFirstThenNetwork` strategy uses `{ ignoreSearch: true }`
-  when matching cache entries so that cache-busted URLs
-  (e.g. `style.css?v=abc`) match pre-cached files. <!-- 02-§92.10 -->
-- The `networkFirstWithOfflineFallback` strategy uses
-  `{ ignoreSearch: true }` when matching cache entries. <!-- 02-§92.11 -->
+- The `cacheFirstThenNetwork` strategy for static assets matches cache
+  entries as defined in §96.5. <!-- 02-§92.10 -->
+- The network-first strategies match cache entries with
+  `{ ignoreSearch: true }` as defined in §96.6. <!-- 02-§92.11 -->
 
 ### 92.3 Offline guard — form pages (user requirements)
 

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -1920,7 +1920,7 @@ display mode. It is copied to `public/app.webmanifest` during the build.
 ### Service worker
 
 `source/static/sw.js` lives at the site root (`public/sw.js`) so its scope
-covers all pages. It uses a versioned cache name (currently `sb-sommar-v5`).
+covers all pages. It uses a versioned cache name (currently `sb-sommar-v6`).
 
 **Scheme guard:** The fetch handler returns early for any request whose
 URL scheme is not `http:` or `https:`. This prevents errors from
@@ -1930,13 +1930,17 @@ browser-extension schemes such as `chrome-extension:`.
 
 | Request type | Strategy | Rationale |
 | --- | --- | --- |
-| HTML (navigation) | Network-first, cache fallback | Users should see fresh content when online |
-| CSS, JS, images | Cache-first, network fallback | Static assets change infrequently; cache-busting hashes force updates |
-| `events.json` | Network-first, cache fallback | Event data should be fresh when online but available offline |
+| HTML (navigation) | Network-first, cache fallback (ignoreSearch) | Users should see fresh content when online |
+| CSS, JS, images | Cache-first (exact match), network fallback | Static assets are served by cache-busted URL; exact match ensures a new hash triggers a fresh network fetch |
+| `events.json` | Network-first, cache fallback (ignoreSearch) | Event data should be fresh when online but available offline |
 | API calls (`/api/`, `/add-event`, `/edit-event`) | Network-only (not cached) | Mutations must always reach the server |
 
-Cache-matching uses `{ ignoreSearch: true }` so that cache-busted URLs
-(e.g. `style.css?v=abc123`) match the pre-cached file.
+Cache-matching for the network-first strategies (HTML and `events.json`)
+uses `{ ignoreSearch: true }` so that cache-busted or query-stringed
+URLs still match the pre-cached file when falling back offline. The
+cache-first strategy for static assets does **not** use `ignoreSearch`
+— a request for `style.css?v=<newHash>` must not satisfy from a cache
+entry keyed at `style.css?v=<oldHash>` (§96.5).
 
 **Offline fallback:** When a navigation request fails and the requested
 page is not in the cache, the service worker responds with
@@ -1951,11 +1955,27 @@ pages, CSS, JS, images, `events.json` — is available offline from the
 first launch. Files excluded from pre-cache: `.htaccess`, `robots.txt`,
 `sw.js`, `version.json`, `.ics`, `.rss`, and per-event detail pages.
 
-**Lifecycle:**
+**Lifecycle (§96 — self-healing upgrade):**
 
-- `install`: Pre-caches all assets from the build-injected list.
-- `activate`: Deletes old caches whose name does not match the current version.
+- `install`: Calls `self.skipWaiting()` and pre-caches all assets from
+  the build-injected list. Each URL is wrapped in
+  `new Request(url, { cache: 'reload' })` so the fetch bypasses the
+  browser's HTTP cache. This prevents a stale HTTP-cache entry (kept
+  fresh for up to a week by `Cache-Control: max-age=604800`) from being
+  copied into the new service-worker cache on install.
+- `activate`: Deletes every cache whose name does not match the current
+  `CACHE_NAME`, then calls `self.clients.claim()` so the new worker
+  immediately controls every open tab without waiting for the user to
+  close and reopen them.
 - `fetch`: Intercepts requests and applies the strategy table above.
+
+Combined, `skipWaiting` + `clients.claim` + `cache: 'reload'` on
+pre-cache mean that any client whose prior service worker had cached a
+stale `/style.css` self-heals on the first post-deploy visit: the
+browser fetches the new `sw.js` (bypassing its HTTP cache because
+`updateViaCache: 'imports'` is Chrome's default for registered service
+workers), installs it, activates it immediately, wipes the old cache,
+and rebuilds the new cache from network-only responses.
 
 **Offline guard (§92):**
 

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -1106,10 +1106,10 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 ## Summary
 
 ```text
-Total requirements:            1195
+Total requirements:            1210
 Covered (implemented + tested): 612
 Implemented, not tested:        583
-Gap (no implementation):          0
+Gap (no implementation):         15
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).
@@ -2152,6 +2152,26 @@ Matrix cleanup (2026-02-25):
 | `02-§95.5` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
 | `02-§95.6` | covered | SLUG-RD-03..12 prove output equivalence; SLUG-RD-14 guarantees no leading/trailing dash regression |
 | `02-§95.7` | covered | CodeQL post-merge scan on main confirmed alerts #17, #30, #31, #32 transitioned to state `fixed` |
+
+### §96 — Self-Healing Service Worker Upgrade
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§96.1` | gap | `sw.js` declares `const CACHE_NAME = 'sb-sommar-v6'` |
+| `02-§96.2` | gap | `install` event handler calls `self.skipWaiting()` |
+| `02-§96.3` | gap | `install` handler wraps each URL as `new Request(u, { cache: 'reload' })` before `cache.addAll` |
+| `02-§96.4` | gap | `activate` handler deletes non-current caches and calls `self.clients.claim()` |
+| `02-§96.5` | gap | `cacheFirstThenNetwork` matches cache entries without `ignoreSearch` |
+| `02-§96.6` | gap | `networkFirstThenCache` and `networkFirstWithOfflineFallback` continue to use `{ ignoreSearch: true }` when falling back to cache |
+| `02-§96.7` | gap | `PRE_CACHE_URLS` entries remain root-relative without query strings (build output) |
+| `02-§96.8` | gap | Cache-first handler falls back to ignoreSearch match against the pre-cached `/style.css` entry when the hashed URL is not yet cached |
+| `02-§96.9` | gap | Manual browser verification: install SW v5 locally, deploy v6, confirm next navigation upgrades without user action |
+| `02-§96.10` | gap | Manual browser verification: confirm `sb-sommar-v5` is deleted on activate and `sb-sommar-v6` is populated with fresh bytes |
+| `02-§96.11` | gap | Manual browser verification: confirm banners render with correct styling on second reload after deploy |
+| `02-§96.12` | gap | Manual browser verification: no clear-site-data or unregister action needed |
+| `02-§96.13` | gap | `sw.js` has no imports; vanilla JavaScript only |
+| `02-§96.14` | gap | `package.json` unchanged by this feature |
+| `02-§96.15` | gap | `offline-guard.js`, `feedback.js`, and `offline.html` remain in place; offline fallback routing in `sw.js` is unchanged |
 
 ### §1 — Camp registry fields (camps.yaml)
 

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -1107,9 +1107,9 @@ Audit date: 2026-02-24. Last updated: 2026-02-28 (cookie domain client-write fix
 
 ```text
 Total requirements:            1210
-Covered (implemented + tested): 612
-Implemented, not tested:        583
-Gap (no implementation):         15
+Covered (implemented + tested): 620
+Implemented, not tested:        590
+Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).
@@ -2157,21 +2157,21 @@ Matrix cleanup (2026-02-25):
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§96.1` | gap | `sw.js` declares `const CACHE_NAME = 'sb-sommar-v6'` |
-| `02-§96.2` | gap | `install` event handler calls `self.skipWaiting()` |
-| `02-§96.3` | gap | `install` handler wraps each URL as `new Request(u, { cache: 'reload' })` before `cache.addAll` |
-| `02-§96.4` | gap | `activate` handler deletes non-current caches and calls `self.clients.claim()` |
-| `02-§96.5` | gap | `cacheFirstThenNetwork` matches cache entries without `ignoreSearch` |
-| `02-§96.6` | gap | `networkFirstThenCache` and `networkFirstWithOfflineFallback` continue to use `{ ignoreSearch: true }` when falling back to cache |
-| `02-§96.7` | gap | `PRE_CACHE_URLS` entries remain root-relative without query strings (build output) |
-| `02-§96.8` | gap | Cache-first handler falls back to ignoreSearch match against the pre-cached `/style.css` entry when the hashed URL is not yet cached |
-| `02-§96.9` | gap | Manual browser verification: install SW v5 locally, deploy v6, confirm next navigation upgrades without user action |
-| `02-§96.10` | gap | Manual browser verification: confirm `sb-sommar-v5` is deleted on activate and `sb-sommar-v6` is populated with fresh bytes |
-| `02-§96.11` | gap | Manual browser verification: confirm banners render with correct styling on second reload after deploy |
-| `02-§96.12` | gap | Manual browser verification: no clear-site-data or unregister action needed |
-| `02-§96.13` | gap | `sw.js` has no imports; vanilla JavaScript only |
-| `02-§96.14` | gap | `package.json` unchanged by this feature |
-| `02-§96.15` | gap | `offline-guard.js`, `feedback.js`, and `offline.html` remain in place; offline fallback routing in `sw.js` is unchanged |
+| `02-§96.1` | covered | OFF-02, PWA-31: `sw.js` declares `const CACHE_NAME = 'sb-sommar-v6'` |
+| `02-§96.2` | covered | SWH-01: `install` event handler contains `self.skipWaiting()` |
+| `02-§96.3` | covered | SWH-02: `install` handler wraps each URL as `new Request(u, { cache: 'reload' })` before `cache.addAll` |
+| `02-§96.4` | covered | SWH-03, SWH-04: `activate` handler deletes caches `!== CACHE_NAME` and calls `self.clients.claim()` |
+| `02-§96.5` | covered | SWH-05: primary `caches.match(request)` in `cacheFirstThenNetwork` has no `ignoreSearch`; secondary `ignoreSearch` match exists only on the fetch-failure branch |
+| `02-§96.6` | covered | SWH-06, SWH-07, OFF-09: `networkFirstThenCache` and `networkFirstWithOfflineFallback` retain `{ ignoreSearch: true }` on their catch-branch cache lookups |
+| `02-§96.7` | implemented | `source/build/build.js` pre-cache-manifest injection uses root-relative paths (no query strings); verified post-build by `public/sw.js` contents |
+| `02-§96.8` | implemented | `cacheFirstThenNetwork` catch branch calls `caches.match(request, { ignoreSearch: true })` so `/style.css` pre-cache entry still serves offline — manual browser verification |
+| `02-§96.9` | implemented | Manual browser verification: load SW v5, deploy v6, confirm next navigation upgrades without user action |
+| `02-§96.10` | implemented | Manual browser verification: confirm `sb-sommar-v5` is deleted on activate and `sb-sommar-v6` populated from fresh network responses |
+| `02-§96.11` | implemented | Manual browser verification: confirm §94 registration-banner styling applies on second reload after deploy |
+| `02-§96.12` | implemented | Manual browser verification: no clear-site-data or unregister action required from the end user |
+| `02-§96.13` | covered | SWH-08: `sw.js` has no `import`, `require`, or `importScripts` |
+| `02-§96.14` | implemented | `package.json` unchanged by this feature |
+| `02-§96.15` | implemented | `offline-guard.js`, `feedback.js`, and `offline.html` unchanged; offline routing in `sw.js` preserved — manual browser verification |
 
 ### §1 — Camp registry fields (camps.yaml)
 

--- a/source/static/sw.js
+++ b/source/static/sw.js
@@ -3,7 +3,7 @@
 // cache-first for static assets (CSS, JS, images).
 // The PRE_CACHE_URLS list is injected at build time — see build.js.
 
-const CACHE_NAME = 'sb-sommar-v5';
+const CACHE_NAME = 'sb-sommar-v6';
 
 // Pages and assets to pre-cache on install.
 // The build replaces the placeholder below with the full list of URLs.
@@ -23,22 +23,32 @@ const NO_CACHE_PATTERNS = [
 // ── Install: pre-cache all site assets ────────────────────────────────────────
 
 self.addEventListener('install', (event) => {
+  // Activate the new worker immediately, bypassing the waiting state.
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRE_CACHE_URLS)),
+    caches.open(CACHE_NAME).then((cache) =>
+      // `cache: 'reload'` bypasses the browser's HTTP cache for each fetch,
+      // so a stale asset cached with a long max-age can't poison the SW cache.
+      cache.addAll(
+        PRE_CACHE_URLS.map((u) => new Request(u, { cache: 'reload' })),
+      ),
+    ),
   );
 });
 
-// ── Activate: remove old caches ─────────────────────────────────────────────
+// ── Activate: remove old caches and take over existing clients ──────────────
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
         keys
           .filter((key) => key !== CACHE_NAME)
           .map((key) => caches.delete(key)),
-      ),
-    ),
+      );
+      await self.clients.claim();
+    })(),
   );
 });
 
@@ -109,7 +119,9 @@ async function networkFirstWithOfflineFallback(request) {
 }
 
 async function cacheFirstThenNetwork(request) {
-  const cached = await caches.match(request, { ignoreSearch: true });
+  // Exact match only — a cache-busted URL (style.css?v=newHash) must
+  // not satisfy from an older entry keyed at a different query string.
+  const cached = await caches.match(request);
   if (cached) return cached;
 
   try {
@@ -120,6 +132,9 @@ async function cacheFirstThenNetwork(request) {
     }
     return response;
   } catch {
-    return new Response('Offline', { status: 503, statusText: 'Offline' });
+    // Offline fallback: try a query-stringless cache entry (e.g. pre-cached
+    // `/style.css` when the request was `/style.css?v=<hash>`).
+    const fallback = await caches.match(request, { ignoreSearch: true });
+    return fallback || new Response('Offline', { status: 503, statusText: 'Offline' });
   }
 }

--- a/tests/pwa-offline.test.js
+++ b/tests/pwa-offline.test.js
@@ -34,15 +34,15 @@ describe('02-§92.3 — sw.js uses build-injected pre-cache list', () => {
   });
 });
 
-// ── §92.7 — Cache name is sb-sommar-v5 ──────────────────────────────────────
+// ── §96.1 — Cache name is sb-sommar-v6 ──────────────────────────────────────
 
-describe('02-§92.7 — Cache name is sb-sommar-v5', () => {
-  it('OFF-02: sw.js uses sb-sommar-v5 cache name', () => {
+describe('02-§96.1 — Cache name is sb-sommar-v6', () => {
+  it('OFF-02: sw.js uses sb-sommar-v6 cache name', () => {
     const swPath = path.join(__dirname, '..', 'source', 'static', 'sw.js');
     const src = fs.readFileSync(swPath, 'utf8');
     assert.ok(
-      src.includes('sb-sommar-v5'),
-      'CACHE_NAME must be sb-sommar-v5',
+      src.includes("'sb-sommar-v6'"),
+      'CACHE_NAME must be sb-sommar-v6',
     );
   });
 });
@@ -90,16 +90,16 @@ describe('02-§92.9 — NO_CACHE_PATTERNS contains only API endpoints', () => {
   });
 });
 
-// ── §92.10, §92.11 — ignoreSearch in cache strategies ───────────────────────
+// ── §96.5, §96.6 — ignoreSearch scoped to network-first strategies ────────
 
-describe('02-§92.10/§92.11 — Cache strategies use ignoreSearch', () => {
+describe('02-§96.5/§96.6 — Cache-match scope for ignoreSearch', () => {
   const swPath = path.join(__dirname, '..', 'source', 'static', 'sw.js');
 
-  it('OFF-09: sw.js contains ignoreSearch: true', () => {
+  it('OFF-09: sw.js still uses ignoreSearch in at least one cache match', () => {
     const src = fs.readFileSync(swPath, 'utf8');
     assert.ok(
       src.includes('ignoreSearch'),
-      'sw.js must use ignoreSearch for cache matching',
+      'sw.js must use ignoreSearch for network-first fallback',
     );
   });
 });

--- a/tests/pwa.test.js
+++ b/tests/pwa.test.js
@@ -453,13 +453,13 @@ describe('02-§83.33 — Service worker pre-caches offline.html', () => {
 
 // ── 02-§83.34 — Cache version incremented ───────────────────────────────────
 
-describe('02-§83.34 — Cache version incremented to v5', () => {
-  it('PWA-31: sw.js uses sb-sommar-v5 cache name', () => {
+describe('02-§83.34 — Cache version incremented', () => {
+  it('PWA-31: sw.js uses current cache name (sb-sommar-v6 per §96.1)', () => {
     const filePath = path.join(__dirname, '..', 'source', 'static', 'sw.js');
     const src = fs.readFileSync(filePath, 'utf8');
     assert.ok(
-      src.includes('sb-sommar-v5'),
-      'CACHE_NAME must be sb-sommar-v5',
+      src.includes("'sb-sommar-v6'"),
+      'CACHE_NAME must be sb-sommar-v6',
     );
   });
 });

--- a/tests/sw-self-healing.test.js
+++ b/tests/sw-self-healing.test.js
@@ -74,14 +74,21 @@ describe('02-§96.4 — activate handler deletes old caches and claims clients',
   });
 });
 
-// ── §96.5 — cacheFirst matches cache entries WITHOUT ignoreSearch ───────────
+// ── §96.5 — cacheFirst primary lookup is exact; fallback may ignoreSearch ──
 
-describe('02-§96.5 — cacheFirstThenNetwork omits ignoreSearch', () => {
-  it('SWH-05: cacheFirstThenNetwork body does not reference ignoreSearch', () => {
+describe('02-§96.5 — cacheFirstThenNetwork primary lookup is exact', () => {
+  it('SWH-05: primary caches.match before fetch does not pass ignoreSearch', () => {
     const body = extractFunctionBody(SW_SRC, 'function cacheFirstThenNetwork');
+    const fetchIdx = body.indexOf('fetch(request)');
+    assert.ok(fetchIdx !== -1, 'body must contain fetch(request)');
+    const primary = body.substring(0, fetchIdx);
     assert.ok(
-      !body.includes('ignoreSearch'),
-      'cacheFirstThenNetwork must not use ignoreSearch on the primary match',
+      primary.includes('caches.match(request)') || primary.includes('caches.match(request,'),
+      'primary section must call caches.match(request, ...)',
+    );
+    assert.ok(
+      !/caches\.match\([^)]*ignoreSearch/.test(primary),
+      'primary caches.match must not use ignoreSearch',
     );
   });
 });

--- a/tests/sw-self-healing.test.js
+++ b/tests/sw-self-healing.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const SW_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'static', 'sw.js'),
+  'utf8',
+);
+
+// Return the source text of the function whose definition starts on the
+// line containing `header`. Matches balanced braces from the first `{`
+// after the header.
+function extractFunctionBody(src, header) {
+  const headerIdx = src.indexOf(header);
+  assert.ok(headerIdx !== -1, `source must contain header: ${header}`);
+  const openIdx = src.indexOf('{', headerIdx);
+  assert.ok(openIdx !== -1, `function body must start with { after: ${header}`);
+  let depth = 0;
+  for (let i = openIdx; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return src.substring(openIdx, i + 1);
+    }
+  }
+  throw new Error(`unterminated function body for header: ${header}`);
+}
+
+// ── §96.2 — install calls self.skipWaiting() ────────────────────────────────
+
+describe('02-§96.2 — install handler calls self.skipWaiting()', () => {
+  it('SWH-01: sw.js install handler contains self.skipWaiting()', () => {
+    const body = extractFunctionBody(SW_SRC, "addEventListener('install'");
+    assert.ok(
+      body.includes('self.skipWaiting()'),
+      'install handler must call self.skipWaiting()',
+    );
+  });
+});
+
+// ── §96.3 — install uses cache: 'reload' to bypass HTTP cache ───────────────
+
+describe("02-§96.3 — install uses cache: 'reload' for pre-cache fetches", () => {
+  it("SWH-02: sw.js wraps pre-cache URLs as new Request(u, { cache: 'reload' })", () => {
+    const body = extractFunctionBody(SW_SRC, "addEventListener('install'");
+    assert.ok(
+      /new Request\([^,]+,\s*\{\s*cache:\s*['"]reload['"]/.test(body),
+      "install handler must wrap URLs as new Request(u, { cache: 'reload' })",
+    );
+  });
+});
+
+// ── §96.4 — activate claims clients and deletes old caches ──────────────────
+
+describe('02-§96.4 — activate handler deletes old caches and claims clients', () => {
+  it('SWH-03: activate handler calls self.clients.claim()', () => {
+    const body = extractFunctionBody(SW_SRC, "addEventListener('activate'");
+    assert.ok(
+      body.includes('self.clients.claim()'),
+      'activate handler must call self.clients.claim()',
+    );
+  });
+
+  it('SWH-04: activate handler deletes caches whose key is not CACHE_NAME', () => {
+    const body = extractFunctionBody(SW_SRC, "addEventListener('activate'");
+    assert.ok(
+      body.includes('caches.delete') && body.includes('!== CACHE_NAME'),
+      'activate handler must delete caches !== CACHE_NAME',
+    );
+  });
+});
+
+// ── §96.5 — cacheFirst matches cache entries WITHOUT ignoreSearch ───────────
+
+describe('02-§96.5 — cacheFirstThenNetwork omits ignoreSearch', () => {
+  it('SWH-05: cacheFirstThenNetwork body does not reference ignoreSearch', () => {
+    const body = extractFunctionBody(SW_SRC, 'function cacheFirstThenNetwork');
+    assert.ok(
+      !body.includes('ignoreSearch'),
+      'cacheFirstThenNetwork must not use ignoreSearch on the primary match',
+    );
+  });
+});
+
+// ── §96.6 — network-first strategies KEEP ignoreSearch ──────────────────────
+
+describe('02-§96.6 — network-first strategies keep ignoreSearch', () => {
+  it('SWH-06: networkFirstThenCache uses ignoreSearch on cache fallback', () => {
+    const body = extractFunctionBody(SW_SRC, 'function networkFirstThenCache');
+    assert.ok(
+      body.includes('ignoreSearch'),
+      'networkFirstThenCache must use ignoreSearch on its cache fallback',
+    );
+  });
+
+  it('SWH-07: networkFirstWithOfflineFallback uses ignoreSearch on cache fallback', () => {
+    const body = extractFunctionBody(
+      SW_SRC,
+      'function networkFirstWithOfflineFallback',
+    );
+    assert.ok(
+      body.includes('ignoreSearch'),
+      'networkFirstWithOfflineFallback must use ignoreSearch on its cache fallback',
+    );
+  });
+});
+
+// ── §96.13 — vanilla JavaScript, no imports ─────────────────────────────────
+
+describe('02-§96.13 — sw.js is vanilla JavaScript with no imports', () => {
+  it('SWH-08: sw.js has no import/require statements', () => {
+    // Strip block + line comments before scanning so comment text doesn't trigger.
+    const stripped = SW_SRC
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    assert.ok(
+      !/^\s*import\s/m.test(stripped),
+      'sw.js must not contain ES module import statements',
+    );
+    assert.ok(
+      !/\brequire\s*\(/.test(stripped),
+      'sw.js must not use CommonJS require',
+    );
+    assert.ok(
+      !/\bimportScripts\s*\(/.test(stripped),
+      'sw.js must not use importScripts (self-contained)',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Bumps `CACHE_NAME` to `sb-sommar-v6` and adds `self.skipWaiting()` + `self.clients.claim()` so a new worker activates on the next visit instead of waiting for every existing client to close.
- Pre-cache fetches use `new Request(u, { cache: 'reload' })` to bypass the browser's HTTP cache, so assets served with a long `Cache-Control: max-age` can no longer poison the fresh SW cache at install time.
- `cacheFirstThenNetwork` primary lookup drops `ignoreSearch`, so a cache-busted URL (`style.css?v=<newHash>`) cannot satisfy from an older entry. The `ignoreSearch` fallback is preserved only on the fetch-failure branch so offline mode still resolves against the pre-cached `/style.css`.
- Network-first strategies keep `ignoreSearch` on their offline cache fallback — HTML navigation and `events.json` still resolve offline when only a query-stringless entry exists.

## Motivation

Phones that visited the site before the v1.2.4 deploy still served the pre-`§94` `/style.css` from their SW cache, so registration banners rendered as unstyled inline links. Root cause was two-fold: (1) pre-cache `cache.addAll` went through the browser's HTTP cache, which had a stale `style.css` kept fresh by `max-age=604800`; (2) no `skipWaiting`/`clients.claim`, so a fresh worker stayed stuck in `waiting` until every tab closed. After this change, affected clients self-heal on the first post-deploy navigation (plus at most one reload).

## Test plan

- [x] `npm test` — all suites green, including the new `tests/sw-self-healing.test.js` (SWH-01..08) and the updated OFF-02, PWA-31
- [x] `npm run lint` — eslint clean
- [x] `npm run lint:md` — markdownlint clean
- [x] `SITE_URL=https://sbsommar.se npm run build` — built `public/sw.js` contains `sb-sommar-v6`, `self.skipWaiting()`, `cache: 'reload'`, and `self.clients.claim()`
- [ ] Manual browser verification after deploy: banners render with §94 styling on second reload, no user action required

🤖 Generated with [Claude Code](https://claude.com/claude-code)