### PR TITLE
Uppdatera matinfo för 2026 och öppna externa länkar i ny flik

### DIFF
--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -9,6 +9,27 @@ const { pwaHeadTags } = require('./pwa');
 const { getImageDimensions } = require('./image-dimensions');
 
 /**
+ * marked link renderer override. External http(s) links open in a new tab
+ * with rel="noopener noreferrer", matching how the hero, registration CTA,
+ * event and calendar links behave. Internal and in-page anchor links (e.g.
+ * #mat, #service) return false so marked's default renderer handles them and
+ * they stay in the same tab. Used as a method, so `this` is the renderer
+ * instance and `this.parser` is available.
+ */
+function renderLink({ href, title, tokens }) {
+  if (!/^https?:\/\//i.test(href)) return false;
+  let cleanHref;
+  try {
+    cleanHref = encodeURI(href).replace(/%25/g, '%');
+  } catch {
+    return false;
+  }
+  const text = this.parser.parseInline(tokens);
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  return `<a href="${cleanHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+}
+
+/**
  * Converts inline Markdown (images, links, bold) to HTML using marked.
  * Content files are author-controlled so no HTML escaping is applied.
  */
@@ -16,6 +37,7 @@ function inlineHtml(text, contentDir) {
   const md = new Marked();
   md.use({
     renderer: {
+      link: renderLink,
       image({ href, text: alt }) {
         const dimAttrs = resolveDimAttrs(href, contentDir);
         return `<img src="${href}" alt="${alt || ''}" class="content-img"${dimAttrs} loading="lazy">`;
@@ -66,6 +88,7 @@ function createMarked(headingOffset, contentDir) {
   const md = new Marked();
   md.use({
     renderer: {
+      link: renderLink,
       heading({ tokens, depth }) {
         const level = Math.min(depth + headingOffset, 6);
         const text = this.parser.parseInline(tokens);

--- a/source/content/food.md
+++ b/source/content/food.md
@@ -1,26 +1,8 @@
 # Vad blir det för mat?
 
-## Veckans meny (3-10 augusti 2025)
-
-Alla dagar går det att beställa utöver menyn nedan:
-
-* Vegetarisk gryta med ris
-* Tjälknöl med potatissallad
-
-|**Dag**|**Lunch**|**Middag**|
-| --- | --- | --- |
-|Söndag|–|Färsbiffar med pepparsås och klyftpotatis. Middag. (Innehåller mjölkprotein.)|
-|Måndag|Kokt sejrygg med vitvinsås och kokt potatis. (Innehåller mjölkprotein)|Lasagne med pestosallad. Middag (Innehåller gluten och mjölkprotein)|
-|Tisdag|Kycklinggryta med ris.|Biffwok med ostronsås och risnudlar. (Innehåller spår av gluten)|
-|Onsdag|Kotlettrad med svampsås och stekt potatis. (Innehåller mjölkprotein)|Linsgryta med bönor och couscous. (Innehåller gluten)|
-|Torsdag|Laxpudding med skirat smör och grönsallad. (Innehåller mjölkprotein och ägg)|Chili con carne med ris.|
-|Fredag|Korvgryta med rostade rotgrönsaker.|Kycklingfile med tomatsås och pasta. (Innehåller gluten)|
-|Lördag|Tjälknöl på nöt med potatissallad. (Serveras kall)|Sukiyaki med grönsaker, räkor och glasnudlar. (innehåller spår av gluten)|
-|Söndag|Räksallad med ägg pasta och dressing. (Serveras kall)|–|
-
 ## Olika alternativ för mat
 
-* Vissa beställer hela veckan
+* Vissa beställer mat under veckan
 * Vissa fixar all mat på plats.
 * Vissa har med sig färdiga matlådor hemifrån.
 * Vissa kör på restauranger och takeaway runtom.
@@ -28,38 +10,26 @@ Alla dagar går det att beställa utöver menyn nedan:
 
 Man får utgå från sin egen situation och planera vad som fungerar bäst. Bor man på området? Är man två föräldrar med? Har man bil tillgänglig? Har barnen specifika behov? Har man tillgång till kök? Mataffären är några kilometer bort och de flesta tar något slags fordon dit(går ofta att samåka med någon till affären), ska alla laga mat i servicehuset blir det trångt och man behöver då ha med sig egna köksprylar som kastrull, stekpanna och tallrikar. Är man en stor familj kostar det en slant att köpa mat till varje måltid, men det är bekvämt. Se även under “[Hur är det med service runtom Sysslebäck?](#service)“
 
-## Information om att beställa mat
+## Beställa mat från Thaivagnen - specialfunktion för lägret
 
-Lunch levereras till campingen i värmeskåp runt kl 12.00 dagligen.
-Middag levereras runt 16.30.
+Det går att beställa mat från Thaivagnen (Baansuan Takeaway) i Ransbyn. Beställningen görs via deras förbeställningssida:
 
-Det kommer även gå att beställa Thaimat från samma leverantör. Priser på Thaimat som beställs direkt från Thai-vagnen kommer att stå i menyn på deras hemsida. Mer information under “[Restaurang och take away](/#service)”.
+[Beställ mat hos Baansuan Takeaway](https://www.baansuantakeaway.se/pre-order/)
 
-### Födoämnesintolleranser / allergier
+Beställ från **specialmenyn för oss** för att få priset **115 kr per portion**. Beställer man från den vanliga menyn på deras hemsida går det inte att lova exakt hämttid, och man får inte det rabatterade priset.
 
-Allt görs **laktosfritt**.
-Det står angivet i menyn vilka rätter som innehåller **gluten**.
-Övriga födoämnesintolleranser/ allergier får man själv hålla reda på utifrån menyn, köket kommer inte göra individuella anpassningar av rätterna.
+Allergi- och innehållsinformation står i menyn på beställningssidan.
 
-### Beställ
+### Så här beställer du
 
-Det kommer att vara stora portioner så räkna en portion till två yngre barn.
-Ange antal portioner per rätt och måltid i formuläret. (Om man vill ha mer än 6 portioner av ett mål en eller flera dagar så gör man en ytterligare beställning.)
-
-[Beställ mat (senast 30 juli 2025)](https://docs.google.com/forms/d/e/1FAIpQLSf_7qvDSueq_QaJcSPfeNN-5a61FBWchCdzxJp1Z3q3PVnu0Q/viewform)
+* **Beställ minst 2 dagar i förväg.**
+* Ange tydligt om beställningen gäller **lunch (hämtas 11.30)** eller **middag (hämtas 16.30)**. Maten läggs i en värmebox.
+* Kom ihåg vad du beställt. I sista rutan (önskemål) anger du **vilken rätt som hör till vilken dag och måltid**. Den rutan kommer innan betalningen, i steget *slutför beställning* — gör hela beställningen klar innan den dyker upp.
 
 ### Betalning
 
-Betalning görs med Swish direkt till Leverantören “***Baansuantakeaway Emma Lagerkvist**”* på **Swish nummer 123 179 54 91**
-**Beställ** och **betala** för maten senast onsdagen **30 juli** för att beställningen ska vara giltig, gärna innan det.
-Märk betalningen med:
+Betala med **Swish vid beställningen**.
 
-* Mat
-* Namn
-* Antal portioner totalt för hela veckan
+### Upphämtning
 
-Exempel: “Mat Anders Andersson 42”
-
-**Pris 130 kr per portion**  
-***Räkna portionsantalet noga så att summan stämmer innan ni gör betalningen.***  
-**Smaklig spis!**  
+Maten hämtas i Ransbyn, ungefär 6 km från lägret, två gånger om dagen (11.30 och 16.30). Det är ingen leverans till campingen — de som beställt mat kommer själva överens om hur hämtningen ska gå till, och man kan gärna samåka. Använd [den här tråden i Facebook](https://www.facebook.com/groups/syssleback2026/posts/1358115749522511) för att samordna hämtningen av mat.

--- a/source/content/local-info.md
+++ b/source/content/local-info.md
@@ -2,8 +2,8 @@
 
 ## **Restauranger och Take-away**
 
-**Baansuan Takeway Thai (även leverantör av matsedeln ovan)**
-[Baansuan Takeaway](https://www.baansuantakeaway.se/) har en hemsida där man kan beställa. På deras [Facebook-sida](https://www.facebook.com/profile.php?id=100086764924582) finns bilder med mera.
+**Baansuan Takeaway Thai (lägrets matleverantör – se [Mat](#mat))**
+[Baansuan Takeaway](https://www.baansuantakeaway.se/) har en hemsida där man kan beställa, och en [förbeställningssida](https://www.baansuantakeaway.se/pre-order/) för att beställa i förväg. På deras [Facebook-sida](https://www.facebook.com/profile.php?id=100086764924582) finns bilder med mera.
 
 **Pizzeria Sysslebäck**
 [Sysslebäcks pizzeria](https://www.sysslebackspizzeria.se/) har en hemsida med enkel beställning. Med utkörning ibland. Kolla hemsidan vad som gäller denna veckan.

--- a/tests/render-index.test.js
+++ b/tests/render-index.test.js
@@ -21,9 +21,26 @@ describe('convertMarkdown – inline Markdown', () => {
     assert.ok(html.includes('<strong>Hello</strong>'), `Got: ${html}`);
   });
 
-  it('converts a link ([text](url)) to <a>', () => {
+  it('converts an external link to <a> that opens in a new tab', () => {
     const html = convertMarkdown('[Click here](https://example.com)');
-    assert.ok(html.includes('<a href="https://example.com">Click here</a>'), `Got: ${html}`);
+    assert.ok(
+      html.includes('<a href="https://example.com" target="_blank" rel="noopener noreferrer">Click here</a>'),
+      `Got: ${html}`,
+    );
+  });
+
+  it('opens http (non-https) external links in a new tab too', () => {
+    const html = convertMarkdown('[Plain](http://example.com)');
+    assert.ok(
+      html.includes('<a href="http://example.com" target="_blank" rel="noopener noreferrer">Plain</a>'),
+      `Got: ${html}`,
+    );
+  });
+
+  it('keeps in-page anchor links in the same tab (no target/rel)', () => {
+    const html = convertMarkdown('[Till maten](#mat)');
+    assert.ok(html.includes('<a href="#mat">Till maten</a>'), `Got: ${html}`);
+    assert.ok(!html.includes('target="_blank"'), `anchor link should not open a new tab. Got: ${html}`);
   });
 
   it('converts an image (![alt](src)) to <img> with loading="lazy"', () => {
@@ -39,7 +56,10 @@ describe('convertMarkdown – inline Markdown', () => {
   it('handles multiple inline elements in one paragraph', () => {
     const html = convertMarkdown('See **this** [link](https://x.com).');
     assert.ok(html.includes('<strong>this</strong>'), `Got: ${html}`);
-    assert.ok(html.includes('<a href="https://x.com">link</a>'), `Got: ${html}`);
+    assert.ok(
+      html.includes('<a href="https://x.com" target="_blank" rel="noopener noreferrer">link</a>'),
+      `Got: ${html}`,
+    );
   });
 });
 


### PR DESCRIPTION
## Sammanfattning

- **Matinfo 2026** (`source/content/food.md`): veckomenyn för 2025, leverans till campingen, Google Forms-beställningen (deadline 30 juli), det gamla Swish-numret och priset 130 kr är borttagna. Sidan beskriver nu beställning via Baansuan Takeaways förbeställningssida (115 kr/portion via specialmenyn för oss), beställning minst 2 dagar i förväg, lunch hämtas 11.30 / middag 16.30 i värmebox, önskemålsrutan för rätt→dag→måltid, betalning med Swish vid beställningen, och upphämtning ca 6 km bort två gånger om dagen med samordning via lägrets Facebook-tråd. Det allmänna stycket om olika matalternativ behålls.
- **Service-sidan** (`source/content/local-info.md`): Baansuan-raden pekar nu på `#mat` i stället för den borttagna menyn och länkar till förbeställningssidan; stavfel "Takeway" rättat.
- **Externa länkar öppnas i ny flik**: en delad `renderLink` ger externa `http(s)`-länkar i innehållssektioner och läger-info `target="_blank" rel="noopener noreferrer"`, i linje med hero/CTA/event/kalender. Interna ankarlänkar (`#mat`, `#service` …) faller tillbaka på marked-standard och stannar i samma flik.

## Testplan

- [x] `npm test` – 1775/1775 gröna (2 nya tester för länk-renderingen: extern→ny flik, http också, `#mat`→samma flik)
- [x] `npm run lint` (eslint) rent
- [x] `npm run lint:md` rent
- [x] `npm run build` ok – renderad `public/index.html` har `target="_blank"` på externa matlänkar, 0 ankarlänkar med felaktig `target`
- [x] Manuell browser-koll på `/#mat` och `/#service`: externa länkar öppnas i ny flik, interna ankare i samma flik

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)