### PR TITLE
Keep spring QA camp open until the real camp opens for editing (#381)

### DIFF
--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -573,19 +573,22 @@ requirements that flow from that design.
 
 #### 42.9.1 Context
 
-The active QA camp must close before the upcoming real camp's pre-camp
-preparation period and reopen after the real-camp season ends, so QA
-testing never overlaps the real-camp window. See
-`03-architecture/data-layer.md §2 "QA camp isolation"` for the spring/autumn camp
-descriptions and the off-season window.
+The active QA camp stays open until the upcoming real camp opens for
+editing, then hands over to that real camp; a separate autumn QA camp
+reopens after the real-camp season ends. This keeps an open camp available
+for QA testing at all times except the real camp's own active window. See
+`03-architecture/data-layer.md §2 "QA camp isolation"` for the spring/autumn
+camp descriptions and the off-season window.
 
 #### 42.9.2 Requirements
 
 - Two QA-only camps exist in `camps.yaml` at any time: one "spring" camp
   active in the period leading up to the next real camp, and one "autumn"
   camp active after the real-camp season. <!-- 02-§42.31 -->
-- The spring QA camp's `end_date` is two weeks before the
-  `start_date` of the next non-QA, non-archived camp. <!-- 02-§42.32 -->
+- The spring QA camp's `end_date` is the date on which the next non-QA,
+  non-archived camp opens for editing (its `opens_for_editing`), so the QA
+  camp stays open for testing right up until the real camp's pre-camp
+  preparation period begins. <!-- 02-§42.32 -->
 - No QA-only camp's date range covers the period from the spring QA camp's
   `end_date` (exclusive) until the autumn QA camp's `start_date` (exclusive),
   so no QA camp is active in QA during the real-camp season. <!-- 02-§42.33 -->

--- a/docs/03-architecture/data-layer.md
+++ b/docs/03-architecture/data-layer.md
@@ -87,8 +87,9 @@ Two QA-only camps coexist in `camps.yaml` to provide a continuous QA
 testing window without overlapping the real-camp season:
 
 - A spring QA camp (`qa-thisweek`) runs through the off-season and
-  closes two weeks before the next real camp's `start_date`, leaving
-  the real-camp window QA-free.
+  closes when the next real camp opens for editing (its
+  `opens_for_editing`), so QA stays testable right up to the point the
+  real camp takes over, leaving the real-camp window QA-free.
 - An autumn QA camp (`qa-testcamp`) covers October 1 through December
   31 of the current year, reopening QA testing once the real-camp
   season ends.

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -538,7 +538,7 @@ Part of [the traceability index](./index.md).
 | `02-§42.28` | Yearly: QA camp date range updated to new year | — | manual: annual maintenance | `source/data/camps.yaml` | implemented |
 | `02-§42.29` | Yearly update is manual one-line change, no automation | — | — | — | implemented |
 | `02-§42.31` | Two QA-only camps coexist: spring + autumn | 02-requirements/event-data.md §42.9, 03-architecture/data-layer.md §2 | QSEAS-01, QSEAS-03 | `source/data/camps.yaml` | covered |
-| `02-§42.32` | Spring QA camp `end_date` is two weeks before next real camp `start_date` | 02-requirements/event-data.md §42.9, 03-architecture/data-layer.md §2 | QSEAS-04 | `source/data/camps.yaml` | covered |
+| `02-§42.32` | Spring QA camp `end_date` equals the next real camp's `opens_for_editing` | 02-requirements/event-data.md §42.9, 03-architecture/data-layer.md §2 | QSEAS-04 | `source/data/camps.yaml` | covered |
 | `02-§42.33` | No QA camp covers the real-camp season window | 02-requirements/event-data.md §42.9 | QSEAS-05 | `source/data/camps.yaml` | covered |
 | `02-§42.34` | Autumn QA camp runs Oct 1 – Dec 31 of current year | 02-requirements/event-data.md §42.9 | QSEAS-02 | `source/data/camps.yaml` | covered |
 | `02-§43.1` | QA event data deploy uses SCP over SSH instead of FTP | 08-ENVIRONMENTS.md | manual: trigger event PR, verify QA pages update via SCP | `.github/workflows/event-data-deploy.yml` – `deploy-qa` job | implemented |

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -39,14 +39,14 @@ camps:
   - id: qa-thisweek
     name: QA Testläger (vår 2026)
     start_date: '2026-04-24'
-    end_date: '2026-06-07'
+    end_date: '2026-06-16'
     opens_for_editing: '2026-04-20'
     registration_opens: '2026-02-23'
     registration_closes: '2026-04-19'
     location: Sysslebäck
     link: ''
     information: |
-      QA-läger aktivt fram till två veckor före nästa riktiga läger (2026-06-21).
+      QA-läger aktivt fram till att det riktiga lägret öppnar för redigering (2026-06-16).
     file: qa-thisweek.yaml
     archived: false
     qa: true

--- a/source/data/qa-thisweek.yaml
+++ b/source/data/qa-thisweek.yaml
@@ -3,7 +3,7 @@ camp:
   name: QA Testläger (vår 2026)
   location: Sysslebäck
   start_date: '2026-04-24'
-  end_date: '2026-06-07'
+  end_date: '2026-06-16'
 events:
   - id: lunch-2026-04-25-1200
     title: Lunch

--- a/tests/qa-camp-seasonal.test.js
+++ b/tests/qa-camp-seasonal.test.js
@@ -2,8 +2,8 @@
 
 // Verifies the seasonal QA camp model in source/data/camps.yaml (02-§42.31–42.34).
 //
-// The site keeps two QA-only camps (qa: true): a "spring" camp that closes two
-// weeks before the next real camp begins, and an "autumn" camp covering Oct 1
+// The site keeps two QA-only camps (qa: true): a "spring" camp that closes when
+// the next real camp opens for editing, and an "autumn" camp covering Oct 1
 // – Dec 31 of the current year. Together they leave the real-camp window
 // QA-free while ensuring continuous QA coverage outside that window.
 
@@ -18,11 +18,6 @@ const camps = yaml.load(fs.readFileSync(CAMPS_PATH, 'utf8')).camps;
 
 const qaCamps = camps.filter((c) => c.qa === true);
 const realCamps = camps.filter((c) => !c.qa && c.archived !== true);
-
-function daysBetween(a, b) {
-  const ms = (new Date(b) - new Date(a));
-  return Math.round(ms / (1000 * 60 * 60 * 24));
-}
 
 describe('camps.yaml – seasonal QA camp model (02-§42.31–42.34)', () => {
   it('QSEAS-01 (02-§42.31): exactly two QA-only camps exist', () => {
@@ -48,7 +43,7 @@ describe('camps.yaml – seasonal QA camp model (02-§42.31–42.34)', () => {
     assert.ok(spring, 'No spring QA camp found');
   });
 
-  it('QSEAS-04 (02-§42.32): spring QA camp end_date is exactly 14 days before the next real camp', () => {
+  it('QSEAS-04 (02-§42.32): spring QA camp end_date equals the next real camp opens_for_editing', () => {
     const spring = qaCamps.find((c) => !/-10-01$/.test(c.start_date));
     assert.ok(spring, 'No spring QA camp found');
 
@@ -58,10 +53,9 @@ describe('camps.yaml – seasonal QA camp model (02-§42.31–42.34)', () => {
 
     assert.ok(upcomingReal, 'No upcoming real camp after spring QA camp end_date');
 
-    const gap = daysBetween(spring.end_date, upcomingReal.start_date);
     assert.equal(
-      gap, 14,
-      `Spring QA camp must end exactly 14 days before next real camp (${upcomingReal.id} on ${upcomingReal.start_date}); got ${gap} days from ${spring.end_date}`,
+      spring.end_date, upcomingReal.opens_for_editing,
+      `Spring QA camp end_date (${spring.end_date}) must equal the next real camp's opens_for_editing (${upcomingReal.id}: ${upcomingReal.opens_for_editing})`,
     );
   });
 


### PR DESCRIPTION
## Summary

Closes #381.

The seasonal QA model closed the spring QA camp **two weeks before the real camp's start** (§42.32 → `qa-thisweek` ended 2026-06-07), but the real June camp's form doesn't open until **2026-06-16** — leaving a 06-08…06-15 window with no open camp to test in QA. This refines the rule so the spring QA camp closes **when the next real camp opens for editing**, which also matches the §42.9.1 context ("close at the start of the real camp's pre-camp prep period").

- **§42.32** (requirement): spring QA `end_date` = next real camp's `opens_for_editing` (was "two weeks before start").
- **§42.9.1** + **data-layer.md §2**: wording updated to match.
- **QSEAS-04**: asserts `end_date == next real opens_for_editing` (dropped the 14-day helper).
- **Data**: `qa-thisweek` `end_date` 2026-06-07 → **2026-06-16**, information text updated, `qa-thisweek.yaml` header synced.

Net: QA testers (and others) have an open QA camp right up until the real camp takes over, without writing into real-camp data. QSEAS-05 (no overlap with the real-camp season) still holds.

## Test plan

- [x] `npm test` → 1807 pass / 0 fail (QSEAS-04 green under the new rule)
- [x] `npm run validate:camps` → OK: 12 camps validated
- [x] `npm run lint` + `lint:md` clean
- [x] Verified: under `BUILD_ENV=qa`, `resolveActiveCamp` → `qa-thisweek`, form open today

🤖 Generated with [Claude Code](https://claude.com/claude-code)