### PR TITLE
docs: clean up isolated docs (01, 04, 06, 08, 09) — package 1

### DIFF
--- a/docs/01-CONTRIBUTORS.md
+++ b/docs/01-CONTRIBUTORS.md
@@ -218,5 +218,7 @@ When reporting a bug, include:
 
 - Which page or view is affected.
 - What you expected to see.
+- What actually happened.
+- Steps to reproduce, if you know them.
 
 If the issue is urgent (e.g. the schedule is broken during camp), contact the maintainers directly — do not wait for a GitHub issue response.

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -179,25 +179,6 @@ camp:
 events: []
 ```
 
-### Admin Tokens (optional)
-
-If one or two people need the ability to edit or delete any event
-through the site UI (not just their own):
-
-1. Run `npm run admin:create` and follow the prompts. The script
-   generates a token in the format `namn_uuid_epoch` (where `epoch` is
-   a Unix timestamp 60 days in the future) and prints instructions.
-   The token is shown only once — save it immediately.
-2. Add the token to `ADMIN_TOKENS` in all three locations (see script
-   output): `.env`, `api/.env` on the server, and GitHub Environment
-   secrets for QA/Production.
-3. Share the token privately with the admin (e.g. via SMS or in person).
-4. The admin visits `/admin.html`, enters the token, and gains admin
-   status for 30 days.
-
-Tokens can be revoked at any time by removing them from `ADMIN_TOKENS`
-and redeploying. No code change is needed.
-
 ### During Camp
 
 Participants add events through the web form at `/lagg-till.html`.
@@ -212,6 +193,32 @@ to fix or remove entries.
 1. Set `archived: true` for the camp in `source/data/camps.yaml`.
 2. Commit. The YAML file already has its permanent name — it becomes the archive as-is.
 3. Deploy. The system automatically derives the next active camp from dates.
+
+---
+
+## Admin Tokens (optional)
+
+Admin tokens grant one or two people the ability to edit or delete any
+event through the site UI — not just their own. The feature is optional;
+omit `ADMIN_TOKENS` to disable it entirely.
+
+### Issuing a token
+
+1. Run `npm run admin:create` and follow the prompts. The script
+   generates a token in the format `namn_uuid_epoch` (where `epoch` is
+   a Unix timestamp 60 days in the future) and prints instructions.
+   The token is shown only once — save it immediately.
+2. Add the token to `ADMIN_TOKENS` in all three locations (see script
+   output): `.env`, `api/.env` on the server, and GitHub Environment
+   secrets for QA/Production.
+3. Share the token privately with the admin (e.g. via SMS or in person).
+4. The admin visits `/admin.html`, enters the token, and gains admin
+   status for 30 days.
+
+### Revoking a token
+
+Remove the token from `ADMIN_TOKENS` and redeploy. No code change is
+needed.
 
 ---
 

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -66,7 +66,7 @@ All environments receive event data within minutes of submission — no manual s
 | `deploy-prod.yml`         | `workflow_dispatch` (manual)                            | `production`         |
 | `event-data-deploy.yml`   | PR from `event/` or `event-edit/` changing data YAMLs  | — (no-op gate)       |
 | `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only)              | `qa` + `production`  |
-| `docker-build.yml`        | Push to `main` (package.json or Dockerfile)            | — (GHCR, no longer used by event-data deploy) |
+| `docker-build.yml`        | Push to `main` (`package.json`, `package-lock.json`, or Dockerfile) | — (pushes Docker image to GHCR) |
 
 `deploy-qa.yml` and `deploy-prod.yml` both call the shared reusable workflow
 `deploy-reusable.yml`, which builds the static site, deploys it via SCP,
@@ -86,19 +86,18 @@ the secrets.
 
 ### GitHub Environment: `qa` (PHP on Loopia)
 
-| Secret            | Purpose                          |
-| ----------------- | -------------------------------- |
-| `SITE_URL`        | QA base URL                      |
-| `API_URL`         | QA PHP API endpoint              |
-| `COOKIE_DOMAIN`   | Session cookie domain (e.g. `sbsommar.se`) — injected at build time |
-| `GOATCOUNTER_SITE_CODE` | GoatCounter site code for QA analytics (e.g. `qa-sbsommar`) |
-| `SERVER_HOST`     | QA SSH/SCP host                  |
-| `SERVER_USER`     | QA SSH username                  |
-| `SERVER_SSH_KEY`  | QA SSH private key               |
-| `SERVER_SSH_PORT` | QA SSH port                      |
-| `DEPLOY_DIR`      | QA deploy directory              |
-
-| `ADMIN_TOKENS`    | Comma-separated list of admin tokens (format: `namn_uuid_epoch`). Optional — omit to disable admin features. Create tokens with `npm run admin:create`. |
+| Secret                  | Purpose                                                                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SITE_URL`              | QA base URL                                                                                                                                             |
+| `API_URL`               | QA PHP API endpoint                                                                                                                                     |
+| `COOKIE_DOMAIN`         | Session cookie domain (e.g. `sbsommar.se`) — injected at build time                                                                                     |
+| `GOATCOUNTER_SITE_CODE` | GoatCounter site code for QA analytics (e.g. `qa-sbsommar`)                                                                                             |
+| `SERVER_HOST`           | QA SSH/SCP host                                                                                                                                         |
+| `SERVER_USER`           | QA SSH username                                                                                                                                         |
+| `SERVER_SSH_KEY`        | QA SSH private key                                                                                                                                      |
+| `SERVER_SSH_PORT`       | QA SSH port                                                                                                                                             |
+| `DEPLOY_DIR`            | QA deploy directory                                                                                                                                     |
+| `ADMIN_TOKENS`          | Comma-separated list of admin tokens (format: `namn_uuid_epoch`). Optional — omit to disable admin features. Create tokens with `npm run admin:create`. |
 
 Example values: `SITE_URL=https://qa.sbsommar.se`,
 `API_URL=https://qa.sbsommar.se/api/add-event`.

--- a/docs/09-RELEASING.md
+++ b/docs/09-RELEASING.md
@@ -199,7 +199,7 @@ Before bumping the version, review what has changed and draft release
 notes. This makes the automatically generated GitHub Release more
 useful and ensures nothing is forgotten.
 
-**1. Check what has changed since the last `.0` release:**
+#### 1. Check what has changed since the last `.0` release
 
 ```bash
 git fetch --tags
@@ -217,7 +217,7 @@ git log v1.0.0..HEAD --oneline
 Replace `v1.0.0` with the actual base tag of the current version
 series — this is the `.0` tag, not the latest patch.
 
-**2. Draft release notes:**
+#### 2. Draft release notes
 
 Write a short summary of the release. Group changes by category:
 
@@ -229,7 +229,7 @@ Write a short summary of the release. Group changes by category:
 Keep it concise — a few bullet points per category. The audience is
 someone who uses the site, not a developer.
 
-**3. Bump and merge:**
+#### 3. Bump and merge
 
 1. Edit the `VERSION` file — change `1.0` to `1.1` (or `2.0`).
 2. Commit: `chore: bump version to 1.1`
@@ -239,7 +239,7 @@ someone who uses the site, not a developer.
    **automatically creates a GitHub Release** with auto-generated notes
    listing all PRs since the previous release.
 
-**4. Edit the GitHub Release:**
+#### 4. Edit the GitHub Release
 
 After the deploy creates the release, open it on GitHub and replace or
 supplement the auto-generated notes with your drafted summary from


### PR DESCRIPTION
Refs #348.

Per-file Clean Code pass for the five docs whose IDs are not cited from
code. No `XX-§N.M` IDs are renumbered; only headings, structure, and
prose change.

- `01-CONTRIBUTORS.md` — finish the bug-report checklist (was missing
  "what actually happened" and "steps to reproduce").
- `04-OPERATIONS.md` — promote `Admin Tokens` from a child of "Camp
  Lifecycle" to its own H2, with `Issuing a token` and `Revoking a
  token` sub-sections. Camp Lifecycle now reads cleanly Before → During
  → After.
- `06-EVENT_DATA_MODEL.md` — reviewed; already conforms (8 short
  numbered sections, all under 25 lines, clear names, no stale refs).
  No changes.
- `08-ENVIRONMENTS.md` — fold the detached `ADMIN_TOKENS` row back into
  the QA secrets table so it renders as one table. Replace
  "no longer used by event-data deploy" with a desired-state
  description for `docker-build.yml`. Clarify the trigger paths to
  match the actual workflow.
- `09-RELEASING.md` — promote bold pseudo-headings inside "Preparing a
  minor or major release" to real H4 sub-headings so the four steps
  are navigable and the section's H3 stays under 50 lines.

`README.md` docs-nav table and `CLAUDE.md §0` table both unchanged —
their topic-level descriptions still match the documents after the
restructure.

Verified: `npm run lint:md` clean; `npm test` passes (1713/1713);
`grep '0[1468]-§' source tests` and `grep '09-§' source tests` both
return 0, identical to the baseline before the package.