### PR TITLE
Add layout, theme, and navigation chrome to the docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ Thumbs.db
 # Build files for deploying
 public/*
 !public/.gitkeep
+
+# Jekyll local-preview artifacts for the docs site (GitHub Pages builds
+# from docs/ itself; these are only produced by a local `jekyll build/serve`)
+docs/_site/
+docs/.jekyll-cache/
+docs/.sass-cache/

--- a/docs/01-CONTRIBUTORS.md
+++ b/docs/01-CONTRIBUTORS.md
@@ -1,3 +1,7 @@
+---
+title: "Contributing to SB Sommar"
+---
+
 # Contributing to SB Sommar
 
 There are two types of contributors: **content editors** and **developers**.

--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Add and Edit Forms"
+---
+
 # SB Sommar – Requirements: Add and Edit Forms
 
 Add-activity and edit-activity forms: fields, validation, submit flows, time-gating, cookies, drafts, multi-day, delete, conflict warning, error visibility.

--- a/docs/02-requirements/archive.md
+++ b/docs/02-requirements/archive.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Archived Requirements"
+---
+
 # SB Sommar – Requirements: Archived Requirements
 
 Sections superseded by later requirements. IDs are preserved because they are still cited from code; prose lives here for historical reference.

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Build and Deploy"
+---
+
 # SB Sommar – Requirements: Build and Deploy
 
 CI pipelines, lint gates, environments (local/QA/production), zero-downtime deploy, release docs, footer version, the docs site build.

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -825,3 +825,42 @@ existing deployment workflow.
   `<head>` regardless of which default theme GitHub Pages selects. <!-- 02-§97.20 -->
 - No sitemap, Open Graph tags, or other discoverability metadata are
   added to the documentation site. <!-- 02-§97.21 -->
+
+### 97.9 Page layout and chrome
+
+- Every rendered documentation page is wrapped in a shared layout that
+  gives it consistent chrome: a header strip above the content and a
+  single content column below it. A newly added documentation file
+  receives this chrome automatically, with no per-file opt-in. <!-- 02-§97.22 -->
+- The chrome header shows the documentation site's title, and the title
+  links to the landing page (`docs/index.md`). <!-- 02-§97.23 -->
+- Page content renders within a constrained maximum width, so that lines
+  of text stay short enough to read comfortably on a wide screen. <!-- 02-§97.24 -->
+
+### 97.10 Page front-matter
+
+- Every Markdown file under `docs/` carries YAML front-matter with a
+  `title` field. <!-- 02-§97.25 -->
+- A page's front-matter `title` matches the document's first in-content
+  heading. The shared layout renders no title of its own as a page
+  heading; the document's existing top-level `#` heading is the only
+  visible page title. <!-- 02-§97.26 -->
+
+### 97.11 Breadcrumb
+
+- A documentation page that lives inside a subfolder (for example
+  `02-requirements/`, `03-architecture/`, `07-design/`, or
+  `99-traceability/`) shows a one-level breadcrumb in the chrome that
+  links back to the landing page and names the family the page belongs
+  to. <!-- 02-§97.27 -->
+
+### 97.12 Within-family navigation
+
+- Each topic file inside a documentation family (`02-requirements/`,
+  `03-architecture/`, `07-design/`, and `99-traceability/`) renders a
+  navigation block that lists the other files in the same family, each
+  linking to its rendered page, so that a reader on a deep page can move
+  to a sibling without first returning to the landing page. <!-- 02-§97.28 -->
+- The list of files in each family is maintained in a single place, so
+  that adding or removing a family member updates every sibling's
+  navigation block without editing each file by hand. <!-- 02-§97.29 -->

--- a/docs/02-requirements/caching-performance.md
+++ b/docs/02-requirements/caching-performance.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Caching and Performance"
+---
+
 # SB Sommar – Requirements: Caching and Performance
 
 Cache strategy: cache headers, content-hash cache-busting for CSS/JS/images, image dimension and filename rules, image lazy-loading.

--- a/docs/02-requirements/design-and-content.md
+++ b/docs/02-requirements/design-and-content.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Design and Content"
+---
+
 # SB Sommar – Requirements: Design and Content
 
 Visual and editorial polish: hero redesign, link colors, modal styling, registration banner, locale overview page, index design.

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Event Data"
+---
+
 # SB Sommar – Requirements: Event Data
 
 Event data: source-of-truth YAML, locations, archive policy, naming convention, derived active camp, QA isolation, the camps.yaml validator.

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements"
+---
+
 # SB Sommar – Requirements
 
 This document defines what the site must do and for whom.

--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Pages and Navigation"
+---
+
 # SB Sommar – Requirements: Pages and Navigation
 
 Site structure: page inventory, the homepage pre-camp section, navigation, footer, hero CTAs, accordions, anchor IDs.

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Platform and Security"
+---
+
 # SB Sommar – Requirements: Platform and Security
 
 Cross-cutting platform concerns: reliability, accessibility, Swedish language, security hardening, analytics, feedback, PWA, admin token, rate limiting.

--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Requirements: Schedule and Activity Detail"
+---
+
 # SB Sommar – Requirements: Schedule and Activity Detail
 
 Schedule views (weekly, today, display), inline activity detail, static per-event pages, RSS, iCal, Markdown rendering of descriptions.

--- a/docs/03-architecture/appendix.md
+++ b/docs/03-architecture/appendix.md
@@ -13,6 +13,9 @@ Decisions evaluated and deliberately rejected. Kept here so they are not re-prop
 | Decision | Reason | Date |
 | --- | --- | --- |
 | CSS/JS minification | Total CSS+JS is ~22 KB; server gzips text assets, so actual transfer savings would be ~3–5 KB. Images (~1.7 MB) are the real payload. Build complexity not justified. | 2026-02 |
+| Docs site: own layout + own CSS (drop the Primer theme) | GitHub Pages' default `jekyll-theme-primer` already gives every page chrome, a max-width container, sans-serif typography, syntax highlighting, and the robots meta. Replacing it would re-implement all of that and own all styling for no gain. Extending Primer with a shadow layout plus nav includes (arch §34) is the smaller change. | 2026-06 |
+| Docs site: `just-the-docs` theme | Provides a sidebar tree and client-side search out of the box, but builds its navigation from per-file `parent`/`nav_order` front-matter — per-file hand-maintenance that conflicts with 02-§97.29's single-source listing — and restyles the whole site. Overkill at the current document count; revisit if the docs grow past ~30 files. | 2026-06 |
+| Docs site: do nothing | Leaves the genuine gaps unaddressed: no breadcrumb, no within-family navigation, and two `<h1>` elements per page. | 2026-06 |
 
 ---
 

--- a/docs/03-architecture/appendix.md
+++ b/docs/03-architecture/appendix.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Appendix"
+---
+
 # SB Sommar – Architecture: Appendix
 
 Trailing sections from the original architecture document: decisions deliberately rejected, and the design philosophy that frames the system. Both `§10` and `§11` here are out of numerical order with the rest of the document and `§11` is a duplicate heading (the other `§11` is "Event Data CI Pipeline" in [`ci-and-deploy.md`](./ci-and-deploy.md)). These irregularities are preserved as-is — the section IDs are stable strings, not encoded positions.

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: CI and Deploy"
+---
+
 # SB Sommar – Architecture: CI and Deploy
 
 The event-data CI pipeline, the camps.yaml validator, the Markdown converter, the PHP API for shared hosting, and content-hash asset cache-busting.

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -374,3 +374,88 @@ miss.
 | `source/build/build.js` | Post-processing: hash computation and URL rewriting |
 
 ---
+
+## 34. Documentation Site Layout and Navigation
+
+### 34.1 Context
+
+The documentation site (02-§97) is served by GitHub Pages using its
+built-in default theme, `jekyll-theme-primer`. Primer already wraps every
+rendered page — not only the landing page — in chrome: a site-title link
+back to the landing page, a max-width `markdown-body` container, a
+system sans-serif typeface, syntax highlighting, and the robots meta
+(02-§97.20) via the head-custom include. GitHub Pages derives a page
+`<title>` from the first `#` heading even when a file has no front-matter.
+
+Three gaps remain. Primer shows no breadcrumb, so a reader on a deep page
+(for example `02-requirements/pages-navigation.html`) cannot see which
+family the page belongs to. Primer offers no navigation between sibling
+files within a family; the only inter-doc link is the in-content "Part of
+the … index" line. And Primer renders the site title as an `<h1>`, so
+every page carries two `<h1>` elements — the site title and the
+document's own heading. Requirements 02-§97.22–97.29 close these gaps.
+
+### 34.2 Approach — extend Primer, do not replace it
+
+The site keeps `jekyll-theme-primer`. A project-owned
+`docs/_layouts/default.html` shadows the theme's layout: it reproduces
+Primer's page structure (head, container, content) and links Primer's
+generated stylesheet (`assets/css/style.css`), so the existing
+typography, tables, and code highlighting are unchanged, while adding the
+breadcrumb and the within-family navigation. Replacing Primer with an
+own-CSS layout or switching to `just-the-docs` were both evaluated and
+rejected; see appendix §10.
+
+### 34.3 Layout application and front-matter
+
+`docs/_config.yml` sets `defaults` so that every page under `docs/`
+receives `layout: default` without per-file opt-in (02-§97.22). Every
+`.md` file under `docs/` carries YAML front-matter with a `title`
+(02-§97.25). The layout uses `page.title` only for the `<title>` element
+and the breadcrumb — never as an on-page heading. The site title in the
+header is rendered as non-heading chrome (a styled link, not an `<h1>`),
+so the document's own top-level `#` heading is the single `<h1>` on the
+page (02-§97.26).
+
+### 34.4 Breadcrumb
+
+For a page inside a documentation subfolder, the layout derives the
+family from the page's URL path (for example `02-requirements/`) and
+renders a one-level breadcrumb above the content that links back to the
+landing page and names the family (02-§97.27). The landing page itself
+shows no breadcrumb. The human-readable family name comes from the same
+data source as the navigation block (§34.5).
+
+### 34.5 Within-family navigation
+
+A single data file, `docs/_data/docs-nav.yml`, lists each documentation
+family (`02-requirements/`, `03-architecture/`, `07-design/`,
+`99-traceability/`) and the files that belong to it. The include
+`docs/_includes/family-nav.html` selects the entry matching the current
+page's family and renders links to its sibling files, emitted as a
+navigation block below the content (02-§97.28). Because the listing lives
+in one data file, adding or removing a family member updates every
+sibling's navigation and the breadcrumb's family name without editing any
+individual page (02-§97.29).
+
+### 34.6 Robots policy preserved
+
+The project-owned layout owns the `<head>`, and it includes the existing
+`head-custom.html` so the `<meta name="robots" content="noindex,
+nofollow">` tag remains the single source of the robots directive
+(02-§97.20). The dual head-custom filenames stay shipped; with Primer
+still active as the theme they remain harmless, and the requirement's
+desired state — the tag present in the `<head>` of every rendered page —
+is unchanged.
+
+### 34.7 Files
+
+| File | Role |
+| ---- | ---- |
+| `docs/_config.yml` | `defaults` applying `layout: default` to every page |
+| `docs/_layouts/default.html` | Shadow layout: Primer structure + breadcrumb + family nav, single `<h1>` |
+| `docs/_data/docs-nav.yml` | Single source listing families and their files |
+| `docs/_includes/family-nav.html` | Renders the within-family navigation block |
+| `docs/_includes/breadcrumb.html` | Renders the one-level breadcrumb |
+
+---

--- a/docs/03-architecture/data-layer.md
+++ b/docs/03-architecture/data-layer.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Data Layer"
+---
+
 # SB Sommar – Architecture: Data Layer
 
 Camp YAML files, the central metadata registry, active-camp resolution, the archive layer, the shared footer, and search-engine blocking.

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Forms and API"
+---
+
 # SB Sommar – Architecture: Forms and API
 
 Participant event editing (session cookie architecture), per-field inline validation, participant event deletion, the add- and edit-activity submit flows, form time-gating, and the form draft cache.

--- a/docs/03-architecture/index.md
+++ b/docs/03-architecture/index.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture Overview"
+---
+
 # SB Sommar – Architecture Overview
 
 This project is a static, YAML-driven camp platform with a small API server for live event submissions. Two API implementations exist: a Node.js version (`app.js`) for local development and Node.js-capable hosts, and a PHP version (`api/`) for shared hosting environments (e.g. Loopia) that do not support Node.js.

--- a/docs/03-architecture/index.md
+++ b/docs/03-architecture/index.md
@@ -20,7 +20,7 @@ Architecture is split across topic files for readability. Section IDs (`03-§N.M
 | [`data-layer.md`](./data-layer.md) | Data Layer | §1, §2, §3, §4, §4a, §4b, §4c |
 | [`rendering.md`](./rendering.md) | Rendering | §5, §6, §17, §18 |
 | [`forms-and-api.md`](./forms-and-api.md) | Forms and API | §7, §7a, §7b, §8, §9, §13, §29 |
-| [`ci-and-deploy.md`](./ci-and-deploy.md) | CI and Deploy | §11 (Event Data CI), §19, §20, §21, §27 |
+| [`ci-and-deploy.md`](./ci-and-deploy.md) | CI and Deploy | §11 (Event Data CI), §19, §20, §21, §27, §34 |
 | [`pages-and-content.md`](./pages-and-content.md) | Pages and Content | §12, §14, §15, §16, §22, §23, §24, §25, §26, §32 |
 | [`platform-and-security.md`](./platform-and-security.md) | Platform and Security | §28, §30, §31, §33 |
 | [`appendix.md`](./appendix.md) | Appendix | §10, §11 (Design Philosophy) |

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Pages and Content"
+---
+
 # SB Sommar – Architecture: Pages and Content
 
 Unified site navigation, the upcoming-camps section, the hero redesign, location accordions, the iCal calendar export, analytics, image dimension attributes, static asset cache headers, the feedback button, and the registration banner.

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Platform and Security"
+---
+
 # SB Sommar – Architecture: Platform and Security
 
 The Progressive Web App layer, admin token infrastructure, authorization endpoint rate limiting, and regex performance and escape hygiene.

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Architecture: Rendering"
+---
+
 # SB Sommar – Architecture: Rendering
 
 Page rendering logic and project structure, plus the RSS feed and per-event page generation.

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Operations Guide"
+---
+
 # SB Sommar – Operations Guide
 
 How to develop, run, and deploy the site.

--- a/docs/05-DATA_CONTRACT.md
+++ b/docs/05-DATA_CONTRACT.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Data Contract"
+---
+
 # SB Sommar – Data Contract
 
 This document defines the official data structure for all camp YAML files.

--- a/docs/06-EVENT_DATA_MODEL.md
+++ b/docs/06-EVENT_DATA_MODEL.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Event Data Model"
+---
+
 # SB Sommar – Event Data Model
 
 This document explains *why* the event data is structured the way it is — the reasoning, the future-proofing decisions, and the design intent.

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Design: Components"
+---
+
 # SB Sommar – Design: Components
 
 Component-level visual rules: header, hero, banners, buttons, cards, accordions, form errors, modals, the Markdown toolbar/preview, the day grid, the locale-overview grid, and the conflict-warning banner.

--- a/docs/07-design/css-strategy.md
+++ b/docs/07-design/css-strategy.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Design: CSS Strategy"
+---
+
 # SB Sommar – Design: CSS Strategy
 
 How the stylesheet is organised, and the design tokens that everything else references.

--- a/docs/07-design/imagery-and-accessibility.md
+++ b/docs/07-design/imagery-and-accessibility.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Design: Imagery, Accessibility, and Guardrails"
+---
+
 # SB Sommar – Design: Imagery, Accessibility, and Guardrails
 
 Photography guidance, accessibility minimums, and the list of design moves to avoid.

--- a/docs/07-design/index.md
+++ b/docs/07-design/index.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Design Specification"
+---
+
 # SB Sommar – Design Specification
 
 Visual design reference for SB Sommar. Inspired by sbsommar.se, the live production site.

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -1,3 +1,7 @@
+---
+title: "SB Sommar – Environments"
+---
+
 # SB Sommar – Environments
 
 Three environments serve different stages of the development-to-production pipeline.

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -218,28 +218,42 @@ so the CI status of a docs-only change does not gate publication.
 
 ### Configuration
 
-The project owns four files under `docs/` that shape the published
-site:
+The project owns the following files under `docs/` that shape the
+published site:
 
-- `docs/_config.yml` activates the
+- `docs/_config.yml` sets `theme: jekyll-theme-primer` (GitHub Pages'
+  default theme, whitelisted — no Gemfile needed), activates the
   [`jekyll-relative-links`](https://github.com/benbalter/jekyll-relative-links)
-  plugin (whitelisted on GitHub Pages) so that relative links between
-  Markdown files such as `[text](other-file.md)` resolve correctly to
-  the rendered HTML pages on the published site.
+  plugin so that relative links between Markdown files such as
+  `[text](other-file.md)` resolve correctly to the rendered HTML pages,
+  and applies `layout: default` to every page via `defaults` so new docs
+  inherit the layout without per-file opt-in.
+- `docs/_layouts/default.html` is the project layout. It shadows the
+  theme's own layout: it links Primer's stylesheet, renders the site
+  title as a link (not a heading) so each page has a single `<h1>`, and
+  adds a breadcrumb above the content and a within-family navigation
+  block below it.
+- `docs/_data/docs-nav.yml` is the single source listing each
+  documentation family (`02-requirements/`, `03-architecture/`,
+  `07-design/`, `99-traceability/`) and the files in it. The breadcrumb
+  (`docs/_includes/breadcrumb.html`) and within-family navigation
+  (`docs/_includes/family-nav.html`) are generated from it, so adding or
+  removing a family member updates every sibling without per-file edits.
+- Every Markdown file under `docs/` carries YAML front-matter with a
+  `title`, used for the page `<title>` and the navigation labels.
 - `docs/robots.txt` (`User-agent: *` / `Disallow: /`) blocks every
   crawler at the documentation site root.
 - `docs/_includes/head-custom.html` and `docs/_includes/head_custom.html`
-  inject `<meta name="robots" content="noindex, nofollow">` into every
-  rendered page. Two filenames are shipped because GitHub Pages themes
-  use different conventions: Primer/Minima look for the dashed name,
-  Cayman looks for the underscored name. Whichever default GitHub
-  Pages selects, the meta tag still lands in `<head>`.
+  both carry `<meta name="robots" content="noindex, nofollow">`. The
+  project layout includes the dashed name; both filenames are shipped so
+  the meta tag lands in `<head>` regardless of theme convention
+  (Primer/Minima use the dashed name, Cayman the underscored one).
 - `docs/index.md` is the landing page — it carries a project-technical
   reverse-discoverability banner pointing back to the source
   repository, README, and issue tracker on github.com.
 
-No other Jekyll configuration is owned by the project; the default
-GitHub Pages theme and defaults are used as-is.
+The layout and navigation design is documented in
+[`03-architecture/ci-and-deploy.md` §34](03-architecture/ci-and-deploy.md).
 
 ### Visibility policy
 

--- a/docs/09-RELEASING.md
+++ b/docs/09-RELEASING.md
@@ -1,3 +1,7 @@
+---
+title: "Releasing to Production"
+---
+
 # Releasing to Production
 
 How to deploy the site to production. This guide assumes your changes are

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1406,6 +1406,14 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§97.19` | covered | DOCS-CFG-05: `docs/robots.txt` (Disallow: /) present; verified to address every user agent |
 | `02-§97.20` | covered | DOCS-CFG-06: both `docs/_includes/head-custom.html` (Primer/Minima) and `docs/_includes/head_custom.html` (Cayman) emit `<meta name="robots" content="noindex, nofollow">`; whichever theme GitHub Pages picks, the tag lands in `<head>` — manual browser verification confirms |
 | `02-§97.21` | covered | DOCS-CFG-07: no `sitemap.xml`, `sitemap.txt`, or forbidden Jekyll plugins (`jekyll-sitemap`, `jekyll-seo-tag`, `jekyll-feed`) under `docs/` |
+| `02-§97.22` | gap | Arch §34.2–34.3: `docs/_config.yml` `defaults` apply `layout: default` to every page; shadow layout over Primer. Issue #355, pending Phase 4 |
+| `02-§97.23` | gap | Arch §34.1: header site-title links to landing page (already provided by Primer; preserved by the shadow layout). Issue #355 |
+| `02-§97.24` | gap | Arch §34.1: max-width `markdown-body` container (Primer's CSS, retained). Issue #355 |
+| `02-§97.25` | gap | Arch §34.3: YAML front-matter `title` on every `.md` under `docs/`. Issue #355, pending Phase 4 |
+| `02-§97.26` | gap | Arch §34.3: site title rendered as non-heading chrome so the document's `#` heading is the only `<h1>`. Issue #355, pending Phase 4 |
+| `02-§97.27` | gap | Arch §34.4: one-level breadcrumb on subfolder pages, naming the family. Issue #355, pending Phase 4 |
+| `02-§97.28` | gap | Arch §34.5: within-family navigation block from `docs/_includes/family-nav.html`. Issue #355, pending Phase 4 |
+| `02-§97.29` | gap | Arch §34.5: `docs/_data/docs-nav.yml` is the single source for family listings; siblings update without per-file edits. Issue #355, pending Phase 4 |
 
 ### §98 — Locale Overview Page
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1406,14 +1406,14 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§97.19` | covered | DOCS-CFG-05: `docs/robots.txt` (Disallow: /) present; verified to address every user agent |
 | `02-§97.20` | covered | DOCS-CFG-06: both `docs/_includes/head-custom.html` (Primer/Minima) and `docs/_includes/head_custom.html` (Cayman) emit `<meta name="robots" content="noindex, nofollow">`; whichever theme GitHub Pages picks, the tag lands in `<head>` — manual browser verification confirms |
 | `02-§97.21` | covered | DOCS-CFG-07: no `sitemap.xml`, `sitemap.txt`, or forbidden Jekyll plugins (`jekyll-sitemap`, `jekyll-seo-tag`, `jekyll-feed`) under `docs/` |
-| `02-§97.22` | gap | Arch §34.2–34.3: `docs/_config.yml` `defaults` apply `layout: default` to every page; shadow layout over Primer. Issue #355, pending Phase 4 |
-| `02-§97.23` | gap | Arch §34.1: header site-title links to landing page (already provided by Primer; preserved by the shadow layout). Issue #355 |
-| `02-§97.24` | gap | Arch §34.1: max-width `markdown-body` container (Primer's CSS, retained). Issue #355 |
-| `02-§97.25` | gap | Arch §34.3: YAML front-matter `title` on every `.md` under `docs/`. Issue #355, pending Phase 4 |
-| `02-§97.26` | gap | Arch §34.3: site title rendered as non-heading chrome so the document's `#` heading is the only `<h1>`. Issue #355, pending Phase 4 |
-| `02-§97.27` | gap | Arch §34.4: one-level breadcrumb on subfolder pages, naming the family. Issue #355, pending Phase 4 |
-| `02-§97.28` | gap | Arch §34.5: within-family navigation block from `docs/_includes/family-nav.html`. Issue #355, pending Phase 4 |
-| `02-§97.29` | gap | Arch §34.5: `docs/_data/docs-nav.yml` is the single source for family listings; siblings update without per-file edits. Issue #355, pending Phase 4 |
+| `02-§97.22` | gap | Arch §34.2–34.3. Manual checkpoint: view any rendered page's source and confirm the project layout is applied (header chrome present) with no per-file `layout:` opt-in. Issue #355, pending Phase 4 |
+| `02-§97.23` | gap | Arch §34.1. Manual checkpoint: every page header shows the site title and the title links to the landing page. Issue #355, pending Phase 4 |
+| `02-§97.24` | gap | Arch §34.1. Manual checkpoint: on a wide screen, content sits in a constrained max-width column (Primer `markdown-body`). Issue #355, pending Phase 4 |
+| `02-§97.25` | gap | DOCS-NAV-05 (`tests/docs-nav.test.js`): every `.md` under `docs/` has front-matter with a non-empty `title`. Issue #355, pending Phase 4 |
+| `02-§97.26` | gap | Arch §34.3. Manual checkpoint: view a deep page's source — exactly one `<h1>` (the document heading); the site title is a link, not an `<h1>`. Issue #355, pending Phase 4 |
+| `02-§97.27` | gap | Arch §34.4. Manual checkpoint: a subfolder page shows a one-level breadcrumb linking to the landing page and naming the family; the landing page shows none. Issue #355, pending Phase 4 |
+| `02-§97.28` | gap | DOCS-NAV-01..04 (`tests/docs-nav.test.js`) verify the nav data; manual checkpoint: a deep page renders a sibling-nav block with working links. Issue #355, pending Phase 4 |
+| `02-§97.29` | gap | DOCS-NAV-04 (`tests/docs-nav.test.js`): `docs/_data/docs-nav.yml` listings stay in sync with the files on disk, so one edit updates every sibling. Issue #355, pending Phase 4 |
 
 ### §98 — Locale Overview Page
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1,3 +1,7 @@
+---
+title: "Traceability — 02-requirements"
+---
+
 # Traceability — 02-requirements
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1410,14 +1410,14 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§97.19` | covered | DOCS-CFG-05: `docs/robots.txt` (Disallow: /) present; verified to address every user agent |
 | `02-§97.20` | covered | DOCS-CFG-06: both `docs/_includes/head-custom.html` (Primer/Minima) and `docs/_includes/head_custom.html` (Cayman) emit `<meta name="robots" content="noindex, nofollow">`; whichever theme GitHub Pages picks, the tag lands in `<head>` — manual browser verification confirms |
 | `02-§97.21` | covered | DOCS-CFG-07: no `sitemap.xml`, `sitemap.txt`, or forbidden Jekyll plugins (`jekyll-sitemap`, `jekyll-seo-tag`, `jekyll-feed`) under `docs/` |
-| `02-§97.22` | gap | Arch §34.2–34.3. Manual checkpoint: view any rendered page's source and confirm the project layout is applied (header chrome present) with no per-file `layout:` opt-in. Issue #355, pending Phase 4 |
-| `02-§97.23` | gap | Arch §34.1. Manual checkpoint: every page header shows the site title and the title links to the landing page. Issue #355, pending Phase 4 |
-| `02-§97.24` | gap | Arch §34.1. Manual checkpoint: on a wide screen, content sits in a constrained max-width column (Primer `markdown-body`). Issue #355, pending Phase 4 |
-| `02-§97.25` | gap | DOCS-NAV-05 (`tests/docs-nav.test.js`): every `.md` under `docs/` has front-matter with a non-empty `title`. Issue #355, pending Phase 4 |
-| `02-§97.26` | gap | Arch §34.3. Manual checkpoint: view a deep page's source — exactly one `<h1>` (the document heading); the site title is a link, not an `<h1>`. Issue #355, pending Phase 4 |
-| `02-§97.27` | gap | Arch §34.4. Manual checkpoint: a subfolder page shows a one-level breadcrumb linking to the landing page and naming the family; the landing page shows none. Issue #355, pending Phase 4 |
-| `02-§97.28` | gap | DOCS-NAV-01..04 (`tests/docs-nav.test.js`) verify the nav data; manual checkpoint: a deep page renders a sibling-nav block with working links. Issue #355, pending Phase 4 |
-| `02-§97.29` | gap | DOCS-NAV-04 (`tests/docs-nav.test.js`): `docs/_data/docs-nav.yml` listings stay in sync with the files on disk, so one edit updates every sibling. Issue #355, pending Phase 4 |
+| `02-§97.22` | implemented | `docs/_config.yml` `defaults` apply `layout: default`; `docs/_layouts/default.html`. Verified via local Jekyll build: all 36 rendered pages wrapped in the layout, no per-file `layout:` opt-in |
+| `02-§97.23` | implemented | `docs/_layouts/default.html` renders the site title as a link to the landing page. Verified in the rendered output |
+| `02-§97.24` | implemented | `theme: jekyll-theme-primer`; content in Primer's `container-lg … markdown-body`; `assets/css/style.css` built. Verified in the rendered output |
+| `02-§97.25` | covered | DOCS-NAV-05 (`tests/docs-nav.test.js`): every `.md` under `docs/` has front-matter with a non-empty `title` (36/36) |
+| `02-§97.26` | implemented | `docs/_layouts/default.html` renders the site title as a link, not an `<h1>`. Verified via build: exactly one `<h1>` on all 36 pages |
+| `02-§97.27` | implemented | `docs/_includes/breadcrumb.html`. Verified: `All docs › <Family>` breadcrumb on family pages, absent on the landing page and top-level docs |
+| `02-§97.28` | implemented | `docs/_includes/family-nav.html`. Verified: sibling links render on deep pages with the current page excluded; absent on landing/top-level. Nav data verified by DOCS-NAV-01..04 |
+| `02-§97.29` | covered | DOCS-NAV-04 (`tests/docs-nav.test.js`): `docs/_data/docs-nav.yml` listings stay in sync with the files on disk, so one edit updates every sibling |
 
 ### §98 — Locale Overview Page
 

--- a/docs/99-traceability/03-architecture.md
+++ b/docs/99-traceability/03-architecture.md
@@ -1,3 +1,7 @@
+---
+title: "Traceability — 03-architecture"
+---
+
 # Traceability — 03-architecture
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/05-data-contract.md
+++ b/docs/99-traceability/05-data-contract.md
@@ -1,3 +1,7 @@
+---
+title: "Traceability — 05-data-contract"
+---
+
 # Traceability — 05-data-contract
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/07-design.md
+++ b/docs/99-traceability/07-design.md
@@ -1,3 +1,7 @@
+---
+title: "Traceability — 07-design"
+---
+
 # Traceability — 07-design
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/claude.md
+++ b/docs/99-traceability/claude.md
@@ -1,3 +1,7 @@
+---
+title: "Traceability — CLAUDE.md"
+---
+
 # Traceability — CLAUDE.md
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -1,3 +1,7 @@
+---
+title: "Requirements Traceability Matrix – SB Sommar"
+---
+
 # Requirements Traceability Matrix – SB Sommar
 
 ## What is this document?

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -1,3 +1,7 @@
+---
+title: "Test ID Legend"
+---
+
 # Test ID Legend
 
 Part of [the traceability index](./index.md).

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -172,3 +172,5 @@ Part of [the traceability index](./index.md).
 | MDT-20 | `tests/markdown-toolbar.test.js` | `02-§57.8 — Accessible aria-label` |
 | MDT-21..22 | `tests/markdown-toolbar.test.js` | `02-§57.10 — Shared markdown-toolbar.js` |
 | MDT-23 | `tests/markdown-toolbar.test.js` | `02-§57.13 — Focus indicator` |
+| DOCS-NAV-01..04 | `tests/docs-nav.test.js` | `docs-nav.yml — single source for within-family navigation (02-§97.28, 02-§97.29)` |
+| DOCS-NAV-05 | `tests/docs-nav.test.js` | `docs front-matter — every page carries a title (02-§97.25)` |

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,13 @@
 
 title: SB Sommar – Project Documentation
 
+# GitHub Pages' built-in default theme. Set explicitly so its stylesheet
+# (assets/css/style.css) is generated even though the project-owned
+# _layouts/default.html shadows the theme's own layout. No Gemfile needed —
+# jekyll-theme-primer is whitelisted on GitHub Pages. See
+# docs/03-architecture/ci-and-deploy.md §34.
+theme: jekyll-theme-primer
+
 # Enable jekyll-relative-links so that intra-docs links written as
 # [text](other-file.md) resolve to the rendered HTML pages.
 # This plugin is whitelisted on GitHub Pages (no Gemfile needed).
@@ -13,3 +20,11 @@ plugins:
 relative_links:
   enabled: true
   collections: true
+
+# Apply the project layout to every page without per-file front-matter
+# opt-in (02-§97.22). Pages still carry a front-matter `title` (02-§97.25).
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/docs/_data/docs-nav.yml
+++ b/docs/_data/docs-nav.yml
@@ -1,0 +1,49 @@
+# Single source for the documentation site's within-family navigation and
+# breadcrumb (02-§97.28, 02-§97.29). Each family lists the Markdown files in
+# its folder; tests/docs-nav.test.js (DOCS-NAV-04) fails if this drifts out of
+# sync with the files on disk. Link text and URLs are not duplicated here —
+# the breadcrumb and nav includes read each page's own front-matter `title`
+# via site.pages, so this file only needs the folder, a display name, and the
+# member filenames.
+families:
+  - dir: 02-requirements
+    name: Requirements
+    files:
+      - index.md
+      - pages-navigation.md
+      - schedule-and-detail.md
+      - add-edit-forms.md
+      - event-data.md
+      - build-deploy.md
+      - caching-performance.md
+      - platform-security.md
+      - design-and-content.md
+      - archive.md
+  - dir: 03-architecture
+    name: Architecture
+    files:
+      - index.md
+      - data-layer.md
+      - rendering.md
+      - forms-and-api.md
+      - ci-and-deploy.md
+      - pages-and-content.md
+      - platform-and-security.md
+      - appendix.md
+  - dir: 07-design
+    name: Design
+    files:
+      - index.md
+      - components.md
+      - css-strategy.md
+      - imagery-and-accessibility.md
+  - dir: 99-traceability
+    name: Traceability
+    files:
+      - index.md
+      - 02-requirements.md
+      - 03-architecture.md
+      - 05-data-contract.md
+      - 07-design.md
+      - claude.md
+      - test-id-legend.md

--- a/docs/_includes/breadcrumb.html
+++ b/docs/_includes/breadcrumb.html
@@ -1,0 +1,18 @@
+{%- comment -%}
+One-level breadcrumb for documentation pages that live inside a family
+subfolder (02-§97.27). Derives the family from the first path segment and
+links back to the landing page and the family index. Top-level pages and the
+landing page itself match no family, so they render no breadcrumb.
+{%- endcomment -%}
+{%- assign nav = site.data["docs-nav"] -%}
+{%- assign parts = page.path | split: "/" -%}
+{%- assign current_dir = parts[0] -%}
+{%- for family in nav.families -%}
+  {%- if family.dir == current_dir -%}
+    <nav class="docs-breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ '/' | relative_url }}">All docs</a>
+      <span aria-hidden="true">›</span>
+      <a href="{{ family.dir | append: '/' | relative_url }}">{{ family.name }}</a>
+    </nav>
+  {%- endif -%}
+{%- endfor -%}

--- a/docs/_includes/family-nav.html
+++ b/docs/_includes/family-nav.html
@@ -17,7 +17,18 @@ render nothing.
           {%- assign target = family.dir | append: "/" | append: file -%}
           {%- for p in site.pages -%}
             {%- if p.path == target and p.url != page.url -%}
-              <li><a href="{{ p.url | relative_url }}">{{ p.title }}</a></li>
+              {%- comment -%}
+              Short link label: drop the repeated family prefix so the list
+              reads "Pages and Navigation" rather than the full page title
+              "SB Sommar – Requirements: Pages and Navigation".
+              {%- endcomment -%}
+              {%- assign label = p.title -%}
+              {%- if label contains ": " -%}
+                {%- assign label = label | split: ": " | last -%}
+              {%- elsif label contains "SB Sommar – " -%}
+                {%- assign label = label | remove_first: "SB Sommar – " -%}
+              {%- endif -%}
+              <li><a href="{{ p.url | relative_url }}">{{ label }}</a></li>
             {%- endif -%}
           {%- endfor -%}
         {%- endfor -%}

--- a/docs/_includes/family-nav.html
+++ b/docs/_includes/family-nav.html
@@ -1,0 +1,27 @@
+{%- comment -%}
+Within-family navigation block (02-§97.28). Lists the other files in the
+current page's family, each linked by its own front-matter title, resolved
+from site.pages via the filenames in _data/docs-nav.yml (02-§97.29). The
+current page is omitted. Top-level and landing pages match no family and
+render nothing.
+{%- endcomment -%}
+{%- assign nav = site.data["docs-nav"] -%}
+{%- assign parts = page.path | split: "/" -%}
+{%- assign current_dir = parts[0] -%}
+{%- for family in nav.families -%}
+  {%- if family.dir == current_dir -%}
+    <nav class="docs-family-nav" aria-label="More in {{ family.name }}">
+      <strong>More in {{ family.name }}</strong>
+      <ul>
+        {%- for file in family.files -%}
+          {%- assign target = family.dir | append: "/" | append: file -%}
+          {%- for p in site.pages -%}
+            {%- if p.path == target and p.url != page.url -%}
+              <li><a href="{{ p.url | relative_url }}">{{ p.title }}</a></li>
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endfor -%}
+      </ul>
+    </nav>
+  {%- endif -%}
+{%- endfor -%}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    {%- comment -%}
+    head-custom.html carries the robots noindex/nofollow meta (02-§97.20).
+    Keeping it as an include preserves that single source under the new layout.
+    {%- endcomment -%}
+    {% include head-custom.html %}
+    <style>
+      /* Scoped chrome for the documentation site. Primer (the active theme)
+         styles the document body; these rules only cover the breadcrumb,
+         within-family navigation, and the site-title link the layout adds. */
+      .docs-site-title { display: block; margin-bottom: 1.5rem; font-size: 1.25rem; font-weight: 600; text-decoration: none; }
+      .docs-breadcrumb { margin-bottom: 1.5rem; font-size: 0.875rem; color: #57606a; }
+      .docs-breadcrumb a { color: #57606a; }
+      .docs-breadcrumb span { margin: 0 0.25rem; }
+      .docs-family-nav { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; }
+      .docs-family-nav ul { margin: 0.5rem 0 0; padding-left: 1.25rem; }
+    </style>
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      {%- comment -%}
+      Site title rendered as a link, not an <h1>, so the document's own
+      top-level heading is the single <h1> on the page (02-§97.23, 02-§97.26).
+      {%- endcomment -%}
+      <a href="{{ '/' | relative_url }}" class="docs-site-title">{{ site.title }}</a>
+      {% include breadcrumb.html %}
+      {{ content }}
+      {% include family-nav.html %}
+    </div>
+  </body>
+</html>

--- a/tests/docs-nav.test.js
+++ b/tests/docs-nav.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+// ── Requirements: 02-§97.25, 02-§97.28, 02-§97.29 ────────────────────────────
+// The documentation site's within-family navigation is driven by a single
+// data file, docs/_data/docs-nav.yml, that lists each documentation family
+// and the files belonging to it (02-§97.28, 02-§97.29). Every Markdown file
+// under docs/ carries YAML front-matter with a title (02-§97.25).
+//
+// These tests read the repository tree directly. The data file is checked
+// against the actual files on disk, so it cannot silently rot when a family
+// member is added or removed — the test fails until the single source is
+// brought back in sync.
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DOCS_DIR = path.join(REPO_ROOT, 'docs');
+const NAV_DATA_PATH = path.join(DOCS_DIR, '_data', 'docs-nav.yml');
+
+// The four documentation families that have a subfolder of their own.
+const FAMILY_DIRS = [
+  '02-requirements',
+  '03-architecture',
+  '07-design',
+  '99-traceability',
+];
+
+/** Markdown files actually present directly inside docs/<dir>/. */
+function actualMarkdownFiles(dir) {
+  return fs
+    .readdirSync(path.join(DOCS_DIR, dir))
+    .filter((name) => name.endsWith('.md'))
+    .sort();
+}
+
+/** Every .md file under docs/, recursively, as repo-relative paths. */
+function allMarkdownFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...allMarkdownFiles(full));
+    } else if (entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Parse the leading YAML front-matter block of a Markdown file, or null. */
+function frontMatter(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const match = /^---\n([\s\S]*?)\n---/.exec(text);
+  if (!match) return null;
+  return yaml.load(match[1]) || {};
+}
+
+describe('docs-nav.yml — single source for within-family navigation (02-§97.28, 02-§97.29)', () => {
+  it('DOCS-NAV-01: the data file exists and parses as a families list', () => {
+    assert.ok(fs.existsSync(NAV_DATA_PATH), 'docs/_data/docs-nav.yml must exist');
+    const data = yaml.load(fs.readFileSync(NAV_DATA_PATH, 'utf8'));
+    assert.ok(data && Array.isArray(data.families), 'must have a `families` array');
+  });
+
+  it('DOCS-NAV-02: every family has a dir, a human-readable name, and a files list', () => {
+    const data = yaml.load(fs.readFileSync(NAV_DATA_PATH, 'utf8'));
+    for (const family of data.families) {
+      assert.ok(typeof family.dir === 'string' && family.dir, 'family needs a dir');
+      assert.ok(typeof family.name === 'string' && family.name, `family ${family.dir} needs a name`);
+      assert.ok(Array.isArray(family.files) && family.files.length > 0, `family ${family.dir} needs files`);
+    }
+  });
+
+  it('DOCS-NAV-03: the data file covers exactly the four family folders', () => {
+    const data = yaml.load(fs.readFileSync(NAV_DATA_PATH, 'utf8'));
+    const dirs = data.families.map((f) => f.dir).sort();
+    assert.deepEqual(dirs, [...FAMILY_DIRS].sort());
+  });
+
+  for (const dir of FAMILY_DIRS) {
+    it(`DOCS-NAV-04 (${dir}): listed files match the .md files actually on disk`, () => {
+      const data = yaml.load(fs.readFileSync(NAV_DATA_PATH, 'utf8'));
+      const family = data.families.find((f) => f.dir === dir);
+      assert.ok(family, `docs-nav.yml must list family ${dir}`);
+      const listed = [...family.files].sort();
+      assert.deepEqual(listed, actualMarkdownFiles(dir),
+        `docs-nav.yml listing for ${dir} is out of sync with the folder`);
+    });
+  }
+});
+
+describe('docs front-matter — every page carries a title (02-§97.25)', () => {
+  for (const file of allMarkdownFiles(DOCS_DIR)) {
+    const rel = path.relative(REPO_ROOT, file);
+    it(`DOCS-NAV-05: ${rel} has front-matter with a non-empty title`, () => {
+      const fm = frontMatter(file);
+      assert.ok(fm, `${rel} is missing YAML front-matter`);
+      assert.ok(typeof fm.title === 'string' && fm.title.trim().length > 0,
+        `${rel} front-matter needs a non-empty title`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds consistent chrome and navigation to the GitHub Pages documentation
site, **keeping** its default theme (`jekyll-theme-primer`) and extending
it rather than replacing it.

- **Front-matter** `title` on every `.md` under `docs/`, matching each
  file's first heading.
- **Project layout** (`docs/_layouts/default.html`) shadowing Primer:
  renders the site title as a link (not a heading) so each page has a
  single `<h1>`, and includes `head-custom.html` so the
  `noindex, nofollow` robots meta stays on every page.
- **Breadcrumb** on family pages (`All docs › <Family>`).
- **Within-family navigation** driven by a single source
  (`docs/_data/docs-nav.yml`), kept in sync with disk by tests.
- `docs/_config.yml` sets the theme explicitly and applies
  `layout: default` to every page via `defaults`.

Requirements `02-§97.22–97.29`; design in
`03-architecture/ci-and-deploy.md §34`; rejected alternatives (own CSS,
just-the-docs, do nothing) recorded in the appendix decision log.

## Test plan

- [x] `npm test` — 1773 pass (includes DOCS-NAV data + front-matter tests)
- [x] `npm run lint` and `npm run lint:md` clean
- [x] Local Jekyll build: 36/36 pages emit the robots meta and have
  exactly one `<h1>`; breadcrumb + family-nav render on deep pages and
  are absent on the landing/top-level pages; `robots.txt` stays raw; no
  OG/SEO tags injected
- [ ] Post-merge: confirm the live GitHub Pages site renders the chrome
  under the `/sbsommar/` base path

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)