### PR TITLE
fix: bypass-button placement + datum-hint wording

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -3724,7 +3724,7 @@ submission.
 ### 80.7 Static multi-day hint (user requirements)
 
 - A static hint with the text
-  `Återkommande aktivitet — välj flera dagar.` is rendered immediately
+  `För återkommande aktivitet — välj flera dagar.` is rendered immediately
   below the `Datum *` label on the add-activity page, above the day
   grid, and is always visible regardless of selection state. <!-- 02-§80.28 -->
 - The hint is rendered with the existing `.field-info` class so it

--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -1068,8 +1068,13 @@ through the website.
   valid admin token (§91), the add-activity and edit-activity forms display
   the same locked message as for ordinary users, plus an additional button
   labelled "Öppna ändå (admin)". <!-- 02-§26.14 -->
+- The bypass button is rendered on its own row directly below the locked
+  message — outside the message box, not inline with any other link or
+  text — and has the same placement on `/lagg-till.html` and `/redigera.html`. <!-- 02-§26.20 -->
 - Activating the bypass button removes the disabled state on the form
-  fieldset and submit button so the admin can complete the submission. <!-- 02-§26.15 -->
+  fieldset and submit button so the admin can complete the submission.
+  Activating the button also hides both the locked message and the button
+  itself so the form alone remains visible. <!-- 02-§26.15 -->
 - The bypass button is only shown when the form is locked because the period
   has not yet opened. It is never shown after `end_date + 1 day`. <!-- 02-§26.16 -->
 - `POST /add-event`, `POST /edit-event`, and `POST /delete-event` accept

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -1024,10 +1024,13 @@ Client side (`lagg-till.js`, `redigera.js`):
    checks for a valid admin token (same extraction as used in `redigera.js`
    for edit/delete — see §12 Admin Token).
 2. If an admin token is present, a secondary button labelled
-   "Öppna ändå (admin)" is rendered next to the locked-form message.
+   "Öppna ändå (admin)" is inserted directly after the locked-message
+   container as its next sibling, so it renders on its own row immediately
+   below the banner rather than inside it. The same DOM position is used on
+   both pages for a consistent layout.
 3. Pressing the button removes the disabled attribute on the fieldset and
-   submit button, allowing submission to proceed. The form then behaves as
-   if the period were open.
+   submit button and hides both the locked message and the bypass button.
+   The form then behaves as if the period were open.
 4. When the locked state applies because `today > closes`, the admin button
    is never rendered.
 5. `lagg-till.js` reads the admin token the same way `redigera.js` does and

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -600,7 +600,7 @@ Audit date: 2026-02-24. Last updated: 2026-04-23 (hidden documentation site poli
 | `02-§26.17` | `/add-event`, `/edit-event`, `/delete-event` accept valid admin tokens before `opens_for_editing` | 03-ARCHITECTURE.md §13.6 | ABYP-01..06, ABYP-11..13 | `app.js` – skips pre-period reject when `verifyAdminToken()` passes; `api/index.php` – same check in all three handlers | covered |
 | `02-§26.18` | Same endpoints reject requests after `end_date + 1 day` regardless of admin token | 03-ARCHITECTURE.md §13.6 | ABYP-07..10 | `app.js`, `api/index.php` – `isAfterEditingPeriod()` rejects before admin check | covered |
 | `02-§26.19` | Add-activity form includes admin token as `adminToken` in request body when bypass is active | 03-ARCHITECTURE.md §13.6 | — (manual: open add form with admin token before period, click bypass, submit, inspect POST body) | `source/assets/js/client/lagg-till.js` – `bodyObj.adminToken = adminToken` when `adminBypassActive` | implemented |
-| `02-§26.20` | Bypass button renders on its own row directly below the locked message, outside the banner, same placement on both pages | 03-ARCHITECTURE.md §13.6 | — (manual: open lagg-till.html and redigera.html before opens with admin token, confirm the button sits below the banner on its own row on both pages) | `source/assets/js/client/lagg-till.js`, `source/assets/js/client/redigera.js` – button inserted as next sibling of the locked message container; `source/assets/cs/style.css` – `.form-gate-bypass { display: block; width: fit-content; }` | gap |
+| `02-§26.20` | Bypass button renders on its own row directly below the locked message, outside the banner, same placement on both pages | 03-ARCHITECTURE.md §13.6 | — (manual: open lagg-till.html and redigera.html before opens with admin token, confirm the button sits below the banner on its own row on both pages) | `source/assets/js/client/lagg-till.js` – button inserted as next sibling of `.form-gate-msg`; `source/assets/js/client/redigera.js` – dedicated `.form-gate-msg` created and button inserted as next sibling; `source/assets/cs/style.css` – `.form-gate-bypass { display: block; width: fit-content; }` and `.form-gate-msg[hidden], .form-gate-bypass[hidden] { display: none }` | implemented |
 | `05-§1.6` | `opens_for_editing` field documented in data contract | 05-DATA_CONTRACT.md §1 | — | `docs/05-DATA_CONTRACT.md` – field added to schema and described | implemented |
 | `02-§30.1` | Hero two-column layout: image ~2/3, sidebar ~1/3 | 03-ARCHITECTURE.md §15, 07-DESIGN.md §6 | HERO-01, HERO-02 | `source/build/render-index.js` – `.hero` grid, `.hero-main`, `.hero-sidebar`; `style.css` – `grid-template-columns: 2fr 1fr` | covered |
 | `02-§30.2` | Mobile: hero stacks vertically | 03-ARCHITECTURE.md §15, 07-DESIGN.md §6 | — (manual: resize to <690px) | `style.css` – `@media (max-width: 690px) { .hero { grid-template-columns: 1fr } }` | implemented |
@@ -1115,8 +1115,8 @@ Audit date: 2026-02-24. Last updated: 2026-04-23 (hidden documentation site poli
 ```text
 Total requirements:            1238
 Covered (implemented + tested): 630
-Implemented, not tested:        607
-Gap (no implementation):          1
+Implemented, not tested:        608
+Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).
@@ -1172,6 +1172,9 @@ End time is now required everywhere (add form, edit form, data contract).
   4 implemented (browser-only): 02-§26.14 (bypass button rendered),
     02-§26.15 (disabled state cleared on click), 02-§26.16 (bypass button
     not shown after period), 02-§26.19 (admin token in /add-event body).
+1 requirement added for bypass-button placement (02-§26.20): implemented
+  (browser-only manual checkpoint) — button renders on its own row below
+  the locked banner, consistent across lagg-till.html and redigera.html.
 6 requirements added for past-date blocking (02-§27.1–27.6):
   3 covered (PDT-03..06): 02-§27.4, 02-§27.5, 02-§27.6
   2 implemented (browser-only client validation): 02-§27.2, 02-§27.3

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -600,6 +600,7 @@ Audit date: 2026-02-24. Last updated: 2026-04-23 (hidden documentation site poli
 | `02-§26.17` | `/add-event`, `/edit-event`, `/delete-event` accept valid admin tokens before `opens_for_editing` | 03-ARCHITECTURE.md §13.6 | ABYP-01..06, ABYP-11..13 | `app.js` – skips pre-period reject when `verifyAdminToken()` passes; `api/index.php` – same check in all three handlers | covered |
 | `02-§26.18` | Same endpoints reject requests after `end_date + 1 day` regardless of admin token | 03-ARCHITECTURE.md §13.6 | ABYP-07..10 | `app.js`, `api/index.php` – `isAfterEditingPeriod()` rejects before admin check | covered |
 | `02-§26.19` | Add-activity form includes admin token as `adminToken` in request body when bypass is active | 03-ARCHITECTURE.md §13.6 | — (manual: open add form with admin token before period, click bypass, submit, inspect POST body) | `source/assets/js/client/lagg-till.js` – `bodyObj.adminToken = adminToken` when `adminBypassActive` | implemented |
+| `02-§26.20` | Bypass button renders on its own row directly below the locked message, outside the banner, same placement on both pages | 03-ARCHITECTURE.md §13.6 | — (manual: open lagg-till.html and redigera.html before opens with admin token, confirm the button sits below the banner on its own row on both pages) | `source/assets/js/client/lagg-till.js`, `source/assets/js/client/redigera.js` – button inserted as next sibling of the locked message container; `source/assets/cs/style.css` – `.form-gate-bypass { display: block; width: fit-content; }` | gap |
 | `05-§1.6` | `opens_for_editing` field documented in data contract | 05-DATA_CONTRACT.md §1 | — | `docs/05-DATA_CONTRACT.md` – field added to schema and described | implemented |
 | `02-§30.1` | Hero two-column layout: image ~2/3, sidebar ~1/3 | 03-ARCHITECTURE.md §15, 07-DESIGN.md §6 | HERO-01, HERO-02 | `source/build/render-index.js` – `.hero` grid, `.hero-main`, `.hero-sidebar`; `style.css` – `grid-template-columns: 2fr 1fr` | covered |
 | `02-§30.2` | Mobile: hero stacks vertically | 03-ARCHITECTURE.md §15, 07-DESIGN.md §6 | — (manual: resize to <690px) | `style.css` – `@media (max-width: 690px) { .hero { grid-template-columns: 1fr } }` | implemented |
@@ -1112,10 +1113,10 @@ Audit date: 2026-02-24. Last updated: 2026-04-23 (hidden documentation site poli
 ## Summary
 
 ```text
-Total requirements:            1237
+Total requirements:            1238
 Covered (implemented + tested): 630
 Implemented, not tested:        607
-Gap (no implementation):          0
+Gap (no implementation):          1
 Orphan tests (no requirement):    0
 
 Note: Archive timeline implemented (02-§2.6, 02-§16.2, 02-§16.4, 02-§21.1–21.11).

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1345,6 +1345,11 @@ textarea {
   transition: background 200ms ease, color 200ms ease;
 }
 
+.form-gate-msg[hidden],
+.form-gate-bypass[hidden] {
+  display: none;
+}
+
 .form-gate-bypass:hover {
   background: var(--color-terracotta);
   color: var(--color-white);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1329,8 +1329,10 @@ textarea {
 }
 
 .form-gate-bypass {
-  display: inline-block;
+  display: block;
+  width: fit-content;
   margin-top: var(--space-sm);
+  margin-bottom: var(--space-md);
   padding: 6px 14px;
   border-radius: var(--radius-sm);
   background: transparent;

--- a/source/assets/js/client/lagg-till.js
+++ b/source/assets/js/client/lagg-till.js
@@ -306,8 +306,10 @@
           submitBtn.disabled = false;
           form.classList.remove('form-gated');
           msg.hidden = true;
+          bypassBtn.hidden = true;
         });
-        msg.appendChild(bypassBtn);
+        // Insert after the banner on its own row, not inside it (02-§26.20).
+        msg.parentNode.insertBefore(bypassBtn, msg.nextSibling);
       }
     } else if (todayGate > closesDate) {
       // After closing — no admin bypass (02-§26.16, §26.18)

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -273,17 +273,21 @@
       var todayGate = new Date().toISOString().slice(0, 10);
       if (todayGate < opensDate || todayGate > closesDate) {
         var isBeforeOpens = todayGate < opensDate;
+        var gateMsg = document.createElement('div');
+        gateMsg.className = 'form-gate-msg';
         if (isBeforeOpens) {
           var parts = opensDate.split('-');
           var months = ['januari','februari','mars','april','maj','juni',
                         'juli','augusti','september','oktober','november','december'];
           var formatted = parseInt(parts[2], 10) + ' ' + months[parseInt(parts[1], 10) - 1] + ' ' + parts[0];
-          errorMsg.textContent = 'Formuläret öppnar den ' + formatted + '.';
+          gateMsg.textContent = 'Formuläret öppnar den ' + formatted + '.';
         } else {
-          errorMsg.textContent = 'Lägret är avslutat.';
+          gateMsg.textContent = 'Lägret är avslutat.';
         }
         loadingEl.hidden = true;
-        errorEl.hidden = false;
+        // Dedicated gate banner — do not reuse errorEl since it also carries
+        // the "Tillbaka till schemat" link used by other error flows.
+        sectionEl.parentNode.insertBefore(gateMsg, sectionEl);
         gateBlocked = true;
 
         // Admin bypass button — only before opens (02-§26.16)
@@ -293,13 +297,13 @@
           bypassBtn.className = 'form-gate-bypass';
           bypassBtn.textContent = 'Öppna ändå (admin)';
           bypassBtn.addEventListener('click', function () {
-            errorEl.hidden = true;
+            gateMsg.hidden = true;
             bypassBtn.hidden = true;
             loadingEl.hidden = false;
             runInit();
           });
-          // Insert after the banner on its own row, not inside it (02-§26.20).
-          errorEl.parentNode.insertBefore(bypassBtn, errorEl.nextSibling);
+          // Insert on its own row directly below the banner (02-§26.20).
+          gateMsg.parentNode.insertBefore(bypassBtn, gateMsg.nextSibling);
         }
 
         // Still render cookie debug panel even while gated.

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -294,10 +294,12 @@
           bypassBtn.textContent = 'Öppna ändå (admin)';
           bypassBtn.addEventListener('click', function () {
             errorEl.hidden = true;
+            bypassBtn.hidden = true;
             loadingEl.hidden = false;
             runInit();
           });
-          errorEl.appendChild(bypassBtn);
+          // Insert after the banner on its own row, not inside it (02-§26.20).
+          errorEl.parentNode.insertBefore(bypassBtn, errorEl.nextSibling);
         }
 
         // Still render cookie debug panel even while gated.

--- a/source/build/render-add.js
+++ b/source/build/render-add.js
@@ -61,7 +61,7 @@ ${pageNav('lagg-till.html', navSections)}
 
       <div class="field">
         <label>Datum <span class="req">*</span></label>
-        <span class="field-info">Återkommande aktivitet — välj flera dagar.</span>
+        <span class="field-info">För återkommande aktivitet — välj flera dagar.</span>
         <div class="day-grid" data-start="${startDate}" data-end="${endDate}" data-page-size="8">
 ${dayBtns}
         </div>

--- a/tests/render-add.test.js
+++ b/tests/render-add.test.js
@@ -148,7 +148,7 @@ describe('renderAddPage – submit UX structure', () => {
 describe('renderAddPage – static multi-day date hint (02-§80.28–80.30)', () => {
   it('DG-HINT-01 (02-§80.28): renders the literal hint text', () => {
     assert.ok(
-      render().includes('Återkommande aktivitet — välj flera dagar.'),
+      render().includes('För återkommande aktivitet — välj flera dagar.'),
       'Expected literal hint text below the Datum label',
     );
   });
@@ -156,7 +156,7 @@ describe('renderAddPage – static multi-day date hint (02-§80.28–80.30)', ()
   it('DG-HINT-02 (02-§80.28): hint is placed between the Datum label and the day-grid container', () => {
     const html = render();
     const labelIdx = html.indexOf('Datum <span class="req">*</span></label>');
-    const hintIdx = html.indexOf('Återkommande aktivitet — välj flera dagar.');
+    const hintIdx = html.indexOf('För återkommande aktivitet — välj flera dagar.');
     const gridIdx = html.indexOf('class="day-grid"');
     assert.ok(labelIdx !== -1, 'Datum label not found');
     assert.ok(hintIdx !== -1, 'Hint text not found');
@@ -169,7 +169,7 @@ describe('renderAddPage – static multi-day date hint (02-§80.28–80.30)', ()
 
   it('DG-HINT-03 (02-§80.29): hint uses the .field-info class', () => {
     const html = render();
-    const re = /<span class="field-info">Återkommande aktivitet — välj flera dagar\.<\/span>/;
+    const re = /<span class="field-info">För återkommande aktivitet — välj flera dagar\.<\/span>/;
     assert.ok(re.test(html), 'Hint must be a <span class="field-info"> with the literal text');
   });
 });
@@ -181,7 +181,7 @@ describe('renderEditPage – does not render the multi-day hint (02-§80.30)', (
     const { renderEditPage } = require('../source/build/render-edit');
     const html = renderEditPage(CAMP, LOCATIONS, API_URL);
     assert.ok(
-      !html.includes('Återkommande aktivitet'),
+      !html.includes('återkommande aktivitet'),
       'Edit page must not include the multi-day hint — single-date selector only',
     );
   });


### PR DESCRIPTION
## Summary
- On both `/lagg-till.html` and `/redigera.html`, the admin bypass button now renders on its own row directly below the locked banner — outside the banner box, consistent layout on both pages.
- `/redigera.html` no longer reuses `<div id="edit-error">` for the time-gate message (that div also carries the "Tillbaka till schemat" link, which pushed the bypass button one row down); a dedicated `.form-gate-msg` is created instead, matching `lagg-till.js`.
- Click on the bypass button now hides both the banner and the button itself (the `[hidden]` attribute was being overridden by `.form-gate-bypass { display: block }` at equal specificity; added `.form-gate-msg[hidden], .form-gate-bypass[hidden] { display: none }` following the pattern used elsewhere in the stylesheet).
- Small text tweak on the Datum field hint: *Återkommande aktivitet — välj flera dagar.* → *För återkommande aktivitet — välj flera dagar.*
- Adds requirement 02-§26.20 and tightens 02-§26.15 to describe the placement and the hide-on-click behaviour.

Refs #335 #336

## Test plan
- [ ] CI: `npm test` (1634 tests, all pass)
- [ ] CI: `npm run lint`, `npm run lint:md`, `npm run lint:css`
- [ ] CI: CodeQL jobs pass
- [ ] Manual (already performed locally, incognito, pre-period with admin token):
  - Bypass button sits directly below the banner on both pages
  - Click hides both banner and button; form alone remains
  - No bypass button without admin token or after `end_date + 1`
  - Datum hint on /lagg-till.html reads "För återkommande aktivitet — välj flera dagar."

🤖 Generated with [Claude Code](https://claude.com/claude-code)