### PR TITLE
chore: point booking link at boka.sbsommar.se

### DIFF
--- a/docs/02-REQUIREMENTS.md
+++ b/docs/02-REQUIREMENTS.md
@@ -94,7 +94,7 @@ The homepage must feel complete and trustworthy even when no camp is currently a
 When a camp is active or upcoming, the schedule and add-activity links are prominent. <!-- 02-§3.4 -->
 The upcoming-camps list renders each camp as a compact one-liner (icon, name, location, and dates on a single line) with no visual separators between items. <!-- 02-§3.5 -->
 
-The registration section must link to the external registration service at `event-friend-ai.lovable.app`, where families complete the full sign-up form. <!-- 02-§3.6 -->
+The registration section must link to the external booking site, where families complete the full sign-up form. The specific URL lives in the build code, not in this requirement. <!-- 02-§3.6 -->
 
 The pricing and rules sections must document the cancellation refund tiers and the organiser's right to refuse participation, matching the terms that bind participants at the point of registration. <!-- 02-§3.7 -->
 
@@ -4542,8 +4542,9 @@ inside the section itself that replaces the inline markdown link.
   window, ordered by the camp's `start_date` ascending (closest camp
   first). <!-- 02-§94.3 -->
 - The "Hur anmäler jag oss?" section contains a visually prominent
-  "Anmäl er här" button that opens the external registration service at
-  `event-friend-ai.lovable.app` in a new tab. <!-- 02-§94.4 -->
+  "Anmäl er här" button that opens the external booking site in a new
+  tab. The specific URL lives in the build code, not in this
+  requirement. <!-- 02-§94.4 -->
 - The "Anmäl er här" button sits on its own line directly under the
   "Hur anmäler jag oss?" heading, as an inline-block element sized to
   its own content. <!-- 02-§94.5 -->

--- a/docs/99-traceability.md
+++ b/docs/99-traceability.md
@@ -126,7 +126,7 @@ Audit date: 2026-02-24. Last updated: 2026-04-23 (hidden documentation site poli
 | `02-§3.3` | Homepage remains complete and usable even when no camp is active | 03-ARCHITECTURE.md §5 (Fallback rule) | COV-12..13 | `source/build/build.js` – falls back to most recent camp by `start_date` | covered |
 | `02-§3.4` | Schedule and add-activity links are prominent when a camp is active or upcoming | 03-ARCHITECTURE.md §3 | — | `source/build/layout.js` – nav always shows all links (not conditionally prominent based on camp state) | implemented |
 | `02-§3.5` | Upcoming-camps list renders each camp as a compact one-liner with no separators | 03-ARCHITECTURE.md §14.6 | CL-01, CL-02, CL-03 (CSS presence); manual: visual check | `source/assets/cs/style.css` – `.camp-item`, `.camp-body` flex layout | covered |
-| `02-§3.6` | Registration section links to the external registration service at `event-friend-ai.lovable.app` | 02-REQUIREMENTS.md §3 | REG-01 | `source/content/registration.md` | covered |
+| `02-§3.6` | Registration section links to the external booking site (URL defined in build code) | 02-REQUIREMENTS.md §3 | REG-01 | `source/build/render-index.js` – `REGISTRATION_URL` | covered |
 | `02-§3.7` | Pricing and rules sections document cancellation refund tiers and organiser's right to refuse | 02-REQUIREMENTS.md §3 | REG-02..05 | `source/content/pricing.md`, `source/content/rules.md` | covered |
 | `02-§4.1` | Weekly schedule shows all activities for the full camp week, grouped by day | 03-ARCHITECTURE.md §5 | SNP-02, SNP-03 | `source/build/render.js` – `renderSchedulePage()`, `groupAndSortEvents()` | covered |
 | `02-§4.2` | Within each day, activities are listed in chronological order by start time | 03-ARCHITECTURE.md §5 | RND-28..32 | `source/build/render.js` – `groupAndSortEvents()` | covered |
@@ -2159,7 +2159,7 @@ Matrix cleanup (2026-02-25):
 | `02-§94.1` | covered | REGB-08, REGB-10: `renderRegistrationBannersHtml` emits a banner per non-archived camp with title + meta; rendered inside hero area |
 | `02-§94.2` | covered | REGB-04: each banner's `<a>` carries `href="#anmalan"` |
 | `02-§94.3` | implemented | `source/build/build.js` sorts `registrationCamps` ascending by `start_date` before passing to `renderIndexPage`; verified in rendered HTML |
-| `02-§94.4` | covered | REGC-03, REGC-06: CTA `href` is `event-friend-ai.lovable.app`; label is "Anmäl er här" |
+| `02-§94.4` | covered | REGC-03, REGC-06: CTA `href` is the `REGISTRATION_URL` defined in `source/build/render-index.js`; label is "Anmäl er här" |
 | `02-§94.5` | implemented | `source/assets/cs/style.css` `.registration-cta { display: block; margin: 0 0 var(--space-md) 0 }` + `.registration-cta-btn { display: inline-block }`; button sits on its own line under the section heading — manual browser verification |
 | `02-§94.6` | implemented | No media query; identical layout on desktop and mobile — manual browser verification |
 | `02-§94.7` | covered | REG-06: `source/content/registration.md` contains no bold `[Anmäl er här]` link |

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -435,7 +435,7 @@ function wrapTestimonialCards(html) {
 
 // ── Registration banner and CTA (02-§94) ────────────────────────────────────
 
-const REGISTRATION_URL = 'https://event-friend-ai.lovable.app';
+const REGISTRATION_URL = 'https://boka.sbsommar.se';
 
 /**
  * Renders the hero registration banners — one per camp with an active

--- a/tests/registration-banner.test.js
+++ b/tests/registration-banner.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { renderIndexPage } = require('../source/build/render-index');
+const { renderIndexPage, REGISTRATION_URL } = require('../source/build/render-index');
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -183,12 +183,12 @@ describe('renderIndexPage – registration CTA in anmalan section (02-§94.4–9
     );
   });
 
-  it('REGC-03: CTA href points to event-friend-ai.lovable.app', () => {
+  it('REGC-03: CTA href points to REGISTRATION_URL', () => {
     const html = renderIndexPage(pageWithAnmalan());
     const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
     assert.ok(
-      /href="https:\/\/event-friend-ai\.lovable\.app"/.test(anmalanMatch[0]),
-      'Expected external registration URL in CTA href',
+      anmalanMatch[0].includes(`href="${REGISTRATION_URL}"`),
+      `Expected CTA href to equal REGISTRATION_URL (${REGISTRATION_URL})`,
     );
   });
 

--- a/tests/registration-content.test.js
+++ b/tests/registration-content.test.js
@@ -5,16 +5,16 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { renderIndexPage } = require('../source/build/render-index');
+const { renderIndexPage, REGISTRATION_URL } = require('../source/build/render-index');
 
 const contentDir = path.join(__dirname, '..', 'source', 'content');
 const pricingMd = fs.readFileSync(path.join(contentDir, 'pricing.md'), 'utf8');
 const rulesMd = fs.readFileSync(path.join(contentDir, 'rules.md'), 'utf8');
 
-// ── 02-§3.6  Registration section links to the external registration service ─
+// ── 02-§3.6  Registration section links to the external booking site ────────
 
-describe('02-§3.6 — Registration section links to external service', () => {
-  it('REG-01: rendered anmalan section links to event-friend-ai.lovable.app', () => {
+describe('02-§3.6 — Registration section links to external booking site', () => {
+  it('REG-01: rendered anmalan section links to REGISTRATION_URL', () => {
     const html = renderIndexPage({
       heroSrc: 'images/k.webp',
       heroAlt: '',
@@ -27,8 +27,8 @@ describe('02-§3.6 — Registration section links to external service', () => {
     const anmalanMatch = html.match(/<section id="anmalan"[\s\S]*?<\/section>/);
     assert.ok(anmalanMatch, 'Expected anmalan section in rendered output');
     assert.ok(
-      anmalanMatch[0].includes('event-friend-ai.lovable.app'),
-      'Rendered anmalan section must link to the external registration service',
+      anmalanMatch[0].includes(REGISTRATION_URL),
+      `Rendered anmalan section must link to REGISTRATION_URL (${REGISTRATION_URL})`,
     );
   });
 });


### PR DESCRIPTION
## Summary

- The external booking site now has its own stable subdomain `boka.sbsommar.se`. `REGISTRATION_URL` in `source/build/render-index.js` is updated to match, replacing the previous lovable.app hostname.
- Requirements 02-§3.6 and 02-§94.4 are abstracted: they describe an "external booking site" without naming a specific hostname. The concrete URL lives only in the build code.
- Tests REG-01 and REGC-03 import `REGISTRATION_URL` and assert against the constant instead of hardcoding a hostname. A future URL change requires no test edits.
- Traceability entries for 02-§3.6 and 02-§94.4 now point at `REGISTRATION_URL` rather than a specific host.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — all 1634 tests green
- [x] Built `public/index.html` links `#anmalan` CTA to `https://boka.sbsommar.se` (verified via grep)
- [x] No remaining references to `event-friend-ai.lovable.app` anywhere in the tree
- [x] Manual browser check on `localhost:3000/#anmalan`: CTA href + new-tab behavior confirmed
- [ ] CI green (Analyze actions, Analyze javascript-typescript, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)