### PR TITLE
Add PHPUnit test harness for the PHP API (#378)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,21 @@ jobs:
       - name: Validate HTML
         if: steps.changes.outputs.has_code == 'true'
         run: npm run lint:html
+
+      - name: Set up PHP
+        if: steps.changes.outputs.has_code == 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, dom, xml
+          tools: composer
+
+      - name: Install PHP dependencies
+        if: steps.changes.outputs.has_code == 'true'
+        working-directory: api
+        run: composer install --no-interaction --no-progress
+
+      - name: Run PHP tests
+        if: steps.changes.outputs.has_code == 'true'
+        working-directory: api
+        run: composer test

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,2 @@
+/.phpunit.cache/
+/composer.lock

--- a/api/composer.json
+++ b/api/composer.json
@@ -7,9 +7,20 @@
         "symfony/yaml": "^7.0",
         "vlucas/phpdotenv": "^5.6"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    },
     "autoload": {
         "psr-4": {
             "SBSommar\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SBSommar\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+    <testsuites>
+        <testsuite name="api">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/api/tests/GitHubTest.php
+++ b/api/tests/GitHubTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBSommar\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SBSommar\GitHub;
+
+/**
+ * Mirrors tests/github.test.js — verifies the PHP YAML helpers behave the same
+ * as the Node helpers, with emphasis on the §102 hardening (CR normalisation,
+ * indentation detection, whole-document validation). Network methods are not
+ * exercised; only the pure helpers.
+ */
+final class GitHubTest extends TestCase
+{
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private static function baseEvent(array $overrides = []): array
+    {
+        return array_merge([
+            'id'          => 'frukost-2026-06-22-0800',
+            'title'       => 'Frukost',
+            'date'        => '2026-06-22',
+            'start'       => '08:00',
+            'end'         => '09:00',
+            'location'    => 'Matsalen',
+            'responsible' => 'Alla',
+            'description' => null,
+            'link'        => null,
+            'owner'       => ['name' => 'Anna', 'email' => ''],
+            'meta'        => ['created_at' => '2026-06-22 07:00', 'updated_at' => '2026-06-22 07:00'],
+        ], $overrides);
+    }
+
+    /**
+     * @param string[] $eventBlocks
+     */
+    private static function campFile(array $eventBlocks = []): string
+    {
+        $header = [
+            'camp:',
+            '  id: test-camp',
+            '  name: Test',
+            '  location: Here',
+            "  start_date: '2026-06-22'",
+            "  end_date: '2026-06-28'",
+            'events:',
+        ];
+
+        return implode("\n", array_merge($header, $eventBlocks)) . "\n";
+    }
+
+    // ── slugify ─────────────────────────────────────────────────────────────
+
+    public function testSlugifyLowercasesAscii(): void
+    {
+        $this->assertSame('hello-world', GitHub::slugify('Hello World'));
+    }
+
+    public function testSlugifyReplacesSwedishChars(): void
+    {
+        $this->assertSame('aang', GitHub::slugify('åäng'));
+        $this->assertSame('oppen', GitHub::slugify('öppen'));
+    }
+
+    public function testSlugifyCapsAt48Chars(): void
+    {
+        $this->assertSame(48, strlen(GitHub::slugify(str_repeat('a', 100))));
+    }
+
+    // ── yamlScalar ──────────────────────────────────────────────────────────
+
+    public function testYamlScalarNull(): void
+    {
+        $this->assertSame('null', GitHub::yamlScalar(null));
+    }
+
+    public function testYamlScalarEmptyString(): void
+    {
+        $this->assertSame("''", GitHub::yamlScalar(''));
+    }
+
+    public function testYamlScalarPlainTextUnchanged(): void
+    {
+        $this->assertSame('Hello world', GitHub::yamlScalar('Hello world'));
+    }
+
+    public function testYamlScalarQuotesColon(): void
+    {
+        $r = GitHub::yamlScalar('key: value');
+        $this->assertStringStartsWith("'", $r);
+    }
+
+    // ── buildEventYaml ──────────────────────────────────────────────────────
+
+    public function testBuildEventYamlStartsWithId(): void
+    {
+        $yaml = GitHub::buildEventYaml(self::baseEvent());
+        $this->assertStringStartsWith('- id: frukost-2026-06-22-0800', $yaml);
+    }
+
+    public function testBuildEventYamlNormalisesCrlfInDescription(): void
+    {
+        $yaml = GitHub::buildEventYaml(self::baseEvent(['description' => "Rad ett.\r\nRad två."]));
+        $this->assertStringNotContainsString("\r", $yaml);
+        $this->assertStringContainsString('    Rad ett.', $yaml);
+        $this->assertStringContainsString('    Rad två.', $yaml);
+    }
+
+    public function testBuildEventYamlNormalisesLoneCrInDescription(): void
+    {
+        $yaml = GitHub::buildEventYaml(self::baseEvent(['description' => "Rad ett.\rRad två."]));
+        $this->assertStringNotContainsString("\r", $yaml);
+        $this->assertStringContainsString('    Rad två.', $yaml);
+    }
+
+    // ── detectEventIndent (02-§10.6, 02-§102.8) ─────────────────────────────
+
+    public function testDetectEventIndentColumnZero(): void
+    {
+        $yaml = "camp:\n  id: c\nevents:\n- id: lunch-2026-06-22-1200\n  title: Lunch\n";
+        $this->assertSame(0, GitHub::detectEventIndent($yaml));
+    }
+
+    public function testDetectEventIndentTwoSpaces(): void
+    {
+        $yaml = "camp:\n  id: c\nevents:\n  - id: lunch-2026-06-22-1200\n    title: Lunch\n";
+        $this->assertSame(2, GitHub::detectEventIndent($yaml));
+    }
+
+    public function testDetectEventIndentFallsBackToTwoWhenEmpty(): void
+    {
+        $yaml = "camp:\n  id: c\nevents: []\n";
+        $this->assertSame(2, GitHub::detectEventIndent($yaml));
+    }
+
+    // ── assertEventYamlValid (02-§102.5) ────────────────────────────────────
+
+    public function testAssertEventYamlValidPassesForDocWithId(): void
+    {
+        $ev = self::baseEvent();
+        $content = self::campFile([GitHub::buildEventYaml($ev)]);
+        GitHub::assertEventYamlValid($content, [$ev['id']]);
+        // Reaching here without an exception is the pass condition.
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertEventYamlValidThrowsOnUnparseableYaml(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        GitHub::assertEventYamlValid("camp:\n  id: t\nevents: [unclosed", ['x']);
+    }
+
+    public function testAssertEventYamlValidThrowsWhenIdMissing(): void
+    {
+        $ev = self::baseEvent();
+        $content = self::campFile([GitHub::buildEventYaml($ev)]);
+        $this->expectException(\RuntimeException::class);
+        GitHub::assertEventYamlValid($content, ['does-not-exist']);
+    }
+
+    public function testAppendingAtDetectedIndentToTwoSpaceFileYieldsValidYaml(): void
+    {
+        // Regression guard for the indent-0-append-into-2-space-file bug.
+        $existing = implode("\n", [
+            'camp:',
+            '  id: test-camp',
+            '  name: Test',
+            '  location: Here',
+            "  start_date: '2026-06-22'",
+            "  end_date: '2026-06-28'",
+            'events:',
+            '  - id: lunch-2026-06-22-1200',
+            '    title: Lunch',
+            "    date: '2026-06-22'",
+            "    start: '12:00'",
+            "    end: '13:00'",
+            '    location: Matsalen',
+            '    responsible: Alla',
+            '    description: null',
+            '    link: null',
+            '    owner:',
+            "      name: ''",
+            "      email: ''",
+            '    meta:',
+            '      created_at: 2026-06-21 07:00',
+            '      updated_at: 2026-06-21 07:00',
+        ]) . "\n";
+
+        $ev = self::baseEvent();
+        $indent = GitHub::detectEventIndent($existing);
+        $this->assertSame(2, $indent);
+
+        $combined = rtrim($existing) . "\n" . GitHub::buildEventYaml($ev, $indent) . "\n";
+        GitHub::assertEventYamlValid($combined, [$ev['id']]);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/api/tests/ValidateTest.php
+++ b/api/tests/ValidateTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBSommar\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SBSommar\Validate;
+
+/**
+ * Mirrors tests/validate.test.js — verifies the PHP validator behaves the same
+ * as the Node validator, with emphasis on the §102 control-character hardening
+ * and the §82.3 responsible = 60 limit.
+ */
+final class ValidateTest extends TestCase
+{
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private static function valid(array $overrides = []): array
+    {
+        return array_merge([
+            'title'       => 'Frukost',
+            'date'        => '2099-06-22',
+            'start'       => '08:00',
+            'end'         => '09:00',
+            'location'    => 'Matsalen',
+            'responsible' => 'Alla',
+        ], $overrides);
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private static function validEdit(array $overrides = []): array
+    {
+        return array_merge([
+            'id'          => '2099-08-04-frukost',
+            'title'       => 'Frukost',
+            'date'        => '2099-06-22',
+            'start'       => '08:00',
+            'end'         => '09:00',
+            'location'    => 'Matsalen',
+            'responsible' => 'Alla',
+        ], $overrides);
+    }
+
+    // ── Required fields / happy path ────────────────────────────────────────
+
+    public function testRejectsMissingTitle(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['title' => '']));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('title', $r['error']);
+    }
+
+    public function testAcceptsFullyValidRequest(): void
+    {
+        $r = Validate::validateEventRequest(self::valid([
+            'description' => 'Ta med din dator.',
+            'link'        => 'https://meet.example.com',
+            'ownerName'   => 'Lisa',
+        ]));
+        $this->assertTrue($r['ok']);
+    }
+
+    // ── String length limits — responsible = 60 (02-§82.3 mirror) ───────────
+
+    public function testRejectsResponsibleOver60(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['responsible' => str_repeat('A', 61)]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('responsible', $r['error']);
+    }
+
+    public function testAcceptsResponsibleAt60(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['responsible' => str_repeat('A', 60)]));
+        $this->assertTrue($r['ok']);
+    }
+
+    // ── Injection scanning (02-§49) ─────────────────────────────────────────
+
+    public function testRejectsScriptTagInTitle(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['title' => '<script>alert(1)</script>']));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('title', $r['error']);
+    }
+
+    public function testRejectsNonHttpLink(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['link' => 'ftp://example.com/file']));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('link', $r['error']);
+    }
+
+    // ── Control characters / line breaks in single-line fields (02-§102.1) ──
+
+    public function testRejectsNewlineInTitle(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['title' => "Frukost\n  responsible: hacker"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('title', $r['error']);
+    }
+
+    public function testRejectsNewlineInLocation(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['location' => "Matsalen\n  smuggled: true"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('location', $r['error']);
+    }
+
+    public function testRejectsNewlineInResponsible(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['responsible' => "Alla\nEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('responsible', $r['error']);
+    }
+
+    public function testRejectsNewlineInLink(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['link' => "https://example.com\nEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('link', $r['error']);
+    }
+
+    public function testRejectsNewlineInOwnerName(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['ownerName' => "Anna\nEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('ownerName', $r['error']);
+    }
+
+    public function testRejectsCarriageReturnInTitle(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['title' => "Frukost\rmiddag"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('title', $r['error']);
+    }
+
+    public function testRejectsTabInResponsible(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['responsible' => "Alla\tEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('responsible', $r['error']);
+    }
+
+    public function testRejectsNulByteInLocation(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['location' => "Mat\0salen"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('location', $r['error']);
+    }
+
+    public function testAcceptsTrailingNewlineInTitle(): void
+    {
+        // The only line break is trailing — trimmed away before the write, so accepted.
+        $r = Validate::validateEventRequest(self::valid(['title' => "Frukost\n"]));
+        $this->assertTrue($r['ok']);
+    }
+
+    // ── description multi-line handling (02-§102.3) ─────────────────────────
+
+    public function testAcceptsNewlineInDescription(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['description' => "Rad ett.\nRad två."]));
+        $this->assertTrue($r['ok']);
+    }
+
+    public function testAcceptsTabInDescription(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['description' => "Kolumn1\tKolumn2"]));
+        $this->assertTrue($r['ok']);
+    }
+
+    public function testRejectsNulByteInDescription(): void
+    {
+        $r = Validate::validateEventRequest(self::valid(['description' => "Text\0slut"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('description', $r['error']);
+    }
+
+    // ── Edit request parity (02-§102.1) ─────────────────────────────────────
+
+    public function testEditRejectsNewlineInTitle(): void
+    {
+        $r = Validate::validateEditRequest(self::validEdit(['title' => "Frukost\nEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('title', $r['error']);
+    }
+
+    public function testEditRejectsNewlineInOwnerName(): void
+    {
+        $r = Validate::validateEditRequest(self::validEdit(['ownerName' => "Anna\nEvil"]));
+        $this->assertFalse($r['ok']);
+        $this->assertStringContainsString('ownerName', $r['error']);
+    }
+}

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -868,3 +868,47 @@ existing deployment workflow.
 - The list of files in each family is maintained in a single place, so
   that adding or removing a family member updates every sibling's
   navigation block without editing each file by hand. <!-- 02-§97.29 -->
+
+---
+
+## 103. PHP API Automated Tests
+
+### 103.1 Context
+
+The PHP API in `api/src/` is a hand-maintained mirror of the Node API in
+`source/api/`. It historically had no automated tests — correctness relied on
+review, which let drift through (for example, the `responsible` maximum length
+was 200 in PHP while the form and Node enforced 60, found during the §102 work).
+Automated PHP tests that run in CI and locally close that gap.
+
+### 103.2 PHPUnit harness (site requirements)
+
+- `api/composer.json` declares `phpunit/phpunit` as a `require-dev` dependency.
+  No new production (non-dev) dependency is added. <!-- 02-§103.1 -->
+- A `phpunit.xml` at `api/` defines a test suite that runs the test classes
+  under `api/tests/`. <!-- 02-§103.2 -->
+- `api/composer.json` defines a `test` script so the suite runs with
+  `composer test` from the `api/` directory. <!-- 02-§103.3 -->
+- The suite covers `api/src/Validate.php` and `api/src/GitHub.php`, asserting the
+  same behaviour as the Node suites `tests/validate.test.js` and
+  `tests/github.test.js` — including the control-character rejection,
+  whole-document validation, indentation matching, and carriage-return
+  normalisation from §102, and the `responsible` 60-character limit from
+  §82.3. <!-- 02-§103.4 -->
+
+### 103.3 CI integration (site requirements)
+
+- The CI workflow runs the PHP test suite on every push and pull request, using
+  `shivammathur/setup-php`, `composer install`, and `composer test`. <!-- 02-§103.5 -->
+- The PHP test steps run only when the change includes code (the existing
+  `has_code` detection in `ci.yml`), so data-only changes skip them, consistent
+  with the data-only CI behaviour in section 9 of `CLAUDE.md`. <!-- 02-§103.6 -->
+- A failing PHP test fails CI. <!-- 02-§103.7 -->
+
+### 103.4 Local development (site requirements)
+
+- After `composer install` in `api/`, the PHP tests run locally with
+  `composer test`. <!-- 02-§103.8 -->
+- The git pre-commit hook remains Node-only (`npm run lint`, `npm run lint:md`,
+  `npm test`); it does not invoke PHP, so contributors without a PHP toolchain
+  are not blocked. <!-- 02-§103.9 -->

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -22,7 +22,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42 |
-| [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97 |
+| [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
 | [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102 |
 | [`design-and-content.md`](./design-and-content.md) | Design and Content | §30, §31, §47, §55, §64, §94, §98 |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -358,6 +358,29 @@ backup). On deploy, if `$DEPLOY_DIR/.env` is absent but a legacy
 `$DEPLOY_DIR/.env` once; afterwards no `.env` remains under `public_html`
 (02-§100.8).
 
+### PHP API tests (02-§103)
+
+The PHP API is a hand-maintained mirror of the Node API, so it is tested with a
+PHPUnit suite that asserts the same behaviour as the Node tests.
+
+- **Layout:** `phpunit/phpunit` is a `require-dev` entry in `api/composer.json`;
+  `api/phpunit.xml` registers a single test suite rooted at `api/tests/`;
+  test classes there use the Composer PSR-4 autoloader (`SBSommar\` → `src/`).
+  `composer test` (a script in `api/composer.json`) runs the suite.
+- **Coverage:** `api/tests/ValidateTest.php` and `api/tests/GitHubTest.php`
+  mirror `tests/validate.test.js` and `tests/github.test.js`, including the
+  §102 hardening (control characters, `assertEventYamlValid`,
+  `detectEventIndent`, CR normalisation) and the `responsible` 60-char limit
+  (§82.3). `GitHub.php`'s network methods (`getFile`, `putFile`, the PR flow)
+  are not exercised; only the pure helpers are.
+- **CI:** `ci.yml` adds `shivammathur/setup-php` (PHP 8.2, with a Composer
+  cache), `composer install` and `composer test` steps, all guarded by the same
+  `has_code` condition as the Node steps so data-only changes skip them
+  (02-§103.5, 02-§103.6). A failing PHP test fails the job (02-§103.7).
+- **Local:** after `composer install` in `api/`, `composer test` runs the suite.
+  The git pre-commit hook stays Node-only, so a missing PHP toolchain never
+  blocks a commit (02-§103.9).
+
 ---
 
 ## 27. Asset Cache-Busting (CSS, JS, Images)

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -373,10 +373,10 @@ PHPUnit suite that asserts the same behaviour as the Node tests.
   `detectEventIndent`, CR normalisation) and the `responsible` 60-char limit
   (§82.3). `GitHub.php`'s network methods (`getFile`, `putFile`, the PR flow)
   are not exercised; only the pure helpers are.
-- **CI:** `ci.yml` adds `shivammathur/setup-php` (PHP 8.2, with a Composer
-  cache), `composer install` and `composer test` steps, all guarded by the same
-  `has_code` condition as the Node steps so data-only changes skip them
-  (02-§103.5, 02-§103.6). A failing PHP test fails the job (02-§103.7).
+- **CI:** `ci.yml` adds `shivammathur/setup-php` (PHP 8.2), `composer install`,
+  and `composer test` steps, all guarded by the same `has_code` condition as the
+  Node steps so data-only changes skip them (02-§103.5, 02-§103.6). A failing PHP
+  test fails the job (02-§103.7).
 - **Local:** after `composer install` in `api/`, `composer test` runs the suite.
   The git pre-commit hook stays Node-only, so a missing PHP toolchain never
   blocks a commit (02-§103.9).

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1534,12 +1534,12 @@ refactor of `render-lokaler.js` onto the shared module).
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§103.1` | gap | `phpunit/phpunit` added as `require-dev` in `api/composer.json`; no production dependency added |
-| `02-§103.2` | gap | `api/phpunit.xml` defines a suite over `api/tests/` |
-| `02-§103.3` | gap | `composer test` script in `api/composer.json` runs PHPUnit |
-| `02-§103.4` | gap | PHPV-* (planned): `api/tests/ValidateTest.php` + `GitHubTest.php` mirror `tests/validate.test.js`/`github.test.js` incl. §102 cases and `responsible` = 60 |
-| `02-§103.5` | gap | `ci.yml`: `shivammathur/setup-php` + `composer install` + `composer test` on push/PR |
-| `02-§103.6` | gap | PHP steps guarded by the existing `has_code` detection; data-only changes skip them (CL-§9.4) |
-| `02-§103.7` | gap | A failing PHP test fails the CI job |
-| `02-§103.8` | gap | `composer test` runs the suite locally after `composer install` in `api/` |
-| `02-§103.9` | gap | Pre-commit hook stays Node-only (`.githooks/pre-commit`); no PHP invocation |
+| `02-§103.1` | covered | PHARN-01, PHARN-02: `phpunit/phpunit` is a `require-dev` entry in `api/composer.json`; not a production dependency |
+| `02-§103.2` | covered | PHARN-05: `api/phpunit.xml` defines a suite over `api/tests/` |
+| `02-§103.3` | covered | PHARN-03: `composer test` script in `api/composer.json` runs PHPUnit |
+| `02-§103.4` | covered | `api/tests/ValidateTest.php` + `GitHubTest.php` (37 PHPUnit tests) mirror `tests/validate.test.js`/`github.test.js` incl. §102 cases and `responsible` = 60 |
+| `02-§103.5` | covered | PHARN-06, PHARN-07: `ci.yml` runs `shivammathur/setup-php` + `composer install` + `composer test` |
+| `02-§103.6` | covered | PHARN-08: PHP steps guarded by the existing `has_code` detection; data-only changes skip them (CL-§9.4) |
+| `02-§103.7` | implemented | A failing PHPUnit test exits non-zero, failing the `Run PHP tests` step; manual (CI behaviour) |
+| `02-§103.8` | implemented | `composer test` runs the suite locally after `composer install` in `api/` (verified: 37 tests, 57 assertions pass) |
+| `02-§103.9` | covered | PHARN-09: pre-commit hook (`.githooks/pre-commit`) invokes no `php`/`composer` |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -658,8 +658,8 @@ Part of [the traceability index](./index.md).
 | `02-§49.2` | Injection patterns rejected: `<script`, `javascript:`, `on*=`, `<iframe`, `<object`, `<embed`, `data:text/html` | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..07 | `source/api/validate.js` – `INJECTION_PATTERNS` array | covered |
 | `02-§49.3` | Error message identifies offending field and pattern category | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..07 | `source/api/validate.js` – error string includes field name and pattern label | covered |
 | `02-§49.4` | Non-empty link must start with `http://` or `https://` | 03-architecture/ci-and-deploy.md §11.6 | ASEC-08..10 | `source/api/validate.js` – protocol regex check on `link` field | covered |
-| `02-§49.5` | Injection and link checks identical in Node.js and PHP implementations | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..16 | `source/api/validate.js` + `api/src/Validate.php` | covered |
-| `02-§49.6` | Both implementations produce equivalent error messages | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..16 | `source/api/validate.js` + `api/src/Validate.php` | covered |
+| `02-§49.5` | Injection and link checks identical in Node.js and PHP implementations | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..16; PHP `ValidateTest::testRejectsScriptTagInTitle`, `testRejectsNonHttpLink` (§103) | `source/api/validate.js` + `api/src/Validate.php` | covered |
+| `02-§49.6` | Both implementations produce equivalent error messages | 03-architecture/ci-and-deploy.md §11.6 | ASEC-01..16; PHP `ValidateTest` (§103) asserts the same field-named errors | `source/api/validate.js` + `api/src/Validate.php` | covered |
 | `02-§50.1` | Docker image contains Node.js 20 and production dependencies — **superseded by 02-§52.1 (setup-node + npm cache)** | 03-architecture/ci-and-deploy.md §11.1 | manual: inspect `.github/docker/Dockerfile` | `.github/docker/Dockerfile` | implemented |
 | `02-§50.2` | Image based on `node:20` (full, not slim) — **superseded by 02-§52.1** | 03-architecture/ci-and-deploy.md §11.1 | manual: inspect Dockerfile FROM line | `.github/docker/Dockerfile` | implemented |
 | `02-§50.3` | Dockerfile lives in `.github/docker/Dockerfile` — **superseded by 02-§52.1** | 03-architecture/ci-and-deploy.md §11.1 | manual: file exists at path | `.github/docker/Dockerfile` | implemented |
@@ -1075,7 +1075,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | | | **§82 — Character Counter on Text Input Fields** |
 | `02-§82.1` | CC-01..CC-08 | Fields: title 80, responsible 60, description 2000, link 500 |
 | `02-§82.2` | CC-01..CC-08 | maxlength attribute on inputs in render-add.js and render-edit.js |
-| `02-§82.3` | CC-09, CC-10 | Both validators enforce the table limits; `responsible` = 60 in `source/api/validate.js` (CC-09/CC-10) and `api/src/Validate.php` (mirror, manual) |
+| `02-§82.3` | CC-09, CC-10 | Both validators enforce the table limits; `responsible` = 60 in `source/api/validate.js` (CC-09/CC-10) and `api/src/Validate.php` (PHPUnit `ValidateTest::testRejects/AcceptsResponsible*`, §103) |
 | `02-§82.4` | manual | Counter hidden below 70% of max (browser-only) |
 | `02-§82.5` | manual | Counter visible at ≥70% of max (browser-only) |
 | `02-§82.6` | CC-12 | Counter turns terracotta at ≥90% of max; `.char-counter.warn` in CSS |
@@ -1527,7 +1527,7 @@ refactor of `render-lokaler.js` onto the shared module).
 | `02-§102.4` | covered | YSEC-15..16: carriage returns in `description` normalised to `\n` in `buildEventYaml()`; `source/api/github.js` + `api/src/GitHub.php` |
 | `02-§102.5` | covered | YSEC-20..23: add/batch flows call `assertEventYamlValid()` to parse the full proposed document and confirm the new event id(s) before any branch/PR; `source/api/github.js` (add) + `api/src/GitHub.php` (add + batch) |
 | `02-§102.6` | implemented | Architectural: edit/delete rebuild via the YAML serializer (02-§10.4) and need no re-parse; existing EDIT/DEL tests confirm valid serialiser output. `source/api/edit-event.js` + `GitHub::patchEventInYaml`/`removeEventFromYaml` |
-| `02-§102.7` | implemented | PHP mirror has no test harness; parity verified by review (manual). `api/src/Validate.php` + `api/src/GitHub.php` mirror the Node implementation; PHP batch flow also covered |
+| `02-§102.7` | covered | PHP parity is exercised by the PHPUnit suite (§103): `api/tests/ValidateTest.php` + `api/tests/GitHubTest.php` assert the same control-character, whole-document, indentation and CR behaviour as the Node tests; PHP batch flow also covered |
 | `02-§102.8` | covered | YSEC-17..19, YSEC-23: `detectEventIndent()` reads the existing list indentation (default 2); appended block matches it so the document stays valid; `source/api/github.js` + `api/src/GitHub.php` |
 
 ### §103 — PHP API Automated Tests

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1529,3 +1529,17 @@ refactor of `render-lokaler.js` onto the shared module).
 | `02-§102.6` | implemented | Architectural: edit/delete rebuild via the YAML serializer (02-§10.4) and need no re-parse; existing EDIT/DEL tests confirm valid serialiser output. `source/api/edit-event.js` + `GitHub::patchEventInYaml`/`removeEventFromYaml` |
 | `02-§102.7` | implemented | PHP mirror has no test harness; parity verified by review (manual). `api/src/Validate.php` + `api/src/GitHub.php` mirror the Node implementation; PHP batch flow also covered |
 | `02-§102.8` | covered | YSEC-17..19, YSEC-23: `detectEventIndent()` reads the existing list indentation (default 2); appended block matches it so the document stays valid; `source/api/github.js` + `api/src/GitHub.php` |
+
+### §103 — PHP API Automated Tests
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§103.1` | gap | `phpunit/phpunit` added as `require-dev` in `api/composer.json`; no production dependency added |
+| `02-§103.2` | gap | `api/phpunit.xml` defines a suite over `api/tests/` |
+| `02-§103.3` | gap | `composer test` script in `api/composer.json` runs PHPUnit |
+| `02-§103.4` | gap | PHPV-* (planned): `api/tests/ValidateTest.php` + `GitHubTest.php` mirror `tests/validate.test.js`/`github.test.js` incl. §102 cases and `responsible` = 60 |
+| `02-§103.5` | gap | `ci.yml`: `shivammathur/setup-php` + `composer install` + `composer test` on push/PR |
+| `02-§103.6` | gap | PHP steps guarded by the existing `has_code` detection; data-only changes skip them (CL-§9.4) |
+| `02-§103.7` | gap | A failing PHP test fails the CI job |
+| `02-§103.8` | gap | `composer test` runs the suite locally after `composer install` in `api/` |
+| `02-§103.9` | gap | Pre-commit hook stays Node-only (`.githooks/pre-commit`); no PHP invocation |

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -184,3 +184,6 @@ Part of [the traceability index](./index.md).
 | MDT-23 | `tests/markdown-toolbar.test.js` | `02-§57.13 — Focus indicator` |
 | DOCS-NAV-01..04 | `tests/docs-nav.test.js` | `docs-nav.yml — single source for within-family navigation (02-§97.28, 02-§97.29)` |
 | DOCS-NAV-05 | `tests/docs-nav.test.js` | `docs front-matter — every page carries a title (02-§97.25)` |
+| PHARN-01..09 | `tests/php-harness.test.js` | PHP harness wiring: Composer, PHPUnit, CI, Node-only hook (02-§103) |
+| (PHPUnit) | `api/tests/ValidateTest.php` | PHP mirror of `validate.test.js`, run via `composer test` (02-§103.4) |
+| (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of `github.test.js`, run via `composer test` (02-§103.4) |

--- a/tests/php-harness.test.js
+++ b/tests/php-harness.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// Guards the PHP test harness wiring (02-§103). The PHP tests themselves run
+// under PHPUnit (api/tests/), but these Node assertions — which always run in
+// the Node suite and pre-commit hook — ensure the harness stays wired into
+// Composer, PHPUnit, and CI, and that the pre-commit hook stays Node-only.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const root = path.join(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('PHP harness — Composer (02-§103.1, 02-§103.3)', () => {
+  const composer = JSON.parse(read('api/composer.json'));
+
+  it('PHARN-01: declares phpunit/phpunit as a dev dependency', () => {
+    assert.ok(composer['require-dev'], 'require-dev block missing');
+    assert.ok(composer['require-dev']['phpunit/phpunit'], 'phpunit/phpunit not in require-dev');
+  });
+
+  it('PHARN-02: keeps phpunit out of production (non-dev) requires', () => {
+    assert.ok(!(composer.require && composer.require['phpunit/phpunit']), 'phpunit must not be a production dependency');
+  });
+
+  it('PHARN-03: defines a composer "test" script', () => {
+    assert.ok(composer.scripts && composer.scripts.test, 'scripts.test missing');
+    assert.match(composer.scripts.test, /phpunit/);
+  });
+
+  it('PHARN-04: autoloads the test namespace from tests/', () => {
+    const dev = composer['autoload-dev'] && composer['autoload-dev']['psr-4'];
+    assert.ok(dev && dev['SBSommar\\Tests\\'] === 'tests/', 'autoload-dev PSR-4 for SBSommar\\Tests\\ → tests/ missing');
+  });
+});
+
+describe('PHP harness — PHPUnit config (02-§103.2)', () => {
+  it('PHARN-05: phpunit.xml exists and registers the tests/ suite', () => {
+    const xml = read('api/phpunit.xml');
+    assert.match(xml, /<testsuite[^>]*>/);
+    assert.match(xml, /<directory>tests<\/directory>/);
+  });
+});
+
+describe('PHP harness — CI integration (02-§103.5, 02-§103.6)', () => {
+  const ci = yaml.load(read('.github/workflows/ci.yml'));
+  const steps = ci.jobs.ci.steps;
+  const guard = "steps.changes.outputs.has_code == 'true'";
+
+  const setupPhp = steps.find((s) => typeof s.uses === 'string' && s.uses.startsWith('shivammathur/setup-php'));
+  const phpTest = steps.find((s) => typeof s.run === 'string' && s.run.includes('composer test'));
+  const composerInstall = steps.find((s) => typeof s.run === 'string' && s.run.includes('composer install'));
+
+  it('PHARN-06: sets up PHP via shivammathur/setup-php', () => {
+    assert.ok(setupPhp, 'setup-php step missing');
+  });
+
+  it('PHARN-07: installs deps and runs composer test in api/', () => {
+    assert.ok(composerInstall, 'composer install step missing');
+    assert.ok(phpTest, 'composer test step missing');
+    assert.strictEqual(composerInstall['working-directory'], 'api');
+    assert.strictEqual(phpTest['working-directory'], 'api');
+  });
+
+  it('PHARN-08: PHP steps are guarded by the has_code data-only skip', () => {
+    for (const step of [setupPhp, composerInstall, phpTest]) {
+      assert.ok(step.if && step.if.includes(guard), `step "${step.name}" is not guarded by has_code`);
+    }
+  });
+});
+
+describe('PHP harness — pre-commit hook stays Node-only (02-§103.9)', () => {
+  it('PHARN-09: pre-commit hook does not invoke php or composer', () => {
+    const hook = read('.githooks/pre-commit');
+    assert.doesNotMatch(hook, /\bphp\b/);
+    assert.doesNotMatch(hook, /\bcomposer\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #378.

The PHP API in \`api/src/\` is a hand-maintained mirror of the Node API but had **no automated tests** — parity relied on review, which let drift through (e.g. the \`responsible\` 200-vs-60 limit found in #368). This adds a PHPUnit harness that runs in **CI and locally**.

- **Harness:** \`phpunit/phpunit\` as a `require-dev` dep, \`api/phpunit.xml\`, and a \`composer test\` script. \`vendor/\` and \`composer.lock\` are gitignored.
- **PHP tests:** \`api/tests/ValidateTest.php\` + \`api/tests/GitHubTest.php\` mirror \`tests/validate.test.js\` / \`tests/github.test.js\` — including the §102 hardening (control characters, \`assertEventYamlValid\`, \`detectEventIndent\`, CR normalisation) and \`responsible\` = 60 (§82.3). **37 tests, 57 assertions.**
- **CI:** \`ci.yml\` gains \`shivammathur/setup-php\` (PHP 8.2) + \`composer install\` + \`composer test\`, guarded by the existing \`has_code\` data-only skip (CL-§9.4) and part of the existing required \"Lint, Test & Build\" check.
- **Node guard:** \`tests/php-harness.test.js\` (9 tests) asserts the wiring stays in place and the pre-commit hook stays Node-only (so contributors without PHP aren't blocked).

Docs: requirement §103, architecture in \`ci-and-deploy.md §21\`, traceability §103.1–§103.9, test-id legend.

First harness PR scoped to \`Validate\` + \`GitHub\`; other classes (\`ActiveCamp\`, \`Session\`, \`TimeGate\`, \`RateLimit\`) follow later.

## Test plan

- [x] \`composer test\` (in \`api/\`) → 37 tests, 57 assertions pass (PHP 8.3 local)
- [x] \`npm test\` → 1807 pass / 0 fail (incl. 9 \`PHARN-*\` guards)
- [x] \`npm run lint\` + \`lint:md\` clean
- [x] \`composer validate\` OK
- [ ] CI runs the new PHP job (validated on this PR)

## Local run
\`\`\`bash
cd api && composer install && composer test
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)