### PR TITLE
Sign participant session ownership cookies

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -11,5 +11,9 @@ QA_ORIGIN=https://qa.sbsommar.se
 COOKIE_DOMAIN=sbsommar.se
 BUILD_ENV=production
 
+# Long random value used to sign participant ownership cookies.
+# Use different values for QA and production.
+SESSION_SECRET=replace_with_long_random_secret
+
 # Comma-separated admin tokens (UUIDs) for admin access (02-§91.1).
 # ADMIN_TOKENS=

--- a/api/index.php
+++ b/api/index.php
@@ -87,6 +87,7 @@ try {
 // ── Parse configured admin tokens once ───────────────────────────────────
 
 $adminTokens = Admin::parseAdminTokens($_ENV['ADMIN_TOKENS'] ?? null);
+$sessionSecret = (string) ($_ENV['SESSION_SECRET'] ?? '');
 
 // ── Handlers ─────────────────────────────────────────────────────────────
 
@@ -101,16 +102,16 @@ try {
             => handleCleanupCookies(),
 
         $method === 'POST' && $route === '/add-event'
-            => handleAddEvent($activeCamp, $adminTokens),
+            => handleAddEvent($activeCamp, $adminTokens, $sessionSecret),
 
         $method === 'POST' && $route === '/add-events'
-            => handleAddEvents($activeCamp, $adminTokens),
+            => handleAddEvents($activeCamp, $adminTokens, $sessionSecret),
 
         $method === 'POST' && $route === '/edit-event'
-            => handleEditEvent($activeCamp, $adminTokens),
+            => handleEditEvent($activeCamp, $adminTokens, $sessionSecret),
 
         $method === 'POST' && $route === '/delete-event'
-            => handleDeleteEvent($activeCamp, $adminTokens),
+            => handleDeleteEvent($activeCamp, $adminTokens, $sessionSecret),
 
         $method === 'POST' && $route === '/feedback'
             => handleFeedback(),
@@ -156,7 +157,7 @@ function handleCleanupCookies(): void
 }
 
 /** @param list<string> $adminTokens */
-function handleAddEvent(?array $activeCamp, array $adminTokens): void
+function handleAddEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'add-event', RATE_LIMIT_ADD_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -191,6 +192,16 @@ function handleAddEvent(?array $activeCamp, array $adminTokens): void
         return;
     }
 
+    $consentGiven = ($body['cookieConsent'] ?? false) === true;
+    if ($consentGiven && $sessionSecret === '') {
+        jsonResponse([
+            'success' => false,
+            'error'   => 'Sessionen kunde inte sparas. Kontakta arrangören.',
+        ], 500);
+
+        return;
+    }
+
     // Build event ID (same logic as github.js)
     $title   = trim((string) ($body['title'] ?? ''));
     $date    = trim((string) ($body['date'] ?? ''));
@@ -210,10 +221,15 @@ function handleAddEvent(?array $activeCamp, array $adminTokens): void
 
     // Session cookie (only if consent given) — set AFTER successful GitHub
     // commit so the browser never stores an ID for an event that failed to save.
-    $consentGiven = ($body['cookieConsent'] ?? false) === true;
     if ($consentGiven) {
-        $existing = Session::parseSessionIds($_SERVER['HTTP_COOKIE'] ?? '');
-        $updated  = Session::mergeIds($existing, $eventId);
+        $existing = array_map(
+            static fn(string $id): array => Session::createOwnershipEntry($id, $sessionSecret),
+            Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret),
+        );
+        $updated  = Session::mergeOwnershipEntries(
+            $existing,
+            Session::createOwnershipEntry($eventId, $sessionSecret),
+        );
         $cookieDomain = !empty($_ENV['COOKIE_DOMAIN']) ? $_ENV['COOKIE_DOMAIN'] : null;
         header('Set-Cookie: ' . Session::buildSetCookieHeader($updated, $cookieDomain));
     }
@@ -222,7 +238,7 @@ function handleAddEvent(?array $activeCamp, array $adminTokens): void
 }
 
 /** @param list<string> $adminTokens */
-function handleAddEvents(?array $activeCamp, array $adminTokens): void
+function handleAddEvents(?array $activeCamp, array $adminTokens, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'add-events', RATE_LIMIT_ADD_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -257,6 +273,16 @@ function handleAddEvents(?array $activeCamp, array $adminTokens): void
         return;
     }
 
+    $consentGiven = ($body['cookieConsent'] ?? false) === true;
+    if ($consentGiven && $sessionSecret === '') {
+        jsonResponse([
+            'success' => false,
+            'error'   => 'Sessionen kunde inte sparas. Kontakta arrangören.',
+        ], 500);
+
+        return;
+    }
+
     // Commit all events to GitHub in a single PR
     try {
         $gh = new GitHub();
@@ -269,12 +295,17 @@ function handleAddEvents(?array $activeCamp, array $adminTokens): void
     }
 
     // Session cookie — add all event IDs (only if consent given)
-    $consentGiven = ($body['cookieConsent'] ?? false) === true;
     if ($consentGiven) {
-        $existing = Session::parseSessionIds($_SERVER['HTTP_COOKIE'] ?? '');
+        $existing = array_map(
+            static fn(string $id): array => Session::createOwnershipEntry($id, $sessionSecret),
+            Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret),
+        );
         $updated  = $existing;
         foreach ($eventIds as $eid) {
-            $updated = Session::mergeIds($updated, $eid);
+            $updated = Session::mergeOwnershipEntries(
+                $updated,
+                Session::createOwnershipEntry((string) $eid, $sessionSecret),
+            );
         }
         $cookieDomain = !empty($_ENV['COOKIE_DOMAIN']) ? $_ENV['COOKIE_DOMAIN'] : null;
         header('Set-Cookie: ' . Session::buildSetCookieHeader($updated, $cookieDomain));
@@ -284,7 +315,7 @@ function handleAddEvents(?array $activeCamp, array $adminTokens): void
 }
 
 /** @param list<string> $adminTokens */
-function handleEditEvent(?array $activeCamp, array $adminTokens): void
+function handleEditEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'edit-event', RATE_LIMIT_EDIT_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -321,9 +352,9 @@ function handleEditEvent(?array $activeCamp, array $adminTokens): void
 
     $eventId = trim((string) ($body['id'] ?? ''));
 
-    // Verify ownership: event ID in session cookie OR valid admin token
+    // Verify ownership: signed session ownership OR valid admin token
     // (02-§7.3, §18.31).
-    $ownedIds = Session::parseSessionIds($_SERVER['HTTP_COOKIE'] ?? '');
+    $ownedIds = Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret);
     if (!in_array($eventId, $ownedIds, true) && !$isAdmin) {
         jsonResponse([
             'success' => false,
@@ -359,7 +390,7 @@ function handleEditEvent(?array $activeCamp, array $adminTokens): void
 }
 
 /** @param list<string> $adminTokens */
-function handleDeleteEvent(?array $activeCamp, array $adminTokens): void
+function handleDeleteEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'delete-event', RATE_LIMIT_DELETE_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -394,9 +425,9 @@ function handleDeleteEvent(?array $activeCamp, array $adminTokens): void
         return;
     }
 
-    // Verify ownership: event ID in session cookie OR valid admin token
+    // Verify ownership: signed session ownership OR valid admin token
     // (02-§7.3, §89.13).
-    $ownedIds = Session::parseSessionIds($_SERVER['HTTP_COOKIE'] ?? '');
+    $ownedIds = Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret);
     if (!in_array($eventId, $ownedIds, true) && !$isAdmin) {
         jsonResponse([
             'success' => false,

--- a/api/src/Session.php
+++ b/api/src/Session.php
@@ -19,6 +19,61 @@ final class Session
      */
     public static function parseSessionIds(string $cookieHeader): array
     {
+        return array_values(array_filter(array_map(
+            static function (mixed $entry): ?string {
+                if (is_string($entry) && $entry !== '') {
+                    return $entry;
+                }
+                if (self::isOwnershipEntry($entry)) {
+                    return $entry['id'];
+                }
+
+                return null;
+            },
+            self::parseSessionPayload($cookieHeader),
+        )));
+    }
+
+    /**
+     * Create a signed ownership entry for one event ID.
+     *
+     * @return array{id:string,exp:int,sig:string}
+     */
+    public static function createOwnershipEntry(string $id, string $secret): array
+    {
+        if ($id === '' || $secret === '') {
+            throw new \InvalidArgumentException('id and secret are required');
+        }
+
+        $exp = time() + self::MAX_AGE_SECONDS;
+
+        return ['id' => $id, 'exp' => $exp, 'sig' => self::signatureForEntry($id, $exp, $secret)];
+    }
+
+    /**
+     * Parse only entries with valid server-side ownership signatures.
+     *
+     * @return string[]
+     */
+    public static function parseVerifiedSessionIds(string $cookieHeader, string $secret): array
+    {
+        if ($secret === '') {
+            return [];
+        }
+
+        $ids = [];
+        foreach (self::parseSessionPayload($cookieHeader) as $entry) {
+            if (self::verifyOwnershipEntry($entry, $secret)) {
+                $ids[] = $entry['id'];
+            }
+        }
+
+        return $ids;
+    }
+
+    /** @return array<int,mixed> */
+    private static function parseSessionPayload(string $cookieHeader): array
+    {
         if ($cookieHeader === '') {
             return [];
         }
@@ -36,14 +91,40 @@ final class Session
                     return [];
                 }
 
-                return array_values(array_filter(
-                    $parsed,
-                    static fn($id) => is_string($id) && $id !== '',
-                ));
+                return array_values($parsed);
             }
         }
 
         return [];
+    }
+
+    private static function signatureForEntry(string $id, int $exp, string $secret): string
+    {
+        return hash_hmac('sha256', "{$id}.{$exp}", $secret);
+    }
+
+    private static function isOwnershipEntry(mixed $entry): bool
+    {
+        return is_array($entry)
+            && is_string($entry['id'] ?? null)
+            && $entry['id'] !== ''
+            && is_int($entry['exp'] ?? null)
+            && $entry['exp'] > 0
+            && is_string($entry['sig'] ?? null)
+            && $entry['sig'] !== '';
+    }
+
+    private static function verifyOwnershipEntry(mixed $entry, string $secret): bool
+    {
+        if ($secret === '' || !self::isOwnershipEntry($entry)) {
+            return false;
+        }
+
+        if ($entry['exp'] < time()) {
+            return false;
+        }
+
+        return hash_equals(self::signatureForEntry($entry['id'], $entry['exp'], $secret), $entry['sig']);
     }
 
     /**
@@ -64,17 +145,25 @@ final class Session
     }
 
     /**
-     * Merge a new event ID into an existing list (deduplicating).
+     * Merge a new ownership entry into an existing list (deduplicating by ID).
      *
-     * @param string[] $existing
-     * @return string[]
+     * @param array<int,mixed> $existing
+     * @param array{id:string,exp:int,sig:string} $newEntry
+     * @return array<int,array{id:string,exp:int,sig:string}>
      */
-    public static function mergeIds(array $existing, string $newId): array
+    public static function mergeOwnershipEntries(array $existing, array $newEntry): array
     {
-        if (in_array($newId, $existing, true)) {
-            return $existing;
+        $entries = array_values(array_filter($existing, static fn(mixed $entry): bool => self::isOwnershipEntry($entry)));
+        if (!self::isOwnershipEntry($newEntry)) {
+            return $entries;
         }
 
-        return [...$existing, $newId];
+        foreach ($entries as $entry) {
+            if ($entry['id'] === $newEntry['id']) {
+                return $entries;
+            }
+        }
+
+        return [...$entries, $newEntry];
     }
 }

--- a/app.js
+++ b/app.js
@@ -9,7 +9,12 @@ const yaml      = require('js-yaml');
 const { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, slugify } = require('./source/api/github');
 const { validateEventRequest, validateEditRequest }              = require('./source/api/validate');
 const { isEventPast }                                            = require('./source/api/edit-event');
-const { parseSessionIds, buildSetCookieHeader, mergeIds }        = require('./source/api/session');
+const {
+  parseVerifiedSessionIds,
+  createOwnershipEntry,
+  buildSetCookieHeader,
+  mergeOwnershipEntries,
+} = require('./source/api/session');
 const { isBeforeEditingPeriod, isAfterEditingPeriod }            = require('./source/api/time-gate');
 const { validateFeedbackRequest, createFeedbackIssue }           = require('./source/api/feedback');
 const { parseAdminTokens, verifyAdminToken }                     = require('./source/api/admin');
@@ -27,6 +32,7 @@ const campsData = yaml.load(fs.readFileSync(campsPath, 'utf8'));
 const BUILD_ENV = process.env.BUILD_ENV || undefined;
 const activeCamp = resolveActiveCamp(campsData.camps || [], undefined, BUILD_ENV);
 const adminTokens = parseAdminTokens(process.env.ADMIN_TOKENS);
+const sessionSecret = process.env.SESSION_SECRET || '';
 
 // ── Middleware ───────────────────────────────────────────────────────────────
 
@@ -108,6 +114,14 @@ app.post('/add-event', addEventLimiter, (req, res) => {
     return res.status(400).json({ success: false, error: v.error });
   }
 
+  const consentGiven = req.body.cookieConsent === true;
+  if (consentGiven && !sessionSecret) {
+    return res.status(500).json({
+      success: false,
+      error: 'Sessionen kunde inte sparas. Kontakta arrangören.',
+    });
+  }
+
   // Build the event ID the same way github.js does, so we can include it
   // in the session cookie before the GitHub commit completes.
   const title  = String(req.body.title).trim();
@@ -116,10 +130,10 @@ app.post('/add-event', addEventLimiter, (req, res) => {
   const eventId = `${slugify(title)}-${date}-${start.replace(':', '')}`;
 
   // If the client signalled cookie consent, update the session cookie.
-  const consentGiven = req.body.cookieConsent === true;
   if (consentGiven) {
-    const existing = parseSessionIds(req.headers.cookie || '');
-    const updated  = mergeIds(existing, eventId);
+    const existing = parseVerifiedSessionIds(req.headers.cookie || '', sessionSecret)
+      .map((id) => createOwnershipEntry(id, sessionSecret));
+    const updated  = mergeOwnershipEntries(existing, createOwnershipEntry(eventId, sessionSecret));
     res.setHeader('Set-Cookie', buildSetCookieHeader(updated, process.env.COOKIE_DOMAIN));
   }
 
@@ -151,9 +165,9 @@ app.post('/edit-event', editEventLimiter, (req, res) => {
 
   const eventId = String(req.body.id).trim();
 
-  // Verify ownership: event ID must be in the session cookie OR
+  // Verify ownership: event ID must have signed session ownership OR
   // the request must carry a valid admin token (02-§7.3, §18.31).
-  const ownedIds = parseSessionIds(req.headers.cookie || '');
+  const ownedIds = parseVerifiedSessionIds(req.headers.cookie || '', sessionSecret);
   if (!ownedIds.includes(eventId) && !isAdmin) {
     return res.status(403).json({ success: false, error: 'Ej behörig att redigera denna aktivitet.' });
   }
@@ -189,9 +203,9 @@ app.post('/delete-event', deleteEventLimiter, (req, res) => {
     return res.status(400).json({ success: false, error: 'Aktivitets-ID saknas.' });
   }
 
-  // Verify ownership: event ID must be in the session cookie OR
+  // Verify ownership: event ID must have signed session ownership OR
   // the request must carry a valid admin token (02-§7.3, §89.13).
-  const ownedIds = parseSessionIds(req.headers.cookie || '');
+  const ownedIds = parseVerifiedSessionIds(req.headers.cookie || '', sessionSecret);
   if (!ownedIds.includes(eventId) && !isAdmin) {
     return res.status(403).json({ success: false, error: 'Ej behörig att radera denna aktivitet.' });
   }

--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -755,8 +755,8 @@ submission.
   created event IDs. <!-- 02-§80.17 -->
 - Time-gating (§26) and injection scanning (§49) apply to the batch endpoint
   identically. <!-- 02-§80.18 -->
-- The session cookie is updated with all new event IDs when consent is
-  given. <!-- 02-§80.19 -->
+- The session cookie is updated with ownership entries for all submitted events
+  when consent is given. <!-- 02-§80.19 -->
 
 ### 80.4 Confirmation and submit flow (user requirements)
 
@@ -986,11 +986,11 @@ Deletion removes the event entirely from the camp's YAML file.
 ### 89.3 Server-side delete endpoint (site requirements)
 
 - A `POST /delete-event` endpoint accepts delete requests. <!-- 02-§89.12 -->
-- The server reads the `sb_session` cookie from the request, parses the
-  event ID array, and verifies the target event ID is present — or that the
-  request body contains a valid `adminToken` (§91). <!-- 02-§89.13 -->
-- If the event ID is not in the cookie and no valid admin token is provided,
-  the server responds with HTTP 403. <!-- 02-§89.14 -->
+- The server reads the `sb_session` cookie from the request and verifies a valid
+  ownership entry for the target event ID — or that the request body contains a
+  valid `adminToken` (§91). <!-- 02-§89.13 -->
+- If the cookie does not contain valid ownership for the event and no valid admin
+  token is provided, the server responds with HTTP 403. <!-- 02-§89.14 -->
 - If the event's date has already passed, the server responds with
   HTTP 400. <!-- 02-§89.15 -->
 - If the editing period is closed, the server responds with

--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -1216,8 +1216,9 @@ but not for server-side authorization.
 
 - The session cookie must contain ownership entries that are tamper-resistant
   for server-side authorization. <!-- 02-§101.1 -->
-- Each ownership entry must bind an event ID to an unguessable server-generated
-  proof, such as a signed capability or equivalent verifier. <!-- 02-§101.2 -->
+- Each ownership entry must bind an event ID and expiry time to an unguessable
+  server-generated proof, such as a signed capability or equivalent verifier.
+  <!-- 02-§101.2 -->
 - The cookie must remain readable by client-side JavaScript so static schedule
   pages can show edit links for events owned in the current browser.
   <!-- 02-§101.3 -->

--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -100,8 +100,9 @@ through a session-cookie-based ownership mechanism. See §18 for the full specif
 Administrators with a valid admin token (§91) can edit or remove any activity
 through the same edit and delete flows available to participants. <!-- 02-§7.2 -->
 
-A user may edit or delete an event if the event ID is present in their session
-cookie (ownership) **or** the user holds a valid admin token. <!-- 02-§7.3 -->
+A user may edit or delete an event if their session cookie contains a valid
+signed ownership entry for that event **or** the user holds a valid admin
+token. <!-- 02-§7.3 -->
 
 ---
 
@@ -1199,3 +1200,53 @@ schedule. Issue #332 (Session 2).
   `.event-detail` container, after the location/responsible row and
   any external-link row, and before the `.event-description` block.
   <!-- 02-§99.17 -->
+
+---
+
+## 101. Signed Session Ownership
+
+### 101.1 Context
+
+The `sb_session` cookie lets participants find, edit, and delete activities
+they submitted from the same browser. Event IDs are public because the schedule
+and `events.json` expose them, so a plain event-ID list is suitable for UI hints
+but not for server-side authorization.
+
+### 101.2 Ownership cookie format
+
+- The session cookie must contain ownership entries that are tamper-resistant
+  for server-side authorization. <!-- 02-§101.1 -->
+- Each ownership entry must bind an event ID to an unguessable server-generated
+  proof, such as a signed capability or equivalent verifier. <!-- 02-§101.2 -->
+- The cookie must remain readable by client-side JavaScript so static schedule
+  pages can show edit links for events owned in the current browser.
+  <!-- 02-§101.3 -->
+- The cookie must keep the existing security attributes: `Path=/`,
+  `Max-Age=604800`, `Secure`, `SameSite=Strict`, and `Domain` when configured.
+  <!-- 02-§101.4 -->
+
+### 101.3 Server-side authorization
+
+- `POST /edit-event` must authorize participant edits only when the request
+  includes a valid ownership entry for the target event ID. <!-- 02-§101.5 -->
+- `POST /delete-event` must authorize participant deletes only when the request
+  includes a valid ownership entry for the target event ID. <!-- 02-§101.6 -->
+- A manually constructed cookie containing only a public event ID must not grant
+  edit or delete permission. <!-- 02-§101.7 -->
+- Invalid, malformed, expired, or unverifiable ownership entries must be ignored
+  for authorization. <!-- 02-§101.8 -->
+- Administrators with a valid admin token must retain the existing ability to
+  edit or delete any activity. <!-- 02-§101.9 -->
+
+### 101.4 Cookie lifecycle and compatibility
+
+- When an activity is submitted and cookie consent is accepted, the response
+  must store a valid ownership entry for each submitted event. <!-- 02-§101.10 -->
+- Existing valid ownership entries must be preserved and deduplicated when
+  another event is stored in the cookie. <!-- 02-§101.11 -->
+- Legacy cookies that contain only event ID strings may be read for client-side
+  display or cleanup, but they must not authorize edit or delete requests.
+  <!-- 02-§101.12 -->
+- The edit page's cookie debug panel must describe unverifiable legacy entries
+  clearly enough that users understand why those events may not be editable.
+  <!-- 02-§101.13 -->

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -336,12 +336,12 @@ that supports Node.js.
 ### 44.5 Session cookies (site requirements)
 
 - The PHP API must read and write the `sb_session` cookie using the same
-  format (JSON-encoded array of event IDs, URL-encoded) as the Node.js
+  format (URL-encoded JSON array of ownership entries) as the Node.js
   implementation. <!-- 02-§44.15 -->
 - Cookie attributes must match: `Path=/`, `Max-Age=604800`, `Secure`,
   `SameSite=Strict`, and optional `Domain` when `COOKIE_DOMAIN` is set. <!-- 02-§44.16 -->
-- Edit requests must verify that the event ID is present in the session
-  cookie; return HTTP 403 if not. <!-- 02-§44.17 -->
+- Edit requests must verify that the session cookie contains valid ownership
+  for the target event; return HTTP 403 if not. <!-- 02-§44.17 -->
 - The cookie is only set when the client signals consent
   (`cookieConsent: true` in the request body). <!-- 02-§44.18 -->
 

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -336,8 +336,8 @@ that supports Node.js.
 ### 44.5 Session cookies (site requirements)
 
 - The PHP API must read and write the `sb_session` cookie using the same
-  format (URL-encoded JSON array of ownership entries) as the Node.js
-  implementation. <!-- 02-§44.15 -->
+  format (URL-encoded JSON array of `{ id, exp, sig }` ownership entries) as
+  the Node.js implementation. <!-- 02-§44.15 -->
 - Cookie attributes must match: `Path=/`, `Max-Age=604800`, `Secure`,
   `SameSite=Strict`, and optional `Domain` when `COOKIE_DOMAIN` is set. <!-- 02-§44.16 -->
 - Edit requests must verify that the session cookie contains valid ownership

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -28,19 +28,22 @@ that requires no login.
 ### 18.1 Ownership and session cookie
 
 - When a participant's event is successfully created, the server sets a session
-  cookie in the response containing the new event's ID. <!-- 02-§18.1 -->
-- The session cookie stores a JSON array of event IDs the current browser owns. <!-- 02-§18.2 -->
-- The cookie has a `Max-Age` of 7 days; submitting another event updates (extends) it. <!-- 02-§18.3 -->
+  cookie in the response containing an ownership entry for the event. <!-- 02-§18.1 -->
+- The session cookie stores a JSON array of ownership entries for events the
+  current browser owns; see §101 for the signed authorization format. <!-- 02-§18.2 -->
+- The cookie has a `Max-Age` of 7 days; submitting another event refreshes the
+  cookie lifetime. <!-- 02-§18.3 -->
 - The cookie uses the `Secure` flag (HTTPS only) and `SameSite=Strict` to prevent
   cross-site misuse. <!-- 02-§18.4 -->
 - **The session cookie is intentionally JavaScript-readable (not `httpOnly`).**
   Because the schedule pages are static HTML pre-rendered at build time, client-side
   JavaScript is the only layer that can read the cookie and show or hide edit links
-  per event. Server-side validation on every edit request compensates for the
-  absence of `httpOnly`. This trade-off is explicit and documented. <!-- 02-§18.5 -->
+  per event. Server-side validation of signed ownership on every edit/delete
+  request compensates for the absence of `httpOnly`. This trade-off is explicit
+  and documented. <!-- 02-§18.5 -->
 - The session cookie is initially set only by the server. Client-side JavaScript
   may write back the cookie solely during expiry cleanup (§18.14), but must never
-  create a new session or add event IDs. <!-- 02-§18.6 -->
+  create ownership proof or add unauthorized ownership entries. <!-- 02-§18.6 -->
 - The cookie name is `sb_session`. <!-- 02-§18.7 -->
 - When the API server and the static site are deployed on different subdomains
   (e.g. `api.sommar.example.com` and `sommar.example.com`), the session cookie
@@ -67,9 +70,9 @@ that requires no login.
 ### 18.3 Expiry management
 
 - On every page load, client-side JavaScript reads the session cookie and removes
-  any event IDs whose date has already passed. <!-- 02-§18.13 -->
-- The cleaned cookie is written back. If no event IDs remain after cleaning, the
-  cookie is deleted. <!-- 02-§18.14 -->
+  ownership entries for events whose date has already passed. <!-- 02-§18.13 -->
+- The cleaned cookie is written back. If no ownership entries remain after
+  cleaning, the cookie is deleted. <!-- 02-§18.14 -->
 - When the client writes back the cleaned cookie, it must include the same
   `Domain` attribute the server used. The domain value is injected at build time
   via a `data-cookie-domain` attribute on the `<body>` element. If the attribute
@@ -78,16 +81,17 @@ that requires no login.
   it as a `data-cookie-domain` attribute on the `<body>` element of every page
   that loads `session.js`. <!-- 02-§18.48 -->
 - "Passed" means the event's date is strictly before today's local date. <!-- 02-§18.15 -->
-- Event IDs present in the session cookie but not found in `events.json` must be
-  kept — not removed. A newly-submitted event may not yet appear in the JSON
-  because the event-data deploy is still in progress. Removing unknown IDs would
-  silently discard the session cookie the server just set. <!-- 02-§18.49 -->
+- Ownership entries present in the session cookie but not found in `events.json`
+  must be kept — not removed. A recently submitted event may not yet appear in
+  the JSON because the event-data deploy is still in progress. Removing unknown
+  entries would silently discard the session cookie the server just set.
+  <!-- 02-§18.49 -->
 
 ### 18.4 Edit links on schedule pages
 
-- Schedule pages add an "Redigera" link next to each event whose ID is present
-  in the session cookie **or** whose user holds a valid admin token (§91), and
-  whose date has not passed. <!-- 02-§18.16 -->
+- Schedule pages add an "Redigera" link next to each event with an ownership
+  entry in the session cookie **or** whose user holds a valid admin token (§91),
+  and whose date has not passed. <!-- 02-§18.16 -->
 - The link is injected by client-side JavaScript after page load; it is never
   part of the static HTML. <!-- 02-§18.17 -->
 - Each event row in the generated HTML carries a `data-event-id` attribute
@@ -110,12 +114,12 @@ that requires no login.
 ### 18.5 Edit form
 
 - An edit page exists at `/redigera.html`. <!-- 02-§18.20 -->
-- When loaded, it reads the `id` query parameter, checks the session cookie,
-  and fetches `/events.json` to pre-populate the form with the event's current
-  values. <!-- 02-§18.21 -->
-- If the event ID is not in the session cookie and the user does not hold a
-  valid admin token (§91), or the event has already passed, the page shows a
-  clear error and no form is rendered. <!-- 02-§18.22 -->
+- When loaded, it reads the `id` query parameter, checks the session cookie for
+  a matching ownership entry, and fetches `/events.json` to pre-populate the form
+  with the event's current values. <!-- 02-§18.21 -->
+- If the event has no matching ownership entry in the session cookie and the user
+  does not hold a valid admin token (§91), or the event has already passed, the
+  page shows a clear error and no form is rendered. <!-- 02-§18.22 -->
 - The edit form exposes the same fields as the add-activity form (title, date,
   start time, end time, location, responsible person, description, link). <!-- 02-§18.23 -->
 - The event's stable `id` must not change after creation, even when mutable
@@ -137,11 +141,11 @@ that requires no login.
 ### 18.10 Server-side edit endpoint
 
 - A `POST /edit-event` endpoint accepts edit requests. <!-- 02-§18.30 -->
-- The server reads the `sb_session` cookie from the request, parses the event
-  ID array, and verifies the target event ID is present — or that the request
-  body contains a valid `adminToken` (§91). <!-- 02-§18.31 -->
-- If the event ID is not in the cookie and no valid admin token is provided,
-  the server responds with HTTP 403. <!-- 02-§18.32 -->
+- The server reads the `sb_session` cookie from the request and verifies a valid
+  ownership entry for the target event ID — or that the request body contains a
+  valid `adminToken` (§91). <!-- 02-§18.31 -->
+- If the cookie does not contain valid ownership for the event and no valid admin
+  token is provided, the server responds with HTTP 403. <!-- 02-§18.32 -->
 - If the event's date has already passed, the server responds with HTTP 400. <!-- 02-§18.33 -->
 - If validation passes, the server reads the YAML file from GitHub, replaces the
   target event's mutable fields in place, and commits the change via an ephemeral

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -31,8 +31,9 @@ that requires no login.
   cookie in the response containing an ownership entry for the event. <!-- 02-§18.1 -->
 - The session cookie stores a JSON array of ownership entries for events the
   current browser owns; see §101 for the signed authorization format. <!-- 02-§18.2 -->
-- The cookie has a `Max-Age` of 7 days; submitting another event refreshes the
-  cookie lifetime. <!-- 02-§18.3 -->
+- The cookie has a `Max-Age` of 7 days; each ownership entry carries the same
+  signed expiry horizon, and submitting another event refreshes both the cookie
+  lifetime and existing valid ownership entries. <!-- 02-§18.3 -->
 - The cookie uses the `Secure` flag (HTTPS only) and `SameSite=Strict` to prevent
   cross-site misuse. <!-- 02-§18.4 -->
 - **The session cookie is intentionally JavaScript-readable (not `httpOnly`).**

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -16,7 +16,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | ---- | ----- | -------- |
 | [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
-| [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99 |
+| [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -19,7 +19,7 @@ date passes. No server-side session store is used.
 | Property | Value |
 | --- | --- |
 | Name | `sb_session` |
-| Content | JSON array of event ID strings |
+| Content | JSON array of ownership entries (`{ id, sig }`) |
 | Max-Age | 7 days (604 800 s) |
 | Secure | Yes (HTTPS only) |
 | SameSite | Strict |
@@ -30,33 +30,38 @@ The schedule pages are static HTML, pre-rendered at build time. There is no
 server-side rendering at request time. Client-side JavaScript is therefore the
 only layer that can read the cookie and selectively show edit links for events
 the current visitor owns. Making the cookie `httpOnly` would prevent this.
-Security is maintained through server-side validation: the `/edit-event` endpoint
-always verifies that the target event ID appears in the cookie sent with the
-request. An attacker who cannot forge a session cookie they do not have cannot
-edit events they do not own.
+Security is maintained through server-side validation: edit and delete endpoints
+verify that the cookie contains a signed ownership entry for the target event.
+The signature uses a server-side `SESSION_SECRET`, so a caller can read the
+event ID for UI purposes without being able to mint ownership for public IDs.
+
+Legacy cookies that contain plain event ID strings may be read by the client for
+display or cleanup, but the server treats them as unauthorised for edit/delete.
 
 ### Cookie lifecycle
 
 1. User submits the add-activity form and accepts cookie consent.
 2. Server validates the event, responds with `Set-Cookie: sb_session=…`.
-3. The cookie contains the new event's ID merged with any IDs already in
-   the existing cookie.
+3. The cookie contains the event's signed ownership entry merged with any
+   existing valid ownership entries.
 4. On every page load, `source/assets/js/client/session.js` reads the
-   cookie, removes IDs for events whose dates have passed, and writes the
-   cleaned cookie back (or deletes it if the array becomes empty).
+   cookie, removes entries for events whose dates have passed, and writes the
+   cleaned cookie back (or deletes it if the array becomes empty). The client
+   preserves each entry's signature; it never creates new signatures.
    The write-back must include the same `Domain` attribute the server used,
    read from a `data-cookie-domain` attribute injected on `<body>` at build time.
 5. Before the expiry cleanup, `session.js` detects duplicate `sb_session`
    cookies (e.g. one with `Domain` and one without, caused by a historical
-   bug in `removeIdFromCookie`). If duplicates are found, all ID arrays are
-   merged and deduplicated, both cookie variants are deleted, and a single
+   bug in `removeIdFromCookie`). If duplicates are found, all ownership entries
+   are merged and deduplicated, both cookie variants are deleted, and a single
    correct cookie is written back. This repair is transparent to the user.
 6. Schedule pages read the cookie and attach "Redigera" links to matching
    event rows.
 7. The edit page (`redigera.html`) includes a collapsible "Om din cookie"
    section that displays the cookie contents: protocol, cookie domain,
-   stored event IDs with their status (active / expired / not found in
-   schema), and whether automatic repair was performed.
+   stored event ownership entries with their status (active / expired / not
+   found in schema / legacy-unverifiable), and whether automatic repair was
+   performed.
 
 ### /events.json
 
@@ -70,7 +75,7 @@ form with current event data.
 `POST /edit-event` handles edit submissions:
 
 1. Read and parse the `sb_session` cookie from the request.
-2. Confirm the target event ID is in the cookie array **or** that the
+2. Confirm the target event ID has a valid signed ownership entry **or** that the
    request body contains a valid `adminToken`.
 3. Validate the submitted fields (same rules as `POST /add-event`).
 4. Confirm the event's date has not passed.
@@ -87,7 +92,7 @@ flowchart TD
     C -->|Yes| E[Fetch /events.json · pre-populate form]
     E --> F[User edits and submits]
     F --> G["POST /edit-event (server)"]
-    G --> H{Cookie ownership OR valid adminToken? + fields + date not passed}
+    G --> H{Signed cookie ownership OR valid adminToken? + fields + date not passed}
     H -->|Fail| I[HTTP 400/403]
     H -->|Pass| J[GitHub API: read camp YAML]
     J --> K[Replace event fields · update meta.updated_at]
@@ -196,8 +201,8 @@ ephemeral-branch → PR → auto-merge pipeline as additions and edits.
 
 ```text
 POST /delete-event  { id }
-  ├─ parse sb_session cookie → owned IDs
-  ├─ reject if id not in cookie → 403
+  ├─ verify sb_session signed ownership for id
+  ├─ reject if no valid ownership/admin token → 403
   ├─ reject if editing period closed → 400
   ├─ reject if event date < today → 400
   └─ removeEventFromActiveCamp(id)

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -19,7 +19,7 @@ date passes. No server-side session store is used.
 | Property | Value |
 | --- | --- |
 | Name | `sb_session` |
-| Content | JSON array of ownership entries (`{ id, sig }`) |
+| Content | JSON array of ownership entries (`{ id, exp, sig }`) |
 | Max-Age | 7 days (604 800 s) |
 | Secure | Yes (HTTPS only) |
 | SameSite | Strict |
@@ -32,8 +32,9 @@ only layer that can read the cookie and selectively show edit links for events
 the current visitor owns. Making the cookie `httpOnly` would prevent this.
 Security is maintained through server-side validation: edit and delete endpoints
 verify that the cookie contains a signed ownership entry for the target event.
-The signature uses a server-side `SESSION_SECRET`, so a caller can read the
-event ID for UI purposes without being able to mint ownership for public IDs.
+The signature uses a server-side `SESSION_SECRET` and covers both `id` and
+`exp`, so a caller can read the event ID for UI purposes without being able to
+mint ownership for public IDs or extend an expired ownership entry.
 
 Legacy cookies that contain plain event ID strings may be read by the client for
 display or cleanup, but the server treats them as unauthorised for edit/delete.
@@ -43,7 +44,8 @@ display or cleanup, but the server treats them as unauthorised for edit/delete.
 1. User submits the add-activity form and accepts cookie consent.
 2. Server validates the event, responds with `Set-Cookie: sb_session=…`.
 3. The cookie contains the event's signed ownership entry merged with any
-   existing valid ownership entries.
+   existing valid ownership entries. Existing valid entries are reissued so
+   their signed expiry matches the refreshed cookie lifetime.
 4. On every page load, `source/assets/js/client/session.js` reads the
    cookie, removes entries for events whose dates have passed, and writes the
    cleaned cookie back (or deletes it if the array becomes empty). The client

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -153,8 +153,9 @@ flowchart TD
 | `GITHUB_BRANCH`  | —       | Branch to commit events to (typically `main`)            |
 | `GITHUB_TOKEN`   | —       | Personal access token with repo write access             |
 | `ADMIN_TOKENS`   | —       | Comma-separated admin tokens (UUIDs). Omit to disable.   |
+| `SESSION_SECRET` | —       | Secret signing key for participant ownership cookies.    |
 
-`API_URL`, `ALLOWED_ORIGIN`, `COOKIE_DOMAIN`, `GITHUB_*`, and SSH credentials are stored as GitHub Actions secrets and server environment variables. They are not needed for local development. Without `API_URL` set, the built form will have no submit endpoint — this is expected in local builds. Without `GITHUB_*` set, event submission via the API will fail; all other functionality works normally.
+`API_URL`, `ALLOWED_ORIGIN`, `COOKIE_DOMAIN`, `GITHUB_*`, `SESSION_SECRET`, and SSH credentials are stored as GitHub Actions secrets and server environment variables. They are not needed for local development. Without `API_URL` set, the built form will have no submit endpoint — this is expected in local builds. Without `GITHUB_*` set, event submission via the API will fail; all other functionality works normally.
 
 **`COOKIE_DOMAIN`**: required when the API and the static site are deployed on different subdomains (e.g. `api.sommar.example.com` and `sommar.example.com`). Set it to the shared parent domain — e.g. `sommar.digitalasynctransparency.com`. This causes the session cookie to include `Domain=<value>` so that client-side JavaScript on the static site can read it. Omit the variable for single-origin deployments.
 

--- a/docs/06-EVENT_DATA_MODEL.md
+++ b/docs/06-EVENT_DATA_MODEL.md
@@ -91,16 +91,17 @@ Initial state:
 - Fields may be empty strings.
 - Email is not yet used.
 - Email is not publicly displayed.
-- Ownership logic is not implemented.
+- Participant edit/delete ownership is carried by the signed `sb_session`
+  cookie, not by the public event YAML.
 
 This structure allows future:
 
-- Self-editing functionality
 - Token-based editing links
 - Week-based session validation
-- Ownership verification
+- Optional server-side ownership records
 
-Ownership design will be defined separately.
+The YAML `owner` object remains internal metadata and is not used as public
+authorization state.
 
 ---
 

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -100,6 +100,7 @@ the secrets.
 | `SERVER_SSH_PORT`       | QA SSH port                                                                                                                                             |
 | `DEPLOY_DIR`            | QA deploy directory                                                                                                                                     |
 | `ADMIN_TOKENS`          | Comma-separated list of admin tokens (format: `namn_uuid_epoch`). Optional — omit to disable admin features. Create tokens with `npm run admin:create`. |
+| `SESSION_SECRET`        | Secret signing key for participant event-ownership cookies. Must differ between QA and Production.                                                       |
 
 Example values: `SITE_URL=https://qa.sbsommar.se`,
 `API_URL=https://qa.sbsommar.se/api/add-event`.
@@ -107,8 +108,9 @@ Example values: `SITE_URL=https://qa.sbsommar.se`,
 The PHP API is deployed alongside the static site via SCP. Its `.env` file
 on the server is managed manually and lives at `$DEPLOY_DIR/.env` — outside
 the web root, never under `public_html/api` (§100). It contains the
-`GITHUB_*`, `ALLOWED_ORIGIN`, `QA_ORIGIN`, `COOKIE_DOMAIN`, `BUILD_ENV`, and
-`ADMIN_TOKENS` variables needed by the PHP API at runtime.
+`GITHUB_*`, `ALLOWED_ORIGIN`, `QA_ORIGIN`, `COOKIE_DOMAIN`, `BUILD_ENV`,
+`ADMIN_TOKENS`, and `SESSION_SECRET` variables needed by the PHP API at
+runtime.
 
 ### GitHub Environment: `production`
 
@@ -125,6 +127,7 @@ Same secret names as `qa` (including `ADMIN_TOKENS`), but with production values
 | `SERVER_SSH_KEY`  | Production SSH private key                            |
 | `SERVER_SSH_PORT` | Production SSH port                                   |
 | `DEPLOY_DIR`      | Production deploy directory                           |
+| `SESSION_SECRET`  | Secret signing key for participant event-ownership cookies |
 
 ---
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -111,13 +111,13 @@ Part of [the traceability index](./index.md).
 | `02-§2.11` | Edit-activity page exists at `/redigera.html` | 03-architecture/forms-and-api.md §7 | REDT-01..03 | `source/build/render-edit.js` → `public/redigera.html` | covered |
 | `02-§7.1` | Participants can edit their own active events (events not yet passed) via session-cookie ownership | 03-architecture/forms-and-api.md §7 | — | `app.js` – `POST /edit-event`; `source/assets/js/client/session.js`; `source/assets/js/client/redigera.js` | implemented |
 | `02-§7.2` | Administrators with a valid admin token (§91) can edit or remove any activity through the same edit and delete flows available to participants | 03-architecture/forms-and-api.md §7, §9 | — | `app.js` – admin token OR in `/edit-event` and `/delete-event`; `session.js` – `injectEditLinks()` for admins; `redigera.js` – admin bypass | implemented |
-| `02-§7.3` | A user may edit or delete an event if the event ID is in their session cookie (ownership) or the user holds a valid admin token | 03-architecture/forms-and-api.md §7 | ADED-01..08 | `app.js` – `parseSessionIds()` + ownership check OR `verifyAdminToken()`, 403 on failure | covered |
-| `02-§18.1` | When an event is successfully created, the server sets the `sb_session` cookie containing the new event ID | 03-architecture/forms-and-api.md §7 | SES-06..09 | `app.js` – `POST /add-event` sets `Set-Cookie` via `buildSetCookieHeader(mergeIds(…))` | covered |
-| `02-§18.2` | The session cookie stores a JSON array of event IDs the current browser owns | 03-architecture/forms-and-api.md §7 | SES-03 | `source/api/session.js` – `parseSessionIds()`, `buildSetCookieHeader()` | covered |
-| `02-§18.3` | The session cookie has Max-Age of 7 days; submitting another event updates and extends it | 03-architecture/forms-and-api.md §7 | SES-07, SES-10..13 | `source/api/session.js` – `MAX_AGE_SECONDS = 604800`; `mergeIds()` | covered |
+| `02-§7.3` | A user may edit or delete an event if their session cookie contains valid signed ownership for the event or the user holds a valid admin token | 03-architecture/forms-and-api.md §7 | — | Planned: signed ownership verification in Node/PHP session helpers and edit/delete handlers | gap |
+| `02-§18.1` | When an event is successfully created, the server sets the `sb_session` cookie containing an ownership entry for the event | 03-architecture/forms-and-api.md §7 | — | Planned: add-event/add-events build signed ownership entries | gap |
+| `02-§18.2` | The session cookie stores a JSON array of ownership entries for events the current browser owns | 03-architecture/forms-and-api.md §7 | — | Planned: `source/api/session.js`, `api/src/Session.php` ownership-entry format | gap |
+| `02-§18.3` | The session cookie has Max-Age of 7 days; submitting another event refreshes the cookie lifetime | 03-architecture/forms-and-api.md §7 | — | Planned: ownership-entry merge preserves Max-Age behavior | gap |
 | `02-§18.4` | The session cookie uses the `Secure` flag (HTTPS only) and `SameSite=Strict` | 03-architecture/forms-and-api.md §7 | SES-08, SES-09, EEC-20..21 | `source/api/session.js` – `buildSetCookieHeader()` | covered |
-| `02-§18.5` | The session cookie is JavaScript-readable (not httpOnly) — documented trade-off; server-side validation compensates | 03-architecture/forms-and-api.md §7 | EEC-26 | By design: `buildSetCookieHeader()` omits `HttpOnly`; server validates ownership on every edit | covered |
-| `02-§18.6` | The session cookie is set only by the server, never written directly by client-side JS | 03-architecture/forms-and-api.md §7 | — | `app.js` sets `Set-Cookie`; `session.js` only re-writes the client-readable cookie after expiry cleanup | implemented |
+| `02-§18.5` | The session cookie is JavaScript-readable (not httpOnly); server-side validation of signed ownership compensates | 03-architecture/forms-and-api.md §7 | — | Planned: readable entries with server-verified signatures | gap |
+| `02-§18.6` | The session cookie is initially set only by the server; client cleanup never creates ownership proof | 03-architecture/forms-and-api.md §7 | — | Planned: client preserves signatures during cleanup only | gap |
 | `02-§18.7` | The session cookie name is `sb_session` | 03-architecture/forms-and-api.md §7 | SES-06, EEC-18 | `source/api/session.js` – `COOKIE_NAME = 'sb_session'` | covered |
 | `02-§18.41` | When API and static site are on different subdomains, the session cookie must include `Domain` covering the shared parent domain, supplied via `COOKIE_DOMAIN` env var; omitted for single-origin deployments | 03-architecture/forms-and-api.md §7 | SES-14, SES-15 | `source/api/session.js` – `buildSetCookieHeader(ids, domain)`; `app.js` – passes `process.env.COOKIE_DOMAIN` | covered |
 | `02-§18.8` | Before setting the session cookie, the client displays a modal consent prompt on the add-activity form | 03-architecture/forms-and-api.md §7 | — (manual: submit form without prior consent and confirm modal appears) | `source/assets/js/client/cookie-consent.js` – `showConsentModal()` | implemented |
@@ -125,11 +125,11 @@ Part of [the traceability index](./index.md).
 | `02-§18.10` | If the user declines consent, the event is still submitted but no session cookie is set | 03-architecture/forms-and-api.md §7 | — | `lagg-till.js` passes `cookieConsent: false`; `app.js` skips `Set-Cookie` | implemented |
 | `02-§18.11` | Only an accepted consent decision is stored in `localStorage` as `sb_cookie_consent`; declining is not persisted so the user can change their mind | 03-architecture/forms-and-api.md §7 | — | `cookie-consent.js` – `saveConsent()` stores only `'accepted'`; decline handler omits `saveConsent()` | implemented |
 | `02-§18.12` | The consent prompt is written in Swedish | 02-requirements/platform-security.md §14 | — | `cookie-consent.js` – banner innerHTML is Swedish text | implemented |
-| `02-§18.13` | On every page load, JS removes event IDs from the cookie whose date has already passed | 03-architecture/forms-and-api.md §7 | — | `session.js` – `removeExpiredIds()` called on load | implemented |
-| `02-§18.14` | After cleaning, if no IDs remain the cookie is deleted; otherwise the cleaned cookie is written back | 03-architecture/forms-and-api.md §7 | — | `session.js` – `writeSessionIds([])` sets `Max-Age=0` | implemented |
+| `02-§18.13` | On every page load, JS removes ownership entries for events whose date has already passed | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` cleans ownership entries by `id` | gap |
+| `02-§18.14` | After cleaning, if no ownership entries remain the cookie is deleted; otherwise the cleaned cookie is written back | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` writes ownership entries and preserves signatures | gap |
 | `02-§18.15` | "Passed" means the event date is strictly before today's local date | 03-architecture/forms-and-api.md §7 | EDIT-01..03 | `source/api/edit-event.js` – `isEventPast()`; `session.js` – `date >= today` | covered |
 | `02-§18.49` | Event IDs in the session cookie but not found in `events.json` must be kept, not removed — newly-submitted events may not yet appear in the JSON | 03-architecture/forms-and-api.md §7 | — (manual: submit event, navigate to schema before deploy completes, verify cookie still contains new ID) | `session.js` – `removeExpiredIds()` keeps unknown IDs | implemented |
-| `02-§18.16` | Schedule pages show a "Redigera" link for events the visitor owns (in cookie) or for which the visitor holds a valid admin token, and that have not passed | 03-architecture/forms-and-api.md §7 | — (manual: activate admin token, open schema.html, verify all future events show "Redigera" link) | `session.js` – `injectEditLinks(active, isAdmin)` with admin branch for all `[data-event-id]` rows | implemented |
+| `02-§18.16` | Schedule pages show a "Redigera" link for events with ownership entries or valid admin token, and that have not passed | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` reads ownership entries for UI hints | gap |
 | `02-§18.17` | Edit links are injected by client-side JS; they are never part of the static HTML | 03-architecture/forms-and-api.md §7 | — | `source/build/render.js` – no edit links at build time; `session.js` injects at runtime | implemented |
 | `02-§18.18` | Event rows in generated HTML carry a `data-event-id` attribute with the event's stable ID | 03-architecture/forms-and-api.md §7 | RND-46, RND-47 | `source/build/render.js` – `renderEventRow()` adds `data-event-id` | covered |
 | `02-§18.19` | The "Redigera" link navigates to `/redigera.html?id={eventId}` | 03-architecture/forms-and-api.md §7 | — | `session.js` – `link.href = 'redigera.html?id=' + encodeURIComponent(id)` | implemented |
@@ -137,8 +137,8 @@ Part of [the traceability index](./index.md).
 | `02-§18.43` | The events JSON embedded in `idag.html` includes the event `id` field | 03-architecture/forms-and-api.md §7 | IDAG-01, IDAG-02 | `source/build/render-idag.js` – `id: e.id \|\| null` in events map | covered |
 | `02-§18.44` | Event rows rendered dynamically on `idag.html` carry `data-event-id` and `data-event-date` attributes for edit-link injection | 03-architecture/forms-and-api.md §7 | — | `source/assets/js/client/events-today.js` – `idAttr`/`dateAttr` added to both row types; browser-only: verify manually (open idag.html, run `document.querySelectorAll('[data-event-id]')` in console) | implemented |
 | `02-§18.20` | An edit page exists at `/redigera.html` | 03-architecture/forms-and-api.md §7 | REDT-01..03 | `source/build/render-edit.js` → `public/redigera.html` | covered |
-| `02-§18.21` | The edit page reads the `id` query param, checks the cookie, and fetches `/events.json` to pre-populate the form | 03-architecture/forms-and-api.md §7 | — | `redigera.js` – `getParam()`, `readSessionIds()`, `fetch('/events.json')`, `populate()` | implemented |
-| `02-§18.22` | If the event ID is not in the cookie and the user has no valid admin token, or the event has passed, the edit page shows an error and no form | 03-architecture/forms-and-api.md §7 | — (manual: open redigera.html?id=xxx without cookie or admin token, verify error shown) | `redigera.js` – `showError()` when ID not in cookie and `!adminToken`, or `event.date < today` | implemented |
+| `02-§18.21` | The edit page reads the `id` query param, checks for a matching ownership entry, and fetches `/events.json` to pre-populate the form | 03-architecture/forms-and-api.md §7 | — | Planned: `redigera.js` reads ownership-entry IDs | gap |
+| `02-§18.22` | If the event has no matching ownership entry and the user has no valid admin token, or the event has passed, the edit page shows an error and no form | 03-architecture/forms-and-api.md §7 | — | Planned: client UI check mirrors ownership-entry format; server remains authority | gap |
 | `02-§18.23` | The edit form exposes the same fields as the add-activity form | 03-architecture/forms-and-api.md §7 | REDT-04..11 | `source/build/render-edit.js` – all add-activity fields present | covered |
 | `02-§18.24` | The event's stable `id` must not change after creation even when mutable fields are edited | 06-EVENT_DATA_MODEL.md §4 | EDIT-13 | `source/api/edit-event.js` – `patchEventInYaml()` preserves `event.id` | covered |
 | `02-§18.25` | The edit form is subject to the same validation rules as the add-activity form (§9) | 03-architecture/forms-and-api.md §7 | VLD-27..32 | `source/api/validate.js` – `validateEditRequest()`; `redigera.js` client-side validate | covered |
@@ -147,8 +147,8 @@ Part of [the traceability index](./index.md).
 | `02-§18.28` | A static `/events.json` file is generated at build time containing all events for the active camp | 03-architecture/forms-and-api.md §7 | — | `source/build/build.js` – writes `public/events.json` | implemented |
 | `02-§18.29` | `/events.json` contains only public fields (id, title, date, start, end, location, responsible, description, link); owner and meta are excluded | 03-architecture/forms-and-api.md §7 | STR-JSON-01..02 | `build.js` – `PUBLIC_EVENT_FIELDS` array | covered |
 | `02-§18.30` | A `POST /edit-event` endpoint accepts edit requests | 03-architecture/forms-and-api.md §7 | — | `app.js` – `app.post('/edit-event', …)` | implemented |
-| `02-§18.31` | The server reads `sb_session` and verifies the target ID is present, or that the request body contains a valid `adminToken` (§91) | 03-architecture/forms-and-api.md §7 | ADED-01..08 | `app.js` – `parseSessionIds(req.headers.cookie)` + `ownedIds.includes(eventId)` OR `verifyAdminToken(req.body.adminToken, adminTokens)` | covered |
-| `02-§18.32` | If the event ID is not in the cookie and no valid admin token is provided, the server responds with HTTP 403 | 03-architecture/forms-and-api.md §7 | ADED-04..07 | `app.js` – `res.status(403)` when `!ownedIds.includes(eventId) && !isAdmin` | covered |
+| `02-§18.31` | The server reads `sb_session` and verifies valid ownership for the target ID, or that the request body contains a valid `adminToken` (§91) | 03-architecture/forms-and-api.md §7 | — | Planned: signed ownership verification in `app.js` and PHP API | gap |
+| `02-§18.32` | If the cookie lacks valid ownership and no valid admin token is provided, the server responds with HTTP 403 | 03-architecture/forms-and-api.md §7 | — | Planned: forged/legacy cookies rejected server-side | gap |
 | `02-§18.33` | If the event's date has already passed, the server responds with HTTP 400 | 03-architecture/forms-and-api.md §7 | EDIT-01..03 | `app.js` – `isEventPast(req.body.date)` → `res.status(400)` | covered |
 | `02-§18.34` | On a valid edit, the server reads YAML from GitHub, replaces mutable fields, commits via ephemeral branch + PR with auto-merge | 03-architecture/forms-and-api.md §7 | EDIT-04..17 | `source/api/github.js` – `updateEventInActiveCamp()`; `edit-event.js` – `patchEventInYaml()` | covered |
 | `02-§18.35` | The event's `meta.updated_at` is updated on every successful edit | 06-EVENT_DATA_MODEL.md §6 | EDIT-15 | `source/api/edit-event.js` – `patchEventInYaml()` sets `meta.updated_at = now` | covered |
@@ -566,9 +566,9 @@ Part of [the traceability index](./index.md).
 | `02-§44.12` | Edit requests patch existing event in YAML | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/GitHub.php` | implemented |
 | `02-§44.13` | Active camp resolved from camps.yaml on GitHub | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/ActiveCamp.php` | implemented |
 | `02-§44.14` | YAML serialisation compatible with data contract | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/GitHub.php` | implemented |
-| `02-§44.15` | Reads and writes sb_session cookie (JSON array, URL-encoded) | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/Session.php` | implemented |
+| `02-§44.15` | PHP API reads and writes `sb_session` using the same URL-encoded JSON ownership-entry format as Node.js | 03-architecture/ci-and-deploy.md §21 | — | Planned: align `api/src/Session.php` with Node session helper | gap |
 | `02-§44.16` | Cookie attributes match Node.js (Path, Max-Age, Secure, SameSite, Domain) | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/Session.php` | implemented |
-| `02-§44.17` | Edit requests verify event ID in session cookie; 403 if not | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
+| `02-§44.17` | Edit requests verify valid cookie ownership for the target event; 403 if not | 03-architecture/ci-and-deploy.md §21 | — | Planned: PHP edit handler verifies signed ownership entries | gap |
 | `02-§44.18` | Cookie only set when cookieConsent is true | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
 | `02-§44.19` | CORS headers set for ALLOWED_ORIGIN and QA_ORIGIN | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
 | `02-§44.20` | OPTIONS preflight returns 204 with CORS headers | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
@@ -1045,7 +1045,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§80.16` | manual | All events committed in single branch and PR (integration) |
 | `02-§80.17` | BATCH-08 | Response includes eventIds array |
 | `02-§80.18` | BATCH-09 | Time-gating and injection scanning apply to batch |
-| `02-§80.19` | manual | Session cookie updated with all new event IDs (browser-only) |
+| `02-§80.19` | gap | Batch endpoint must store ownership entries for all submitted events |
 | `02-§80.20` | manual | Confirmation modal shown before every submission (browser-only) |
 | `02-§80.21` | manual | Success message states number of created activities (browser-only) |
 | `02-§80.22` | manual | Error displays message; no partial state (browser-only) |
@@ -1203,8 +1203,8 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§89.10` | manual | Browser-only: verify success modal shows "Gå till schemat" link |
 | `02-§89.11` | manual | Browser-only: verify error modal shows "Försök igen" button |
 | `02-§89.12` | implemented | app.js POST /delete-event route; api/index.php POST /delete-event route |
-| `02-§89.13` | covered | app.js reads parseSessionIds from cookie header OR verifyAdminToken from body; ADED-01..08 |
-| `02-§89.14` | covered | app.js returns 403 when event ID not in cookie and no valid admin token; ADED-04..07 |
+| `02-§89.13` | gap | Delete endpoint must verify signed ownership entry OR valid admin token |
+| `02-§89.14` | gap | Delete endpoint must return 403 when cookie ownership is invalid/missing and no valid admin token is provided |
 | `02-§89.15` | implemented | app.js returns 400 when isEventPast is true; api/index.php same |
 | `02-§89.16` | implemented | app.js returns 400 when isOutsideEditingPeriod is true; api/index.php same |
 | `02-§89.17` | covered | DEL-01–DEL-07: removeEventFromYaml tested; github.js + GitHub.php removeEventFromActiveCamp implemented |
@@ -1486,3 +1486,21 @@ refactor of `render-lokaler.js` onto the shared module).
 | `02-§100.9` | implemented | `package.json` and `api/composer.json` unchanged by this feature |
 | `02-§100.10` | implemented | Local Node API unaffected — `app.js` uses `--env-file=.env`; no PHP runs locally (manual: `npm start`) |
 | `02-§100.11` | covered | ENVLOC-04: no `.env.api.persistent`/`.env.api.bak` reference remains; supersedes §53.3 |
+
+### §101 — Signed Session Ownership
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§101.1` | gap | Session cookie must contain tamper-resistant ownership entries |
+| `02-§101.2` | gap | Each entry must bind event ID to server-generated proof |
+| `02-§101.3` | gap | Cookie remains JavaScript-readable for static schedule edit links |
+| `02-§101.4` | gap | Cookie attributes stay Path, Max-Age, Secure, SameSite, and optional Domain |
+| `02-§101.5` | gap | `POST /edit-event` must require valid ownership entry for participant edits |
+| `02-§101.6` | gap | `POST /delete-event` must require valid ownership entry for participant deletes |
+| `02-§101.7` | gap | Raw public event-ID cookies must not authorize edit/delete |
+| `02-§101.8` | gap | Invalid, malformed, expired, or unverifiable entries must be ignored |
+| `02-§101.9` | gap | Valid admin token bypass remains available |
+| `02-§101.10` | gap | Add-event responses store ownership entries when cookie consent is accepted |
+| `02-§101.11` | gap | Existing valid ownership entries are preserved and deduplicated |
+| `02-§101.12` | gap | Legacy ID-only cookies may be read for display/cleanup but not authorization |
+| `02-§101.13` | gap | Cookie debug panel describes unverifiable legacy entries clearly |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -111,13 +111,13 @@ Part of [the traceability index](./index.md).
 | `02-§2.11` | Edit-activity page exists at `/redigera.html` | 03-architecture/forms-and-api.md §7 | REDT-01..03 | `source/build/render-edit.js` → `public/redigera.html` | covered |
 | `02-§7.1` | Participants can edit their own active events (events not yet passed) via session-cookie ownership | 03-architecture/forms-and-api.md §7 | — | `app.js` – `POST /edit-event`; `source/assets/js/client/session.js`; `source/assets/js/client/redigera.js` | implemented |
 | `02-§7.2` | Administrators with a valid admin token (§91) can edit or remove any activity through the same edit and delete flows available to participants | 03-architecture/forms-and-api.md §7, §9 | — | `app.js` – admin token OR in `/edit-event` and `/delete-event`; `session.js` – `injectEditLinks()` for admins; `redigera.js` – admin bypass | implemented |
-| `02-§7.3` | A user may edit or delete an event if their session cookie contains valid signed ownership for the event or the user holds a valid admin token | 03-architecture/forms-and-api.md §7 | — | Planned: signed ownership verification in Node/PHP session helpers and edit/delete handlers | gap |
-| `02-§18.1` | When an event is successfully created, the server sets the `sb_session` cookie containing an ownership entry for the event | 03-architecture/forms-and-api.md §7 | — | Planned: add-event/add-events build signed ownership entries | gap |
-| `02-§18.2` | The session cookie stores a JSON array of ownership entries for events the current browser owns | 03-architecture/forms-and-api.md §7 | — | Planned: `source/api/session.js`, `api/src/Session.php` ownership-entry format | gap |
-| `02-§18.3` | The session cookie has Max-Age of 7 days; submitting another event refreshes the cookie lifetime | 03-architecture/forms-and-api.md §7 | — | Planned: ownership-entry merge preserves Max-Age behavior | gap |
+| `02-§7.3` | A user may edit or delete an event if their session cookie contains valid signed ownership for the event or the user holds a valid admin token | 03-architecture/forms-and-api.md §7 | ADED-01..08, SES-17..21, PSES-02 | `source/api/session.js` / `api/src/Session.php` parse verified signed ownership; `app.js` and `api/index.php` apply ownership OR admin checks | covered |
+| `02-§18.1` | When an event is successfully created, the server sets the `sb_session` cookie containing an ownership entry for the event | 03-architecture/forms-and-api.md §7 | SES-06, SES-16, PSES-03 | `app.js` `/add-event`; `api/index.php` `handleAddEvent()` set signed ownership cookies when consent is true | covered |
+| `02-§18.2` | The session cookie stores a JSON array of ownership entries for events the current browser owns | 03-architecture/forms-and-api.md §7 | SES-03, SES-16, SES-06, PSES-01 | `source/api/session.js` and `api/src/Session.php` use `{ id, exp, sig }` ownership entries | covered |
+| `02-§18.3` | The session cookie has Max-Age of 7 days; submitting another event refreshes the cookie lifetime | 03-architecture/forms-and-api.md §7 | SES-07, SES-21 | `createOwnershipEntry()` signs a 7-day expiry; add handlers reissue existing verified entries before writing `Max-Age=604800` cookie | covered |
 | `02-§18.4` | The session cookie uses the `Secure` flag (HTTPS only) and `SameSite=Strict` | 03-architecture/forms-and-api.md §7 | SES-08, SES-09, EEC-20..21 | `source/api/session.js` – `buildSetCookieHeader()` | covered |
-| `02-§18.5` | The session cookie is JavaScript-readable (not httpOnly); server-side validation of signed ownership compensates | 03-architecture/forms-and-api.md §7 | — | Planned: readable entries with server-verified signatures | gap |
-| `02-§18.6` | The session cookie is initially set only by the server; client cleanup never creates ownership proof | 03-architecture/forms-and-api.md §7 | — | Planned: client preserves signatures during cleanup only | gap |
+| `02-§18.5` | The session cookie is JavaScript-readable (not httpOnly); server-side validation of signed ownership compensates | 03-architecture/forms-and-api.md §7 | EEC-26, SES-17..21 | `buildSetCookieHeader()` omits HttpOnly; edit/delete authorization uses `parseVerifiedSessionIds()` server-side | covered |
+| `02-§18.6` | The session cookie is initially set only by the server; client cleanup never creates ownership proof | 03-architecture/forms-and-api.md §7 | — (manual/code review: verify `session.js`/`redigera.js` preserve entries and never calculate signatures) | `app.js`/`api/index.php` create signatures; `session.js` and `redigera.js` preserve and filter existing entries only | implemented |
 | `02-§18.7` | The session cookie name is `sb_session` | 03-architecture/forms-and-api.md §7 | SES-06, EEC-18 | `source/api/session.js` – `COOKIE_NAME = 'sb_session'` | covered |
 | `02-§18.41` | When API and static site are on different subdomains, the session cookie must include `Domain` covering the shared parent domain, supplied via `COOKIE_DOMAIN` env var; omitted for single-origin deployments | 03-architecture/forms-and-api.md §7 | SES-14, SES-15 | `source/api/session.js` – `buildSetCookieHeader(ids, domain)`; `app.js` – passes `process.env.COOKIE_DOMAIN` | covered |
 | `02-§18.8` | Before setting the session cookie, the client displays a modal consent prompt on the add-activity form | 03-architecture/forms-and-api.md §7 | — (manual: submit form without prior consent and confirm modal appears) | `source/assets/js/client/cookie-consent.js` – `showConsentModal()` | implemented |
@@ -125,11 +125,11 @@ Part of [the traceability index](./index.md).
 | `02-§18.10` | If the user declines consent, the event is still submitted but no session cookie is set | 03-architecture/forms-and-api.md §7 | — | `lagg-till.js` passes `cookieConsent: false`; `app.js` skips `Set-Cookie` | implemented |
 | `02-§18.11` | Only an accepted consent decision is stored in `localStorage` as `sb_cookie_consent`; declining is not persisted so the user can change their mind | 03-architecture/forms-and-api.md §7 | — | `cookie-consent.js` – `saveConsent()` stores only `'accepted'`; decline handler omits `saveConsent()` | implemented |
 | `02-§18.12` | The consent prompt is written in Swedish | 02-requirements/platform-security.md §14 | — | `cookie-consent.js` – banner innerHTML is Swedish text | implemented |
-| `02-§18.13` | On every page load, JS removes ownership entries for events whose date has already passed | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` cleans ownership entries by `id` | gap |
-| `02-§18.14` | After cleaning, if no ownership entries remain the cookie is deleted; otherwise the cleaned cookie is written back | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` writes ownership entries and preserves signatures | gap |
+| `02-§18.13` | On every page load, JS removes ownership entries for events whose date has already passed | 03-architecture/forms-and-api.md §7 | — (browser-only: open schedule with owned past event and confirm cookie cleanup) | `source/assets/js/client/session.js` – `removeExpiredEntries()` filters by event date and signed-entry expiry | implemented |
+| `02-§18.14` | After cleaning, if no ownership entries remain the cookie is deleted; otherwise the cleaned cookie is written back | 03-architecture/forms-and-api.md §7 | — (browser-only: inspect `sb_session` after schedule page cleanup) | `source/assets/js/client/session.js` – `writeSessionEntries()` deletes empty cookies or writes preserved ownership entries | implemented |
 | `02-§18.15` | "Passed" means the event date is strictly before today's local date | 03-architecture/forms-and-api.md §7 | EDIT-01..03 | `source/api/edit-event.js` – `isEventPast()`; `session.js` – `date >= today` | covered |
 | `02-§18.49` | Event IDs in the session cookie but not found in `events.json` must be kept, not removed — newly-submitted events may not yet appear in the JSON | 03-architecture/forms-and-api.md §7 | — (manual: submit event, navigate to schema before deploy completes, verify cookie still contains new ID) | `session.js` – `removeExpiredIds()` keeps unknown IDs | implemented |
-| `02-§18.16` | Schedule pages show a "Redigera" link for events with ownership entries or valid admin token, and that have not passed | 03-architecture/forms-and-api.md §7 | — | Planned: `session.js` reads ownership entries for UI hints | gap |
+| `02-§18.16` | Schedule pages show a "Redigera" link for events with ownership entries or valid admin token, and that have not passed | 03-architecture/forms-and-api.md §7 | — (browser-only: set signed `sb_session`, open `schema.html`, confirm edit links only for signed owned future events) | `source/assets/js/client/session.js` – `signedEntryIds()` plus admin-token branch in `injectEditLinks()` | implemented |
 | `02-§18.17` | Edit links are injected by client-side JS; they are never part of the static HTML | 03-architecture/forms-and-api.md §7 | — | `source/build/render.js` – no edit links at build time; `session.js` injects at runtime | implemented |
 | `02-§18.18` | Event rows in generated HTML carry a `data-event-id` attribute with the event's stable ID | 03-architecture/forms-and-api.md §7 | RND-46, RND-47 | `source/build/render.js` – `renderEventRow()` adds `data-event-id` | covered |
 | `02-§18.19` | The "Redigera" link navigates to `/redigera.html?id={eventId}` | 03-architecture/forms-and-api.md §7 | — | `session.js` – `link.href = 'redigera.html?id=' + encodeURIComponent(id)` | implemented |
@@ -137,8 +137,8 @@ Part of [the traceability index](./index.md).
 | `02-§18.43` | The events JSON embedded in `idag.html` includes the event `id` field | 03-architecture/forms-and-api.md §7 | IDAG-01, IDAG-02 | `source/build/render-idag.js` – `id: e.id \|\| null` in events map | covered |
 | `02-§18.44` | Event rows rendered dynamically on `idag.html` carry `data-event-id` and `data-event-date` attributes for edit-link injection | 03-architecture/forms-and-api.md §7 | — | `source/assets/js/client/events-today.js` – `idAttr`/`dateAttr` added to both row types; browser-only: verify manually (open idag.html, run `document.querySelectorAll('[data-event-id]')` in console) | implemented |
 | `02-§18.20` | An edit page exists at `/redigera.html` | 03-architecture/forms-and-api.md §7 | REDT-01..03 | `source/build/render-edit.js` → `public/redigera.html` | covered |
-| `02-§18.21` | The edit page reads the `id` query param, checks for a matching ownership entry, and fetches `/events.json` to pre-populate the form | 03-architecture/forms-and-api.md §7 | — | Planned: `redigera.js` reads ownership-entry IDs | gap |
-| `02-§18.22` | If the event has no matching ownership entry and the user has no valid admin token, or the event has passed, the edit page shows an error and no form | 03-architecture/forms-and-api.md §7 | — | Planned: client UI check mirrors ownership-entry format; server remains authority | gap |
+| `02-§18.21` | The edit page reads the `id` query param, checks for a matching ownership entry, and fetches `/events.json` to pre-populate the form | 03-architecture/forms-and-api.md §7 | — (browser-only: open `redigera.html?id=<owned>` with signed cookie and confirm form populates) | `source/assets/js/client/redigera.js` – `readSessionIds()` returns only signed, non-expired ownership IDs before fetching `/events.json` | implemented |
+| `02-§18.22` | If the event has no matching ownership entry and the user has no valid admin token, or the event has passed, the edit page shows an error and no form | 03-architecture/forms-and-api.md §7 | — (browser-only: open `redigera.html?id=<legacy-only>` and confirm Swedish authorization error) | `source/assets/js/client/redigera.js` – client gate uses signed ownership IDs or admin token before showing the form | implemented |
 | `02-§18.23` | The edit form exposes the same fields as the add-activity form | 03-architecture/forms-and-api.md §7 | REDT-04..11 | `source/build/render-edit.js` – all add-activity fields present | covered |
 | `02-§18.24` | The event's stable `id` must not change after creation even when mutable fields are edited | 06-EVENT_DATA_MODEL.md §4 | EDIT-13 | `source/api/edit-event.js` – `patchEventInYaml()` preserves `event.id` | covered |
 | `02-§18.25` | The edit form is subject to the same validation rules as the add-activity form (§9) | 03-architecture/forms-and-api.md §7 | VLD-27..32 | `source/api/validate.js` – `validateEditRequest()`; `redigera.js` client-side validate | covered |
@@ -147,8 +147,8 @@ Part of [the traceability index](./index.md).
 | `02-§18.28` | A static `/events.json` file is generated at build time containing all events for the active camp | 03-architecture/forms-and-api.md §7 | — | `source/build/build.js` – writes `public/events.json` | implemented |
 | `02-§18.29` | `/events.json` contains only public fields (id, title, date, start, end, location, responsible, description, link); owner and meta are excluded | 03-architecture/forms-and-api.md §7 | STR-JSON-01..02 | `build.js` – `PUBLIC_EVENT_FIELDS` array | covered |
 | `02-§18.30` | A `POST /edit-event` endpoint accepts edit requests | 03-architecture/forms-and-api.md §7 | — | `app.js` – `app.post('/edit-event', …)` | implemented |
-| `02-§18.31` | The server reads `sb_session` and verifies valid ownership for the target ID, or that the request body contains a valid `adminToken` (§91) | 03-architecture/forms-and-api.md §7 | — | Planned: signed ownership verification in `app.js` and PHP API | gap |
-| `02-§18.32` | If the cookie lacks valid ownership and no valid admin token is provided, the server responds with HTTP 403 | 03-architecture/forms-and-api.md §7 | — | Planned: forged/legacy cookies rejected server-side | gap |
+| `02-§18.31` | The server reads `sb_session` and verifies valid ownership for the target ID, or that the request body contains a valid `adminToken` (§91) | 03-architecture/forms-and-api.md §7 | ADED-01..08, SES-17..21, PSES-02 | `app.js` `/edit-event`; `api/index.php` `handleEditEvent()` use `parseVerifiedSessionIds()` plus admin-token bypass | covered |
+| `02-§18.32` | If the cookie lacks valid ownership and no valid admin token is provided, the server responds with HTTP 403 | 03-architecture/forms-and-api.md §7 | ADED-01b, ADED-04..07, SES-18..21, PSES-02 | `app.js` and `api/index.php` reject missing/legacy/tampered/expired ownership without a valid admin token | covered |
 | `02-§18.33` | If the event's date has already passed, the server responds with HTTP 400 | 03-architecture/forms-and-api.md §7 | EDIT-01..03 | `app.js` – `isEventPast(req.body.date)` → `res.status(400)` | covered |
 | `02-§18.34` | On a valid edit, the server reads YAML from GitHub, replaces mutable fields, commits via ephemeral branch + PR with auto-merge | 03-architecture/forms-and-api.md §7 | EDIT-04..17 | `source/api/github.js` – `updateEventInActiveCamp()`; `edit-event.js` – `patchEventInYaml()` | covered |
 | `02-§18.35` | The event's `meta.updated_at` is updated on every successful edit | 06-EVENT_DATA_MODEL.md §6 | EDIT-15 | `source/api/edit-event.js` – `patchEventInYaml()` sets `meta.updated_at = now` | covered |
@@ -566,9 +566,9 @@ Part of [the traceability index](./index.md).
 | `02-§44.12` | Edit requests patch existing event in YAML | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/GitHub.php` | implemented |
 | `02-§44.13` | Active camp resolved from camps.yaml on GitHub | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/ActiveCamp.php` | implemented |
 | `02-§44.14` | YAML serialisation compatible with data contract | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/GitHub.php` | implemented |
-| `02-§44.15` | PHP API reads and writes `sb_session` using the same URL-encoded JSON ownership-entry format as Node.js | 03-architecture/ci-and-deploy.md §21 | — | Planned: align `api/src/Session.php` with Node session helper | gap |
+| `02-§44.15` | PHP API reads and writes `sb_session` using the same URL-encoded JSON ownership-entry format as Node.js | 03-architecture/ci-and-deploy.md §21 | PSES-01, PSES-03, SES-16 | `api/src/Session.php` mirrors Node `{ id, exp, sig }` ownership entries; `api/index.php` add handlers write those entries | covered |
 | `02-§44.16` | Cookie attributes match Node.js (Path, Max-Age, Secure, SameSite, Domain) | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/src/Session.php` | implemented |
-| `02-§44.17` | Edit requests verify valid cookie ownership for the target event; 403 if not | 03-architecture/ci-and-deploy.md §21 | — | Planned: PHP edit handler verifies signed ownership entries | gap |
+| `02-§44.17` | Edit requests verify valid cookie ownership for the target event; 403 if not | 03-architecture/ci-and-deploy.md §21 | PSES-02, ADED-01..08 | `api/index.php` edit/delete handlers call `Session::parseVerifiedSessionIds()` and reject unauthorized requests with 403 | covered |
 | `02-§44.18` | Cookie only set when cookieConsent is true | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
 | `02-§44.19` | CORS headers set for ALLOWED_ORIGIN and QA_ORIGIN | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
 | `02-§44.20` | OPTIONS preflight returns 204 with CORS headers | 03-architecture/ci-and-deploy.md §21 | manual: deploy and test | `api/index.php` | implemented |
@@ -1045,7 +1045,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§80.16` | manual | All events committed in single branch and PR (integration) |
 | `02-§80.17` | BATCH-08 | Response includes eventIds array |
 | `02-§80.18` | BATCH-09 | Time-gating and injection scanning apply to batch |
-| `02-§80.19` | gap | Batch endpoint must store ownership entries for all submitted events |
+| `02-§80.19` | implemented | `app.js` and `api/index.php` `/add-events` merge signed ownership entries for all returned event IDs when cookie consent is accepted; manual integration: submit multi-day activity and inspect `sb_session` |
 | `02-§80.20` | manual | Confirmation modal shown before every submission (browser-only) |
 | `02-§80.21` | manual | Success message states number of created activities (browser-only) |
 | `02-§80.22` | manual | Error displays message; no partial state (browser-only) |
@@ -1203,8 +1203,8 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§89.10` | manual | Browser-only: verify success modal shows "Gå till schemat" link |
 | `02-§89.11` | manual | Browser-only: verify error modal shows "Försök igen" button |
 | `02-§89.12` | implemented | app.js POST /delete-event route; api/index.php POST /delete-event route |
-| `02-§89.13` | gap | Delete endpoint must verify signed ownership entry OR valid admin token |
-| `02-§89.14` | gap | Delete endpoint must return 403 when cookie ownership is invalid/missing and no valid admin token is provided |
+| `02-§89.13` | covered | ADED-01..08 and PSES-02: Node/PHP delete authorization uses signed ownership entry OR valid admin token |
+| `02-§89.14` | covered | ADED-01b, ADED-04..07, SES-18..21: missing/legacy/tampered/expired ownership is rejected without valid admin token |
 | `02-§89.15` | implemented | app.js returns 400 when isEventPast is true; api/index.php same |
 | `02-§89.16` | implemented | app.js returns 400 when isOutsideEditingPeriod is true; api/index.php same |
 | `02-§89.17` | covered | DEL-01–DEL-07: removeEventFromYaml tested; github.js + GitHub.php removeEventFromActiveCamp implemented |
@@ -1491,16 +1491,16 @@ refactor of `render-lokaler.js` onto the shared module).
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§101.1` | gap | Session cookie must contain tamper-resistant ownership entries |
-| `02-§101.2` | gap | Each entry must bind event ID to server-generated proof |
-| `02-§101.3` | gap | Cookie remains JavaScript-readable for static schedule edit links |
-| `02-§101.4` | gap | Cookie attributes stay Path, Max-Age, Secure, SameSite, and optional Domain |
-| `02-§101.5` | gap | `POST /edit-event` must require valid ownership entry for participant edits |
-| `02-§101.6` | gap | `POST /delete-event` must require valid ownership entry for participant deletes |
-| `02-§101.7` | gap | Raw public event-ID cookies must not authorize edit/delete |
-| `02-§101.8` | gap | Invalid, malformed, expired, or unverifiable entries must be ignored |
-| `02-§101.9` | gap | Valid admin token bypass remains available |
-| `02-§101.10` | gap | Add-event responses store ownership entries when cookie consent is accepted |
-| `02-§101.11` | gap | Existing valid ownership entries are preserved and deduplicated |
-| `02-§101.12` | gap | Legacy ID-only cookies may be read for display/cleanup but not authorization |
-| `02-§101.13` | gap | Cookie debug panel describes unverifiable legacy entries clearly |
+| `02-§101.1` | covered | SES-16 and PSES-01: Node/PHP ownership entries include signed proof fields |
+| `02-§101.2` | covered | SES-19, SES-20, SES-21: signature binds secret, event ID, and expiry |
+| `02-§101.3` | implemented | Cookie intentionally omits `HttpOnly`; `session.js` and `redigera.js` read signed-entry IDs for UI hints |
+| `02-§101.4` | covered | SES-07..09, SES-14..15, EEC-18..26 verify cookie name, Max-Age, Secure, SameSite, no HttpOnly, and optional Domain |
+| `02-§101.5` | covered | ADED-01..08 and PSES-02: edit authorization uses signed ownership OR valid admin token |
+| `02-§101.6` | covered | ADED-01..08 and PSES-02: delete authorization uses signed ownership OR valid admin token |
+| `02-§101.7` | covered | SES-18 and ADED-01b: raw public event-ID strings do not authorize edit/delete |
+| `02-§101.8` | covered | SES-04, SES-05, SES-18..21: malformed, legacy, wrong-secret, tampered, and expired entries are ignored for authorization |
+| `02-§101.9` | covered | ADED-02, ADED-03, ADED-08: valid admin token bypass remains available without cookie ownership |
+| `02-§101.10` | covered | PSES-03, SES-06, SES-16: add handlers create signed ownership entries and write them through `Set-Cookie` helpers |
+| `02-§101.11` | covered | SES-10..13 and EEC-14..17: ownership entries are merged and deduplicated by event ID |
+| `02-§101.12` | covered | SES-05, SES-18, ADED-01b: legacy ID-only cookies may be displayed but never authorize |
+| `02-§101.13` | implemented | `redigera.js` debug panel labels legacy entries as old/unverifiable and explains they need to be re-added for editing; browser-only manual check |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -112,7 +112,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-04-24 (locale overview page delivered, 02-§98.1–98.20 all covered/implemented).
+Audit date: 2026-02-24. Last updated: 2026-06-09 (signed session ownership delivered, 02-§101.1–101.13 covered/implemented).
 
 ---
 
@@ -122,7 +122,7 @@ The matrix is split by ID family. Each file carries the rows for one family.
 
 | Family | Source | Rows | File |
 | --- | --- | --- | --- |
-| `02` | `docs/02-requirements/` | 1264 | [02-requirements](./02-requirements.md) |
+| `02` | `docs/02-requirements/` | 1277 | [02-requirements](./02-requirements.md) |
 | `03` | `docs/03-architecture/` | 0 | [03-architecture](./03-architecture.md) |
 | `05` | `docs/05-DATA_CONTRACT.md` | 18 | [05-data-contract](./05-data-contract.md) |
 | `07` | `docs/07-design/` | 91 | [07-design](./07-design.md) |
@@ -134,11 +134,16 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1287
-Covered (implemented + tested): 662
-Implemented, not tested:        625
+Total requirements:            1300
+Covered (implemented + tested): 672
+Implemented, not tested:        628
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
+
+Note: §101 (signed session ownership) adds 13 requirements:
+  10 covered (SES-16..21, ADED-01..08, PSES-01..03) and 3 implemented
+  (browser/manual checkpoints for JavaScript-readable cookie UI hints,
+  cleanup/debug-panel behaviour).
 
 Note: §100 (API .env outside web root) adds 11 requirements
   (02-§100.1–100.11): 7 covered (HTACC-01..06, ENVLOC-01..04) and 4

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -28,8 +28,11 @@ Part of [the traceability index](./index.md).
 | IMG-01..06 | `tests/render-index.test.js` | `renderIndexPage – image loading performance` |
 | SES-01..05 | `tests/session.test.js` | `parseSessionIds` |
 | SES-06..09 | `tests/session.test.js` | `buildSetCookieHeader` |
-| SES-10..13 | `tests/session.test.js` | `mergeIds` |
+| SES-10..13 | `tests/session.test.js` | `mergeOwnershipEntries` |
 | SES-14..15 | `tests/session.test.js` | `buildSetCookieHeader – domain` |
+| SES-16..21 | `tests/session.test.js` | `signed ownership entries` |
+| ADED-01..08 | `tests/admin-edit-delete.test.js` | `edit/delete authorisation OR condition (02-§7.3, §18.31, §89.13)` |
+| PSES-01..03 | `tests/php-session-ownership.test.js` | `PHP signed session ownership parity (02-§44.15, §44.17, §101)` |
 | SNP-01..06 | `tests/snapshot.test.js` | `renderSchedulePage` |
 | ARK-01..08 | `tests/render-arkiv.test.js` | `renderArkivPage` (original timeline tests) |
 | ARK-09..24 | `tests/render-arkiv.test.js` | `renderArkivPage` (header layout, FB logo, event list) |
@@ -78,7 +81,7 @@ Part of [the traceability index](./index.md).
 | EEC-04 | `tests/coverage-edit-event.test.js` | meta.created_at preserved (02-§18.35) |
 | EEC-05..08 | `tests/coverage-edit-event.test.js` | addOneDay date arithmetic |
 | EEC-09..13 | `tests/coverage-edit-event.test.js` | isOutsideEditingPeriod time-gate logic |
-| EEC-14..17 | `tests/coverage-edit-event.test.js` | mergeIds session cookie deduplication |
+| EEC-14..17 | `tests/coverage-edit-event.test.js` | mergeOwnershipEntries session cookie deduplication |
 | EEC-18..26 | `tests/coverage-edit-event.test.js` | Session cookie properties (02-§18.4, 02-§18.5, 02-§18.7, 02-§18.41) |
 | VCMP-01..08 | `tests/validate-camps.test.js` | `validateCamps – required fields (02-§37.1)` |
 | VCMP-09..12 | `tests/validate-camps.test.js` | `validateCamps – date format (02-§37.2)` |

--- a/source/api/session.js
+++ b/source/api/session.js
@@ -1,13 +1,61 @@
 'use strict';
 
+const crypto = require('node:crypto');
+
 const COOKIE_NAME    = 'sb_session';
 const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
-// ── parseSessionIds ───────────────────────────────────────────────────────────
+// ── ownership entries ─────────────────────────────────────────────────────────
 
-// Parse the sb_session cookie from a raw Cookie header string.
-// Returns a (possibly empty) array of event ID strings.
-function parseSessionIds(cookieHeader) {
+function expiresAt(now = Date.now()) {
+  return Math.floor(now / 1000) + MAX_AGE_SECONDS;
+}
+
+function signatureForEntry(id, exp, secret) {
+  return crypto
+    .createHmac('sha256', String(secret))
+    .update(`${id}.${exp}`)
+    .digest('hex');
+}
+
+function createOwnershipEntry(id, secret, now = Date.now()) {
+  if (!id || typeof id !== 'string') {
+    throw new TypeError('id must be a non-empty string');
+  }
+  if (!secret || typeof secret !== 'string') {
+    throw new TypeError('secret must be a non-empty string');
+  }
+  const exp = expiresAt(now);
+  return { id, exp, sig: signatureForEntry(id, exp, secret) };
+}
+
+function isOwnershipEntry(entry) {
+  return Boolean(
+    entry &&
+    typeof entry === 'object' &&
+    typeof entry.id === 'string' &&
+    entry.id.length > 0 &&
+    Number.isInteger(entry.exp) &&
+    entry.exp > 0 &&
+    typeof entry.sig === 'string' &&
+    entry.sig.length > 0
+  );
+}
+
+function verifyOwnershipEntry(entry, secret, now = Date.now()) {
+  if (!secret || typeof secret !== 'string' || !isOwnershipEntry(entry)) {
+    return false;
+  }
+  if (entry.exp < Math.floor(now / 1000)) {
+    return false;
+  }
+  const expected = signatureForEntry(entry.id, entry.exp, secret);
+  const actual = entry.sig;
+  if (actual.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(actual, 'utf8'), Buffer.from(expected, 'utf8'));
+}
+
+function parseSessionPayload(cookieHeader) {
   if (!cookieHeader || typeof cookieHeader !== 'string') return [];
 
   const pair = cookieHeader
@@ -21,11 +69,31 @@ function parseSessionIds(cookieHeader) {
 
   try {
     const parsed = JSON.parse(decodeURIComponent(raw));
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((id) => typeof id === 'string' && id.length > 0);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
+}
+
+// ── parseSessionIds ───────────────────────────────────────────────────────────
+
+// Parse the sb_session cookie from a raw Cookie header string.
+// Returns a (possibly empty) array of event ID strings for display/cleanup.
+// Legacy raw string entries are included here but are not authorization.
+function parseSessionIds(cookieHeader) {
+  return parseSessionPayload(cookieHeader)
+    .map((entry) => {
+      if (typeof entry === 'string' && entry.length > 0) return entry;
+      if (isOwnershipEntry(entry)) return entry.id;
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function parseVerifiedSessionIds(cookieHeader, secret, now = Date.now()) {
+  return parseSessionPayload(cookieHeader)
+    .filter((entry) => verifyOwnershipEntry(entry, secret, now))
+    .map((entry) => entry.id);
 }
 
 // ── buildSetCookieHeader ──────────────────────────────────────────────────────
@@ -39,13 +107,24 @@ function buildSetCookieHeader(ids, domain) {
   return `${COOKIE_NAME}=${value}; Path=/; Max-Age=${MAX_AGE_SECONDS}; Secure; SameSite=Strict${domainPart}`;
 }
 
-// ── mergeIds ─────────────────────────────────────────────────────────────────
+// ── mergeOwnershipEntries ─────────────────────────────────────────────────────
 
-// Return a new array with newId appended to existing, deduplicating.
-function mergeIds(existing, newId) {
+// Return a new array with newEntry appended to existing, deduplicating by id.
+function mergeOwnershipEntries(existing, newEntry) {
   if (!Array.isArray(existing)) existing = [];
-  if (existing.includes(newId)) return existing;
-  return [...existing, newId];
+  if (!isOwnershipEntry(newEntry)) return existing.filter(isOwnershipEntry);
+
+  const entries = existing.filter(isOwnershipEntry);
+  if (entries.some((entry) => entry.id === newEntry.id)) return entries;
+  return [...entries, newEntry];
 }
 
-module.exports = { COOKIE_NAME, MAX_AGE_SECONDS, parseSessionIds, buildSetCookieHeader, mergeIds };
+module.exports = {
+  COOKIE_NAME,
+  MAX_AGE_SECONDS,
+  createOwnershipEntry,
+  parseSessionIds,
+  parseVerifiedSessionIds,
+  buildSetCookieHeader,
+  mergeOwnershipEntries,
+};

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -192,7 +192,44 @@
 
   // ── Cookie helper ────────────────────────────────────────────────────────────
 
-  function readSessionIds() {
+  function entryId(entry) {
+    if (typeof entry === 'string' && entry.length > 0) return entry;
+    if (entry && typeof entry === 'object' && typeof entry.id === 'string' && entry.id.length > 0) {
+      return entry.id;
+    }
+    return null;
+  }
+
+  function normalizeEntries(entries) {
+    if (!Array.isArray(entries)) return [];
+    return entries.filter(function (entry) { return entryId(entry); });
+  }
+
+  function entryIds(entries) {
+    return normalizeEntries(entries).map(entryId);
+  }
+
+  function isSignedEntry(entry) {
+    return Boolean(
+      entry &&
+      typeof entry === 'object' &&
+      typeof entry.id === 'string' &&
+      entry.id.length > 0 &&
+      typeof entry.exp === 'number' &&
+      isFinite(entry.exp) &&
+      entry.exp >= Math.floor(Date.now() / 1000) &&
+      typeof entry.sig === 'string' &&
+      entry.sig.length > 0,
+    );
+  }
+
+  function signedEntryIds(entries) {
+    return normalizeEntries(entries)
+      .filter(isSignedEntry)
+      .map(entryId);
+  }
+
+  function readSessionEntries() {
     var pairs = document.cookie.split(';');
     for (var i = 0; i < pairs.length; i++) {
       var pair = pairs[i].trim();
@@ -200,12 +237,16 @@
         try {
           var raw = pair.slice(COOKIE_NAME.length + 1);
           var parsed = JSON.parse(decodeURIComponent(raw));
-          if (Array.isArray(parsed)) return parsed;
+          if (Array.isArray(parsed)) return normalizeEntries(parsed);
         } catch { /* ignore */ }
         return [];
       }
     }
     return [];
+  }
+
+  function readSessionIds() {
+    return signedEntryIds(readSessionEntries());
   }
 
   // ── Admin token helper (02-§7.3) ─────────────────────────────────────────────
@@ -709,7 +750,7 @@
   }
 
   function removeIdFromCookie(idToRemove) {
-    var ids = readSessionIds().filter(function (id) { return id !== idToRemove; });
+    var entries = readSessionEntries().filter(function (entry) { return entryId(entry) !== idToRemove; });
     // Delete both cookie variants (with and without Domain) to avoid
     // orphaned duplicates — same pattern as repairDuplicateCookies (02-§90.9).
     document.cookie = COOKIE_NAME + '=; Path=/; Max-Age=0; Secure; SameSite=Strict';
@@ -717,8 +758,8 @@
       document.cookie = COOKIE_NAME + '=; Path=/; Max-Age=0; Secure; SameSite=Strict' + domainPart;
     }
     // Write back the cleaned list.
-    if (ids.length) {
-      var encoded = encodeURIComponent(JSON.stringify(ids));
+    if (entries.length) {
+      var encoded = encodeURIComponent(JSON.stringify(entries));
       document.cookie = COOKIE_NAME + '=' + encoded +
         '; Path=/; Max-Age=604800; Secure; SameSite=Strict' + domainPart;
     }
@@ -773,7 +814,8 @@
 
     var isSecure = location.protocol === 'https:';
     var domain = cookieDomain || 'ej satt';
-    var ids = readSessionIds();
+    var entries = readSessionEntries();
+    var ids = entryIds(entries);
     var eventMap = {};
     if (Array.isArray(eventsArray)) {
       for (var i = 0; i < eventsArray.length; i++) {
@@ -806,9 +848,16 @@
       var debugToday = new Date().toISOString().slice(0, 10);
       for (var j = 0; j < ids.length; j++) {
         var id = ids[j];
+        var isLegacy = typeof entries[j] === 'string';
+        var isExpiredOwnership = !isLegacy && entries[j] && typeof entries[j].exp === 'number' &&
+          entries[j].exp < Math.floor(Date.now() / 1000);
         var ev = eventMap[id];
         var status;
-        if (!ev) {
+        if (isLegacy) {
+          status = '<span class="cookie-status-unknown">gammal cookie – behöver läggas till igen för redigering</span>';
+        } else if (isExpiredOwnership) {
+          status = '<span class="cookie-status-expired">signaturen har gått ut</span>';
+        } else if (!ev) {
           status = '<span class="cookie-status-unknown">hittades inte i schemat (kan vara under publicering)</span>';
         } else if (ev.date < debugToday) {
           status = '<span class="cookie-status-expired">passerat</span>';

--- a/source/assets/js/client/session.js
+++ b/source/assets/js/client/session.js
@@ -11,7 +11,40 @@
 
   // ── Cookie helpers ──────────────────────────────────────────────────────────
 
-  function readSessionIds() {
+  function entryId(entry) {
+    if (typeof entry === 'string' && entry.length > 0) return entry;
+    if (entry && typeof entry === 'object' && typeof entry.id === 'string' && entry.id.length > 0) {
+      return entry.id;
+    }
+    return null;
+  }
+
+  function normalizeEntries(entries) {
+    if (!Array.isArray(entries)) return [];
+    return entries.filter(function (entry) { return entryId(entry); });
+  }
+
+  function isSignedEntry(entry) {
+    return Boolean(
+      entry &&
+      typeof entry === 'object' &&
+      typeof entry.id === 'string' &&
+      entry.id.length > 0 &&
+      typeof entry.exp === 'number' &&
+      isFinite(entry.exp) &&
+      entry.exp >= Math.floor(Date.now() / 1000) &&
+      typeof entry.sig === 'string' &&
+      entry.sig.length > 0,
+    );
+  }
+
+  function signedEntryIds(entries) {
+    return normalizeEntries(entries)
+      .filter(isSignedEntry)
+      .map(entryId);
+  }
+
+  function readSessionEntries() {
     var pairs = document.cookie.split(';');
     for (var i = 0; i < pairs.length; i++) {
       var pair = pairs[i].trim();
@@ -20,7 +53,7 @@
           var raw = pair.slice(COOKIE_NAME.length + 1);
           var parsed = JSON.parse(decodeURIComponent(raw));
           if (Array.isArray(parsed)) {
-            return parsed.filter(function (id) { return typeof id === 'string' && id.length > 0; });
+            return normalizeEntries(parsed);
           }
         } catch { /* malformed — ignore */ }
         return [];
@@ -29,25 +62,28 @@
     return [];
   }
 
-  function writeSessionIds(ids) {
-    if (!ids || ids.length === 0) {
+  function writeSessionEntries(entries) {
+    entries = normalizeEntries(entries);
+    if (!entries.length) {
       // Delete the cookie by setting Max-Age=0
       document.cookie = COOKIE_NAME + '=; Path=/; Max-Age=0; Secure; SameSite=Strict' + domainPart;
       return;
     }
-    var value = encodeURIComponent(JSON.stringify(ids));
+    var value = encodeURIComponent(JSON.stringify(entries));
     document.cookie = COOKIE_NAME + '=' + value +
       '; Path=/; Max-Age=' + MAX_AGE_SECONDS + '; Secure; SameSite=Strict' + domainPart;
   }
 
   // ── Expiry cleanup ──────────────────────────────────────────────────────────
 
-  // Remove IDs for events whose date is strictly before today.
+  // Remove entries for events whose date is strictly before today.
   // IDs not found in events.json are kept — a newly-submitted event may not
   // yet appear because the event-data deploy is still in progress (02-§18.49).
-  function removeExpiredIds(ids, events) {
+  function removeExpiredEntries(entries, events) {
     var today = new Date().toISOString().slice(0, 10);
-    return ids.filter(function (id) {
+    return normalizeEntries(entries).filter(function (entry) {
+      if (typeof entry !== 'string' && !isSignedEntry(entry)) return false;
+      var id = entryId(entry);
       var ev = events[id];
       if (!ev) return true; // unknown — keep (deploy may be in progress)
       return ev.date >= today;
@@ -145,22 +181,31 @@
         try {
           var parsed = JSON.parse(decodeURIComponent(raw));
           if (Array.isArray(parsed)) {
-            found.push(parsed.filter(function (id) { return typeof id === 'string' && id.length > 0; }));
+            found.push(normalizeEntries(parsed));
           }
         } catch { /* skip malformed */ }
       }
     }
-    if (found.length <= 1) return { repaired: false, ids: found[0] || [] };
+    if (found.length <= 1) return { repaired: false, entries: found[0] || [] };
 
-    // Merge all ID arrays, deduplicate.
+    // Merge all ownership arrays, deduplicate by event ID. Prefer signed
+    // objects over legacy strings when both exist for the same ID.
     var seen = {};
     var merged = [];
     for (var j = 0; j < found.length; j++) {
       for (var k = 0; k < found[j].length; k++) {
-        var id = found[j][k];
+        var entry = found[j][k];
+        var id = entryId(entry);
         if (!seen[id]) {
           seen[id] = true;
-          merged.push(id);
+          merged.push(entry);
+        } else if (isSignedEntry(entry)) {
+          for (var m = 0; m < merged.length; m++) {
+            if (entryId(merged[m]) === id && !isSignedEntry(merged[m])) {
+              merged[m] = entry;
+              break;
+            }
+          }
         }
       }
     }
@@ -172,15 +217,16 @@
     }
 
     // Write back a single correct cookie.
-    writeSessionIds(merged);
-    return { repaired: true, ids: merged };
+    writeSessionEntries(merged);
+    return { repaired: true, entries: merged };
   }
 
   // ── Main ────────────────────────────────────────────────────────────────────
 
   // Repair duplicates first (before expiry cleanup).
   var repair = repairDuplicateCookies();
-  var ids = repair.repaired ? repair.ids : readSessionIds();
+  var entries = repair.repaired ? repair.entries : readSessionEntries();
+  var ids = signedEntryIds(entries);
   var isAdmin = hasValidAdminToken();
 
   // If no cookie IDs and not admin, nothing to do.
@@ -191,12 +237,12 @@
     .then(function (r) { return r.json(); })
     .then(function (eventsArray) {
       var eventMap = buildEventMap(eventsArray);
-      var active = removeExpiredIds(ids, eventMap);
+      var active = removeExpiredEntries(entries, eventMap);
 
       // Persist the cleaned list back.
-      writeSessionIds(active);
+      writeSessionEntries(active);
 
-      injectEditLinks(active, isAdmin);
+      injectEditLinks(signedEntryIds(active), isAdmin);
     })
     .catch(function () {
       // If events.json is unavailable, still inject links for what we have.

--- a/tests/admin-edit-delete.test.js
+++ b/tests/admin-edit-delete.test.js
@@ -5,7 +5,7 @@
 //
 // Testable in Node.js:
 //   - verifyAdminToken correctly gates access (reuses admin module)
-//   - parseSessionIds + verifyAdminToken OR condition
+//   - parseVerifiedSessionIds + verifyAdminToken OR condition
 //
 // Browser-only (manual checkpoints documented in traceability):
 //   - 02-§18.16: Edit links injected for all events when admin is active
@@ -17,17 +17,18 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
 const { verifyAdminToken } = require('../source/api/admin');
-const { parseSessionIds } = require('../source/api/session');
+const { createOwnershipEntry, parseVerifiedSessionIds } = require('../source/api/session');
 
 // Future epoch so tokens are not rejected by expiry check
 const futureEpoch = Math.floor(Date.now() / 1000) + 86400;
 const VALID_TOKEN = `admin_test-uuid_${futureEpoch}`;
 const ADMIN_TOKENS = [VALID_TOKEN];
+const SESSION_SECRET = 'test-session-secret';
 
 // Simulates the OR condition that app.js will use:
-// authorised if event ID is in session cookie OR admin token is valid.
-function isAuthorised(cookieHeader, eventId, adminToken, validTokens) {
-  const ownedIds = parseSessionIds(cookieHeader);
+// authorised if event ID has valid signed ownership OR admin token is valid.
+function isAuthorised(cookieHeader, eventId, adminToken, validTokens, sessionSecret = SESSION_SECRET) {
+  const ownedIds = parseVerifiedSessionIds(cookieHeader, sessionSecret);
   if (ownedIds.includes(eventId)) return true;
   if (adminToken && verifyAdminToken(adminToken, validTokens)) return true;
   return false;
@@ -37,12 +38,17 @@ function isAuthorised(cookieHeader, eventId, adminToken, validTokens) {
 
 describe('edit/delete authorisation OR condition (02-§7.3, §18.31, §89.13)', () => {
   const eventId = 'test-event-2099-06-01-1000';
-  const cookieWithId = `sb_session=${encodeURIComponent(JSON.stringify([eventId]))}`;
-  const cookieWithoutId = 'sb_session=%5B%22other-event%22%5D';
+  const cookieWithOwnership = `sb_session=${encodeURIComponent(JSON.stringify([createOwnershipEntry(eventId, SESSION_SECRET)]))}`;
+  const cookieWithLegacyId = `sb_session=${encodeURIComponent(JSON.stringify([eventId]))}`;
+  const cookieWithoutId = `sb_session=${encodeURIComponent(JSON.stringify([createOwnershipEntry('other-event', SESSION_SECRET)]))}`;
   const noCookie = '';
 
-  it('ADED-01: authorised when event ID is in session cookie (no admin token)', () => {
-    assert.strictEqual(isAuthorised(cookieWithId, eventId, undefined, []), true);
+  it('ADED-01: authorised when event has signed ownership in session cookie (no admin token)', () => {
+    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, undefined, []), true);
+  });
+
+  it('ADED-01b: rejected when cookie only contains a legacy raw event ID', () => {
+    assert.strictEqual(isAuthorised(cookieWithLegacyId, eventId, undefined, []), false);
   });
 
   it('ADED-02: authorised when admin token is valid (event ID not in cookie)', () => {
@@ -50,7 +56,7 @@ describe('edit/delete authorisation OR condition (02-§7.3, §18.31, §89.13)', 
   });
 
   it('ADED-03: authorised when both cookie ownership and admin token are present', () => {
-    assert.strictEqual(isAuthorised(cookieWithId, eventId, VALID_TOKEN, ADMIN_TOKENS), true);
+    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, VALID_TOKEN, ADMIN_TOKENS), true);
   });
 
   it('ADED-04: rejected when neither cookie ownership nor admin token', () => {

--- a/tests/coverage-edit-event.test.js
+++ b/tests/coverage-edit-event.test.js
@@ -6,7 +6,15 @@ const yaml = require('js-yaml');
 
 const { patchEventInYaml } = require('../source/api/edit-event');
 const { addOneDay, isOutsideEditingPeriod } = require('../source/api/time-gate');
-const { mergeIds, buildSetCookieHeader, COOKIE_NAME, MAX_AGE_SECONDS } = require('../source/api/session');
+const {
+  createOwnershipEntry,
+  mergeOwnershipEntries,
+  buildSetCookieHeader,
+  COOKIE_NAME,
+  MAX_AGE_SECONDS,
+} = require('../source/api/session');
+
+const SESSION_SECRET = 'test-session-secret';
 
 // ── 05-§6.2  Event id stable after creation ─────────────────────────────────
 
@@ -123,23 +131,29 @@ describe('isOutsideEditingPeriod — time-gate logic', () => {
   });
 });
 
-// ── mergeIds ────────────────────────────────────────────────────────────────
+// ── mergeOwnershipEntries ───────────────────────────────────────────────────
 
-describe('mergeIds — session cookie deduplication', () => {
-  it('EEC-14: appends a new id', () => {
-    assert.deepStrictEqual(mergeIds(['a'], 'b'), ['a', 'b']);
+describe('mergeOwnershipEntries — session cookie deduplication', () => {
+  it('EEC-14: appends a new ownership entry', () => {
+    const a = createOwnershipEntry('a', SESSION_SECRET);
+    const b = createOwnershipEntry('b', SESSION_SECRET);
+    assert.deepStrictEqual(mergeOwnershipEntries([a], b), [a, b]);
   });
 
   it('EEC-15: does not duplicate an existing id', () => {
-    assert.deepStrictEqual(mergeIds(['a', 'b'], 'a'), ['a', 'b']);
+    const a = createOwnershipEntry('a', SESSION_SECRET);
+    const duplicate = createOwnershipEntry('a', SESSION_SECRET);
+    assert.deepStrictEqual(mergeOwnershipEntries([a], duplicate), [a]);
   });
 
   it('EEC-16: handles empty array', () => {
-    assert.deepStrictEqual(mergeIds([], 'x'), ['x']);
+    const x = createOwnershipEntry('x', SESSION_SECRET);
+    assert.deepStrictEqual(mergeOwnershipEntries([], x), [x]);
   });
 
   it('EEC-17: handles null existing', () => {
-    assert.deepStrictEqual(mergeIds(null, 'x'), ['x']);
+    const x = createOwnershipEntry('x', SESSION_SECRET);
+    assert.deepStrictEqual(mergeOwnershipEntries(null, x), [x]);
   });
 });
 
@@ -155,22 +169,22 @@ describe('02-§18.4 / 02-§18.7 — Session cookie properties', () => {
   });
 
   it('EEC-20: cookie header includes Secure flag', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(header.includes('Secure'), 'has Secure');
   });
 
   it('EEC-21: cookie header includes SameSite=Strict', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(header.includes('SameSite=Strict'), 'has SameSite=Strict');
   });
 
   it('EEC-22: cookie header includes Path=/', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(header.includes('Path=/'), 'has Path=/');
   });
 
   it('EEC-23: cookie header starts with sb_session=', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(header.startsWith('sb_session='), 'starts with cookie name');
   });
 });
@@ -179,12 +193,12 @@ describe('02-§18.4 / 02-§18.7 — Session cookie properties', () => {
 
 describe('02-§18.41 — Cookie domain for cross-subdomain', () => {
   it('EEC-24: no Domain= when domain not provided', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(!header.includes('Domain='), 'no Domain by default');
   });
 
   it('EEC-25: Domain= included when domain provided', () => {
-    const header = buildSetCookieHeader(['id1'], '.example.com');
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)], '.example.com');
     assert.ok(header.includes('Domain=.example.com'), 'Domain included');
   });
 });
@@ -193,7 +207,7 @@ describe('02-§18.41 — Cookie domain for cross-subdomain', () => {
 
 describe('02-§18.5 — Session cookie is JS-readable', () => {
   it('EEC-26: cookie header does NOT include HttpOnly', () => {
-    const header = buildSetCookieHeader(['id1']);
+    const header = buildSetCookieHeader([createOwnershipEntry('id1', SESSION_SECRET)]);
     assert.ok(!header.includes('HttpOnly'), 'no HttpOnly flag');
   });
 });

--- a/tests/php-session-ownership.test.js
+++ b/tests/php-session-ownership.test.js
@@ -18,6 +18,8 @@ describe('PHP signed session ownership parity (02-§44.15, §44.17, §101)', () 
     assert.match(src, /function\s+parseVerifiedSessionIds\b/);
     assert.match(src, /hash_hmac\s*\(\s*['"]sha256['"]/);
     assert.match(src, /hash_equals\s*\(/);
+    assert.match(src, /'exp'\s*=>/);
+    assert.match(src, /time\s*\(\s*\)\s*\+\s*self::MAX_AGE_SECONDS/);
   });
 
   it('PSES-02: edit/delete handlers use verified ownership, not display IDs', () => {
@@ -30,5 +32,7 @@ describe('PHP signed session ownership parity (02-§44.15, §44.17, §101)', () 
     const src = read('api/index.php');
     assert.match(src, /\$_ENV\['SESSION_SECRET'\]/);
     assert.match(src, /Session::createOwnershipEntry/);
+    assert.match(src, /handleAddEvent\(\$activeCamp,\s*\$adminTokens,\s*\$sessionSecret\)/);
+    assert.match(src, /function\s+handleAddEvent\([^)]*string\s+\$sessionSecret/);
   });
 });

--- a/tests/php-session-ownership.test.js
+++ b/tests/php-session-ownership.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('PHP signed session ownership parity (02-§44.15, §44.17, §101)', () => {
+  it('PSES-01: Session.php exposes signed ownership helpers', () => {
+    const src = read('api/src/Session.php');
+    assert.match(src, /function\s+createOwnershipEntry\b/);
+    assert.match(src, /function\s+parseVerifiedSessionIds\b/);
+    assert.match(src, /hash_hmac\s*\(\s*['"]sha256['"]/);
+    assert.match(src, /hash_equals\s*\(/);
+  });
+
+  it('PSES-02: edit/delete handlers use verified ownership, not display IDs', () => {
+    const src = read('api/index.php');
+    assert.match(src, /Session::parseVerifiedSessionIds/);
+    assert.doesNotMatch(src, /ownedIds\s*=\s*Session::parseSessionIds/);
+  });
+
+  it('PSES-03: add handlers require SESSION_SECRET before setting ownership cookies', () => {
+    const src = read('api/index.php');
+    assert.match(src, /\$_ENV\['SESSION_SECRET'\]/);
+    assert.match(src, /Session::createOwnershipEntry/);
+  });
+});

--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -38,7 +38,8 @@ describe('parseSessionIds', () => {
   });
 
   it('SES-05: filters out malformed entries but keeps legacy strings for display only', () => { // SES-05
-    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([42, '', 'legacy-id', null, { id: 'signed-id', sig: 'abc' }]))}`;
+    const signed = createOwnershipEntry('signed-id', SECRET);
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([42, '', 'legacy-id', null, signed]))}`;
     assert.deepStrictEqual(parseSessionIds(cookieHeader), ['legacy-id', 'signed-id']);
   });
 });
@@ -48,8 +49,9 @@ describe('parseSessionIds', () => {
 describe('signed ownership entries', () => {
   it('SES-16: createOwnershipEntry binds id to a signature', () => {
     const entry = createOwnershipEntry('event-a', SECRET);
-    assert.deepStrictEqual(Object.keys(entry).sort(), ['id', 'sig']);
+    assert.deepStrictEqual(Object.keys(entry).sort(), ['exp', 'id', 'sig']);
     assert.strictEqual(entry.id, 'event-a');
+    assert.ok(entry.exp > Math.floor(Date.now() / 1000));
     assert.match(entry.sig, /^[a-f0-9]{64}$/);
   });
 
@@ -75,6 +77,14 @@ describe('signed ownership entries', () => {
     const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([{ ...entry, id: 'event-b' }]))}`;
     assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET), []);
   });
+
+  it('SES-21: parseVerifiedSessionIds rejects expired ownership entries', () => {
+    const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const entry = createOwnershipEntry('event-a', SECRET, now);
+    const afterExpiry = now + (7 * 24 * 60 * 60 * 1000) + 1000;
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([entry]))}`;
+    assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET, afterExpiry), []);
+  });
 });
 
 // ── buildSetCookieHeader ──────────────────────────────────────────────────────
@@ -84,6 +94,7 @@ describe('buildSetCookieHeader', () => {
     const header = buildSetCookieHeader([createOwnershipEntry('my-event-id', SECRET)]);
     assert.ok(header.startsWith('sb_session='), `Expected header to start with sb_session=, got: ${header}`);
     assert.ok(header.includes('my-event-id'));
+    assert.ok(header.includes('exp'));
     assert.ok(header.includes('sig'));
   });
 

--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -3,7 +3,15 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { parseSessionIds, buildSetCookieHeader, mergeIds } = require('../source/api/session');
+const {
+  parseSessionIds,
+  parseVerifiedSessionIds,
+  createOwnershipEntry,
+  buildSetCookieHeader,
+  mergeOwnershipEntries,
+} = require('../source/api/session');
+
+const SECRET = 'test-session-secret';
 
 // ── parseSessionIds ───────────────────────────────────────────────────────────
 
@@ -16,29 +24,67 @@ describe('parseSessionIds', () => {
     assert.deepStrictEqual(parseSessionIds('other=value; another=foo'), []);
   });
 
-  it('SES-03: correctly parses a valid sb_session cookie', () => { // SES-03
-    const ids = ['event-a', 'event-b'];
-    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify(ids))}; Path=/`;
-    assert.deepStrictEqual(parseSessionIds(cookieHeader), ids);
+  it('SES-03: returns display IDs from signed ownership entries', () => { // SES-03
+    const entries = [
+      createOwnershipEntry('event-a', SECRET),
+      createOwnershipEntry('event-b', SECRET),
+    ];
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify(entries))}; Path=/`;
+    assert.deepStrictEqual(parseSessionIds(cookieHeader), ['event-a', 'event-b']);
   });
 
   it('SES-04: returns [] for malformed JSON in sb_session', () => { // SES-04
     assert.deepStrictEqual(parseSessionIds('sb_session=not-json'), []);
   });
 
-  it('SES-05: filters out non-string and empty-string entries', () => { // SES-05
-    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([42, '', 'valid-id', null]))}`;
-    assert.deepStrictEqual(parseSessionIds(cookieHeader), ['valid-id']);
+  it('SES-05: filters out malformed entries but keeps legacy strings for display only', () => { // SES-05
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([42, '', 'legacy-id', null, { id: 'signed-id', sig: 'abc' }]))}`;
+    assert.deepStrictEqual(parseSessionIds(cookieHeader), ['legacy-id', 'signed-id']);
+  });
+});
+
+// ── signed ownership verification ────────────────────────────────────────────
+
+describe('signed ownership entries', () => {
+  it('SES-16: createOwnershipEntry binds id to a signature', () => {
+    const entry = createOwnershipEntry('event-a', SECRET);
+    assert.deepStrictEqual(Object.keys(entry).sort(), ['id', 'sig']);
+    assert.strictEqual(entry.id, 'event-a');
+    assert.match(entry.sig, /^[a-f0-9]{64}$/);
+  });
+
+  it('SES-17: parseVerifiedSessionIds accepts a valid signed ownership entry', () => {
+    const entry = createOwnershipEntry('event-a', SECRET);
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([entry]))}`;
+    assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET), ['event-a']);
+  });
+
+  it('SES-18: parseVerifiedSessionIds rejects legacy raw event ID strings', () => {
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify(['event-a']))}`;
+    assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET), []);
+  });
+
+  it('SES-19: parseVerifiedSessionIds rejects entries signed with another secret', () => {
+    const entry = createOwnershipEntry('event-a', 'other-secret');
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([entry]))}`;
+    assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET), []);
+  });
+
+  it('SES-20: parseVerifiedSessionIds rejects a tampered event ID', () => {
+    const entry = createOwnershipEntry('event-a', SECRET);
+    const cookieHeader = `sb_session=${encodeURIComponent(JSON.stringify([{ ...entry, id: 'event-b' }]))}`;
+    assert.deepStrictEqual(parseVerifiedSessionIds(cookieHeader, SECRET), []);
   });
 });
 
 // ── buildSetCookieHeader ──────────────────────────────────────────────────────
 
 describe('buildSetCookieHeader', () => {
-  it('SES-06: includes the cookie name and encoded event IDs', () => { // SES-06
-    const header = buildSetCookieHeader(['my-event-id']);
+  it('SES-06: includes the cookie name and encoded ownership entries', () => { // SES-06
+    const header = buildSetCookieHeader([createOwnershipEntry('my-event-id', SECRET)]);
     assert.ok(header.startsWith('sb_session='), `Expected header to start with sb_session=, got: ${header}`);
     assert.ok(header.includes('my-event-id'));
+    assert.ok(header.includes('sig'));
   });
 
   it('SES-07: includes Max-Age of 604800 (7 days)', () => { // SES-07
@@ -57,36 +103,42 @@ describe('buildSetCookieHeader', () => {
   });
 
   it('SES-14: includes Domain attribute when a domain is provided', () => { // SES-14
-    const header = buildSetCookieHeader(['my-event'], 'sommar.example.com');
+    const header = buildSetCookieHeader([createOwnershipEntry('my-event', SECRET)], 'sommar.example.com');
     assert.ok(header.includes('Domain=sommar.example.com'), `Missing Domain= in: ${header}`);
   });
 
   it('SES-15: omits Domain attribute when no domain is provided', () => { // SES-15
-    const header = buildSetCookieHeader(['my-event']);
+    const header = buildSetCookieHeader([createOwnershipEntry('my-event', SECRET)]);
     assert.ok(!header.includes('Domain='), `Unexpected Domain= in: ${header}`);
   });
 });
 
-// ── mergeIds ─────────────────────────────────────────────────────────────────
+// ── mergeOwnershipEntries ─────────────────────────────────────────────────────
 
-describe('mergeIds', () => {
-  it('SES-10: adds a new ID to an existing array', () => { // SES-10
-    const result = mergeIds(['a', 'b'], 'c');
-    assert.deepStrictEqual(result, ['a', 'b', 'c']);
+describe('mergeOwnershipEntries', () => {
+  it('SES-10: adds a new ownership entry to an existing array', () => { // SES-10
+    const a = createOwnershipEntry('a', SECRET);
+    const b = createOwnershipEntry('b', SECRET);
+    const result = mergeOwnershipEntries([a], b);
+    assert.deepStrictEqual(result, [a, b]);
   });
 
-  it('SES-11: does not duplicate an ID already present', () => { // SES-11
-    const result = mergeIds(['a', 'b'], 'a');
-    assert.deepStrictEqual(result, ['a', 'b']);
+  it('SES-11: does not duplicate an event ID already present', () => { // SES-11
+    const a = createOwnershipEntry('a', SECRET);
+    const duplicate = createOwnershipEntry('a', SECRET);
+    const result = mergeOwnershipEntries([a], duplicate);
+    assert.deepStrictEqual(result, [a]);
   });
 
   it('SES-12: handles an empty existing array', () => { // SES-12
-    const result = mergeIds([], 'new-event');
-    assert.deepStrictEqual(result, ['new-event']);
+    const entry = createOwnershipEntry('new-event', SECRET);
+    const result = mergeOwnershipEntries([], entry);
+    assert.deepStrictEqual(result, [entry]);
   });
 
   it('SES-13: handles a non-array existing value gracefully', () => { // SES-13
-    const result = mergeIds(null, 'new-event');
-    assert.deepStrictEqual(result, ['new-event']);
+    const entry = createOwnershipEntry('new-event', SECRET);
+    const result = mergeOwnershipEntries(null, entry);
+    assert.deepStrictEqual(result, [entry]);
   });
 });


### PR DESCRIPTION
## Summary

- Sign participant `sb_session` ownership entries as `{ id, exp, sig }` using `SESSION_SECRET` in both Node and PHP.
- Require verified signed ownership for participant edit/delete while preserving the admin-token bypass.
- Keep legacy raw ID cookies readable for display/cleanup only, and update docs/traceability/env docs for the signed format.

Closes #367

## Validation

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run lint:md`
- [x] `npm run validate:camps`
- [x] `npm start` build smoke check

## Manual Notes

- Real browser interaction still needs QA review: set/create a signed `sb_session`, confirm edit links appear for owned future events, and confirm legacy raw ID cookies do not authorize edit/delete.
- `SESSION_SECRET` must be configured in QA and production before this is deployed, otherwise cookie-consenting participant submissions cannot store ownership cookies.

Generated with Claude Code.