### PR TITLE
feat: HMAC-signed admin tokens (token-model foundation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,10 +45,12 @@ PORT=3000
 # Leave unset for local dev (no analytics script rendered).
 # GOATCOUNTER_SITE_CODE=
 
-# Comma-separated admin tokens (UUIDs) for admin access (02-§91.1).
-# Generate with: node -e "console.log(crypto.randomUUID())"
+# HMAC signing secret that validates admin tokens (02-§91.1, §91.32).
+# Tokens are signed (namn_roll_epoch_sig), not listed — mint them with
+# `npm run admin:create`, which reads this secret. Use a long random value
+# (>= 32 bytes). Generate with: openssl rand -base64 48
 # Leave unset to disable admin features.
-# ADMIN_TOKENS=
+# ADMIN_TOKEN_SECRET=
 
 # Secret key for signing activity-ownership session cookies (02-§18, #387).
 # Edit/delete authorisation rests on an HMAC-SHA256 signature keyed by this

--- a/api/index.php
+++ b/api/index.php
@@ -131,7 +131,7 @@ try {
 
 // ── Parse configured admin tokens once ───────────────────────────────────
 
-$adminTokens = Admin::parseAdminTokens($_ENV['ADMIN_TOKENS'] ?? null);
+$adminTokenSecret = (string) ($_ENV['ADMIN_TOKEN_SECRET'] ?? '');
 $sessionSecret = (string) ($_ENV['SESSION_SECRET'] ?? '');
 
 // Warn (don't fail) when SESSION_SECRET is set but too weak to resist
@@ -139,6 +139,13 @@ $sessionSecret = (string) ($_ENV['SESSION_SECRET'] ?? '');
 // entirely and fails closed, which is safe.
 if ($sessionSecret !== '' && strlen($sessionSecret) < 32) {
     error_log('WARNING: SESSION_SECRET is shorter than 32 characters — use a long random value to protect activity-ownership signatures.');
+}
+
+// Warn (don't fail) when ADMIN_TOKEN_SECRET is set but too weak to resist
+// token forgery (02-§91.32). An unset secret disables admin functionality
+// entirely (no token validates), which fails closed and is safe.
+if ($adminTokenSecret !== '' && strlen($adminTokenSecret) < 32) {
+    error_log('WARNING: ADMIN_TOKEN_SECRET is shorter than 32 characters — use a long random value to protect admin token signatures.');
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────────
@@ -154,22 +161,22 @@ try {
             => handleCleanupCookies(),
 
         $method === 'POST' && $route === '/add-event'
-            => handleAddEvent($activeCamp, $adminTokens, $sessionSecret),
+            => handleAddEvent($activeCamp, $adminTokenSecret, $sessionSecret),
 
         $method === 'POST' && $route === '/add-events'
-            => handleAddEvents($activeCamp, $adminTokens, $sessionSecret),
+            => handleAddEvents($activeCamp, $adminTokenSecret, $sessionSecret),
 
         $method === 'POST' && $route === '/edit-event'
-            => handleEditEvent($activeCamp, $adminTokens, $sessionSecret),
+            => handleEditEvent($activeCamp, $adminTokenSecret, $sessionSecret),
 
         $method === 'POST' && $route === '/delete-event'
-            => handleDeleteEvent($activeCamp, $adminTokens, $sessionSecret),
+            => handleDeleteEvent($activeCamp, $adminTokenSecret, $sessionSecret),
 
         $method === 'POST' && $route === '/feedback'
             => handleFeedback(),
 
         $method === 'POST' && $route === '/verify-admin'
-            => handleVerifyAdmin($adminTokens),
+            => handleVerifyAdmin($adminTokenSecret),
 
         default
             => jsonResponse(['error' => 'Not found'], 404),
@@ -208,8 +215,7 @@ function handleCleanupCookies(): void
     jsonResponse(['cleaned' => count(array_unique($stale))]);
 }
 
-/** @param list<string> $adminTokens */
-function handleAddEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
+function handleAddEvent(?array $activeCamp, string $adminTokenSecret, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'add-event', RATE_LIMIT_ADD_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -233,7 +239,7 @@ function handleAddEvent(?array $activeCamp, array $adminTokens, string $sessionS
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
             || (TimeGate::isBeforeEditingPeriod($today, $opens)
-                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokens))
+                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -296,8 +302,7 @@ function handleAddEvent(?array $activeCamp, array $adminTokens, string $sessionS
     jsonResponse(['success' => true, 'eventId' => $eventId]);
 }
 
-/** @param list<string> $adminTokens */
-function handleAddEvents(?array $activeCamp, array $adminTokens, string $sessionSecret): void
+function handleAddEvents(?array $activeCamp, string $adminTokenSecret, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'add-events', RATE_LIMIT_ADD_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -321,7 +326,7 @@ function handleAddEvents(?array $activeCamp, array $adminTokens, string $session
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
             || (TimeGate::isBeforeEditingPeriod($today, $opens)
-                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokens))
+                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -380,8 +385,7 @@ function handleAddEvents(?array $activeCamp, array $adminTokens, string $session
     jsonResponse(['success' => true, 'eventIds' => $eventIds]);
 }
 
-/** @param list<string> $adminTokens */
-function handleEditEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
+function handleEditEvent(?array $activeCamp, string $adminTokenSecret, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'edit-event', RATE_LIMIT_EDIT_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -397,7 +401,7 @@ function handleEditEvent(?array $activeCamp, array $adminTokens, string $session
     }
 
     $body    = getJsonBody();
-    $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokens);
+    $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret);
 
     // Time-gating with admin bypass (02-§26.17, 02-§26.18)
     if ($activeCamp !== null) {
@@ -462,8 +466,7 @@ function handleEditEvent(?array $activeCamp, array $adminTokens, string $session
     jsonResponse(['success' => true]);
 }
 
-/** @param list<string> $adminTokens */
-function handleDeleteEvent(?array $activeCamp, array $adminTokens, string $sessionSecret): void
+function handleDeleteEvent(?array $activeCamp, string $adminTokenSecret, string $sessionSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'delete-event', RATE_LIMIT_DELETE_EVENT, HOUR_SECONDS)) {
         jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
@@ -479,7 +482,7 @@ function handleDeleteEvent(?array $activeCamp, array $adminTokens, string $sessi
     }
 
     $body    = getJsonBody();
-    $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokens);
+    $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret);
 
     // Time-gating with admin bypass (02-§26.17, 02-§26.18)
     if ($activeCamp !== null) {
@@ -586,8 +589,7 @@ function handleFeedback(): void
     }
 }
 
-/** @param list<string> $adminTokens */
-function handleVerifyAdmin(array $adminTokens): void
+function handleVerifyAdmin(string $adminTokenSecret): void
 {
     if (RateLimit::isLimited(clientIp(), 'verify-admin', RATE_LIMIT_VERIFY_ADMIN, HOUR_SECONDS)) {
         jsonResponse(['error' => RATE_LIMIT_MSG], 429);
@@ -598,7 +600,7 @@ function handleVerifyAdmin(array $adminTokens): void
     $body  = getJsonBody();
     $token = trim((string) ($body['token'] ?? ''));
 
-    if (Admin::verifyAdminToken($token, $adminTokens)) {
+    if (Admin::verifyAdminToken($token, $adminTokenSecret)) {
         jsonResponse(['valid' => true]);
     } else {
         jsonResponse(['valid' => false], 403);

--- a/api/src/Admin.php
+++ b/api/src/Admin.php
@@ -7,54 +7,25 @@ namespace SBSommar;
 /**
  * Admin token helpers – mirrors source/api/admin.js.
  *
- * Tokens have the shape "name_uuid_epoch"; the trailing `_epoch` is a Unix
- * timestamp after which the token expires (02-§91.5).
+ * Tokens are self-validating: each carries its claims and an HMAC signature
+ * keyed by ADMIN_TOKEN_SECRET, so the server validates a token by recomputing
+ * its signature — there is no stored list of issued tokens (02-§91.1, §91.2).
+ *
+ * Format: "namn_roll_epoch_sig", where `sig` is the base64url HMAC-SHA256 of
+ * "namn_roll_epoch" keyed by the secret; `roll` is admin | early | superadmin.
  */
 final class Admin
 {
-    /**
-     * Parses a comma-separated ADMIN_TOKENS value into a trimmed array
-     * (02-§91.1, §91.2).
-     *
-     * @return list<string>
-     */
-    public static function parseAdminTokens(?string $raw): array
-    {
-        if ($raw === null || $raw === '') {
-            return [];
-        }
+    /** @var list<string> */
+    private const VALID_ROLES = ['admin', 'early', 'superadmin'];
 
-        $parts = explode(',', $raw);
-        $result = [];
-        foreach ($parts as $part) {
-            $trimmed = trim($part);
-            if ($trimmed !== '') {
-                $result[] = $trimmed;
-            }
-        }
-
-        return $result;
-    }
+    /** @var list<string> */
+    private const ADMIN_ROLES = ['admin', 'superadmin'];
 
     /**
-     * Returns true when the embedded expiry timestamp has passed.
-     */
-    public static function isTokenExpired(string $token): bool
-    {
-        $i = strrpos($token, '_');
-        if ($i === false) {
-            return false;
-        }
-        $epoch = (int) substr($token, $i + 1);
-        if ($epoch <= 0) {
-            return false;
-        }
-
-        return time() > $epoch;
-    }
-
-    /**
-     * Per-process random key used only to equalise lengths before comparison.
+     * Per-process random key used only to equalise lengths before comparison,
+     * so the comparison leaks neither validity nor value length via timing
+     * (02-§91.8, #386).
      */
     private static function compareKey(): string
     {
@@ -66,44 +37,110 @@ final class Admin
         return $key;
     }
 
-    /**
-     * Hash a token to a fixed-width digest so comparison leaks neither the
-     * match nor the token length via timing (02-§91.8, #386).
-     */
     private static function tokenDigest(string $value): string
     {
         return hash_hmac('sha256', $value, self::compareKey(), true);
     }
 
-    /**
-     * Constant-time check of a candidate against the list of valid tokens.
-     * Returns false for empty/expired candidates and empty token lists.
-     *
-     * Hashing both sides to a fixed-width digest lets hash_equals run on every
-     * candidate/valid pair without a length pre-check, so the comparison leaks
-     * neither which token matched nor the candidate's length.
-     *
-     * @param list<string> $validTokens
-     */
-    public static function verifyAdminToken(?string $candidate, array $validTokens): bool
+    private static function base64url(string $raw): string
     {
-        if ($candidate === null || $candidate === '') {
-            return false;
+        return rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
+    }
+
+    /**
+     * Compute the base64url HMAC-SHA256 signature of the claim string.
+     */
+    private static function signClaims(string $message, string $secret): string
+    {
+        return self::base64url(hash_hmac('sha256', $message, $secret, true));
+    }
+
+    /**
+     * Produce a signed token for the given claims (02-§91.2).
+     */
+    public static function signToken(string $name, string $role, int $epoch, string $secret): string
+    {
+        $message = "{$name}_{$role}_{$epoch}";
+
+        return "{$message}_" . self::signClaims($message, $secret);
+    }
+
+    /**
+     * Extract the embedded expiry epoch (seconds), or 0 if malformed. `namn`,
+     * `roll`, `epoch` are underscore-free, so the first three underscores are
+     * the field delimiters (the base64url signature may contain underscores).
+     */
+    private static function embeddedEpoch(string $token): int
+    {
+        $parts = explode('_', $token, 4);
+        if (count($parts) < 4 || preg_match('/^\d+$/', $parts[2]) !== 1) {
+            return 0;
         }
-        if (self::isTokenExpired($candidate)) {
-            return false;
+        $epoch = (int) $parts[2];
+
+        return $epoch > 0 ? $epoch : 0;
+    }
+
+    /**
+     * Returns true when the embedded expiry has passed. A malformed token
+     * (epoch 0) is treated as expired (fail-closed).
+     */
+    public static function isTokenExpired(string $token): bool
+    {
+        $epoch = self::embeddedEpoch($token);
+        if ($epoch === 0) {
+            return true;
         }
 
-        $candidateDigest = self::tokenDigest($candidate);
-        $match = false;
-        // Compare against every token (no early return) so neither which token
-        // matched nor the candidate's length is observable through timing.
-        foreach ($validTokens as $valid) {
-            if (hash_equals(self::tokenDigest($valid), $candidateDigest)) {
-                $match = true;
-            }
+        return time() > $epoch;
+    }
+
+    /**
+     * Validate a token against the signing secret. Returns
+     * ['name' => ..., 'role' => ..., 'epoch' => ...] when the recomputed
+     * signature matches (constant-time), the role is recognised, and the epoch
+     * is in the future; otherwise null (02-§91.2, §91.29).
+     *
+     * @return array{name: string, role: string, epoch: int}|null
+     */
+    public static function verifyToken(?string $candidate, string $secret): ?array
+    {
+        if ($secret === '' || $candidate === null || $candidate === '') {
+            return null;
+        }
+        $parts = explode('_', $candidate, 4);
+        if (count($parts) < 4) {
+            return null;
+        }
+        [$name, $role, $epochStr, $sig] = $parts;
+        if ($name === '' || $role === '' || $sig === '' || preg_match('/^\d+$/', $epochStr) !== 1) {
+            return null;
+        }
+        $epoch = (int) $epochStr;
+        if ($epoch <= 0 || !in_array($role, self::VALID_ROLES, true)) {
+            return null;
+        }
+        if (time() > $epoch) {
+            return null;
         }
 
-        return $match;
+        $expected = self::signClaims("{$name}_{$role}_{$epoch}", $secret);
+        if (!hash_equals(self::tokenDigest($expected), self::tokenDigest($sig))) {
+            return null;
+        }
+
+        return ['name' => $name, 'role' => $role, 'epoch' => $epoch];
+    }
+
+    /**
+     * True only for administrator-equivalent roles (admin, superadmin).
+     * Preserves the boolean contract used by the add/edit/delete handlers
+     * (02-§91.31).
+     */
+    public static function verifyAdminToken(?string $candidate, string $secret): bool
+    {
+        $token = self::verifyToken($candidate, $secret);
+
+        return $token !== null && in_array($token['role'], self::ADMIN_ROLES, true);
     }
 }

--- a/api/tests/AdminTokenTest.php
+++ b/api/tests/AdminTokenTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBSommar\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SBSommar\Admin;
+
+/**
+ * PHP behavioural coverage for the HMAC admin-token model — parity with
+ * tests/admin-token.test.js (02-§91.1–91.31).
+ *
+ * The fixed vectors below are byte-identical to the Node suite: if PHP and
+ * Node sign the same claims to the same token string, the runtimes are proven
+ * interoperable (a token minted by one validates in the other).
+ */
+final class AdminTokenTest extends TestCase
+{
+    private const VEC_SECRET = '0123456789abcdef0123456789abcdef';
+    private const VEC_EPOCH  = 2000000000;
+    private const VEC_ADMIN  = 'erik_admin_2000000000_BxCLVBJtH61eKTpsn8zsTvYzhL83yf-nF-2HwbBIBVI';
+    private const VEC_EARLY  = 'anna_early_2000000000_0jz-8E6aG-x-z2jjKaEY2YgV6Me9qFAJyG5s4mLl61w';
+    private const VEC_SUPER  = 'sigge_superadmin_2000000000_4oTZ8CsILnVAvDRIqO8ZZj1tuVF52KAxRDKjPs7xyAQ';
+
+    private const SECRET = 'unit-test-secret-32-bytes-long!!';
+
+    private static function future(): int
+    {
+        return time() + 86400;
+    }
+
+    public function testSignTokenMatchesNodeVector(): void
+    {
+        self::assertSame(self::VEC_ADMIN, Admin::signToken('erik', 'admin', self::VEC_EPOCH, self::VEC_SECRET));
+        self::assertSame(self::VEC_EARLY, Admin::signToken('anna', 'early', self::VEC_EPOCH, self::VEC_SECRET));
+        self::assertSame(self::VEC_SUPER, Admin::signToken('sigge', 'superadmin', self::VEC_EPOCH, self::VEC_SECRET));
+    }
+
+    public function testVerifyTokenAcceptsFreshToken(): void
+    {
+        $epoch = self::future();
+        $tok   = Admin::signToken('erik', 'admin', $epoch, self::SECRET);
+        self::assertSame(['name' => 'erik', 'role' => 'admin', 'epoch' => $epoch], Admin::verifyToken($tok, self::SECRET));
+    }
+
+    public function testVerifyTokenValidatesNodeVector(): void
+    {
+        self::assertSame('admin', Admin::verifyToken(self::VEC_ADMIN, self::VEC_SECRET)['role']);
+        self::assertSame('early', Admin::verifyToken(self::VEC_EARLY, self::VEC_SECRET)['role']);
+    }
+
+    public function testVerifyTokenRejectsWrongSecret(): void
+    {
+        self::assertNull(Admin::verifyToken(Admin::signToken('erik', 'admin', self::future(), 'a-secret'), self::SECRET));
+    }
+
+    public function testVerifyTokenRejectsTamperedRole(): void
+    {
+        $tok = Admin::signToken('erik', 'early', self::future(), self::SECRET);
+        self::assertNull(Admin::verifyToken(str_replace('_early_', '_admin_', $tok), self::SECRET));
+    }
+
+    public function testVerifyTokenRejectsUnknownRole(): void
+    {
+        self::assertNull(Admin::verifyToken(Admin::signToken('erik', 'root', self::future(), self::SECRET), self::SECRET));
+    }
+
+    public function testVerifyTokenRejectsExpired(): void
+    {
+        self::assertNull(Admin::verifyToken(Admin::signToken('e', 'admin', time() - 10, self::SECRET), self::SECRET));
+    }
+
+    public function testVerifyTokenRejectsEmptySecret(): void
+    {
+        self::assertNull(Admin::verifyToken(self::VEC_ADMIN, ''));
+    }
+
+    public function testVerifyTokenRejectsMalformed(): void
+    {
+        foreach (['', 'noseparators', 'a_b_c', 'a_b_notnum_sig'] as $bad) {
+            self::assertNull(Admin::verifyToken($bad, self::SECRET), "should reject: {$bad}");
+        }
+    }
+
+    public function testVerifyTokenHandlesUnderscoreSignatures(): void
+    {
+        for ($i = 0; $i < 50; $i++) {
+            $epoch = self::future();
+            $tok   = Admin::signToken("user{$i}", 'admin', $epoch, self::SECRET);
+            self::assertSame(['name' => "user{$i}", 'role' => 'admin', 'epoch' => $epoch], Admin::verifyToken($tok, self::SECRET));
+        }
+    }
+
+    public function testVerifyAdminTokenRoleGating(): void
+    {
+        self::assertTrue(Admin::verifyAdminToken(Admin::signToken('a', 'admin', self::future(), self::SECRET), self::SECRET));
+        self::assertTrue(Admin::verifyAdminToken(Admin::signToken('s', 'superadmin', self::future(), self::SECRET), self::SECRET));
+        self::assertFalse(Admin::verifyAdminToken(Admin::signToken('e', 'early', self::future(), self::SECRET), self::SECRET));
+        self::assertFalse(Admin::verifyAdminToken('', self::SECRET));
+    }
+
+    public function testIsTokenExpired(): void
+    {
+        self::assertTrue(Admin::isTokenExpired(Admin::signToken('e', 'admin', time() - 10, self::SECRET)));
+        self::assertFalse(Admin::isTokenExpired(Admin::signToken('e', 'admin', self::future(), self::SECRET)));
+        self::assertTrue(Admin::isTokenExpired('a_b_c'));
+    }
+}

--- a/api/tests/SecurityHardeningTest.php
+++ b/api/tests/SecurityHardeningTest.php
@@ -64,23 +64,24 @@ final class SecurityHardeningTest extends TestCase
 
     // ── #386 Constant-time admin token ──────────────────────────────────────
 
-    public function testAdminTokenAcceptsMatchRegardlessOfListLengths(): void
+    private const HARDENING_SECRET = 'hardening-test-secret-value-xyz!';
+
+    public function testAdminTokenAcceptsValidSignature(): void
     {
-        $future = time() + 86400;
-        $tok    = 'admin_' . str_repeat('a', 20) . '_' . $future;
-        self::assertTrue(Admin::verifyAdminToken($tok, ['short', $tok, 'another_longer_token_value']));
+        $tok = Admin::signToken('admin', 'admin', time() + 86400, self::HARDENING_SECRET);
+        self::assertTrue(Admin::verifyAdminToken($tok, self::HARDENING_SECRET));
     }
 
-    public function testAdminTokenRejectsEqualLengthMismatch(): void
+    public function testAdminTokenRejectsWrongSecret(): void
     {
-        $future = time() + 86400;
-        self::assertFalse(Admin::verifyAdminToken("aaaaa_{$future}", ["bbbbb_{$future}"]));
+        $tok = Admin::signToken('admin', 'admin', time() + 86400, 'other-secret');
+        self::assertFalse(Admin::verifyAdminToken($tok, self::HARDENING_SECRET));
     }
 
     public function testAdminTokenRejectsExpired(): void
     {
-        $past = time() - 10;
-        self::assertFalse(Admin::verifyAdminToken("admin_uuid_{$past}", ["admin_uuid_{$past}"]));
+        $tok = Admin::signToken('admin', 'admin', time() - 10, self::HARDENING_SECRET);
+        self::assertFalse(Admin::verifyAdminToken($tok, self::HARDENING_SECRET));
     }
 
     // ── #371 Rate-limit counting under the lock ─────────────────────────────

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const {
 } = require('./source/api/session');
 const { isBeforeEditingPeriod, isAfterEditingPeriod }            = require('./source/api/time-gate');
 const { validateFeedbackRequest, createFeedbackIssue }           = require('./source/api/feedback');
-const { parseAdminTokens, verifyAdminToken }                     = require('./source/api/admin');
+const { verifyAdminToken }                                       = require('./source/api/admin');
 const { resolveActiveCamp }                                      = require('./source/scripts/resolve-active-camp');
 
 const app = express();
@@ -31,7 +31,7 @@ const campsPath = path.join(__dirname, 'source', 'data', 'camps.yaml');
 const campsData = yaml.load(fs.readFileSync(campsPath, 'utf8'));
 const BUILD_ENV = process.env.BUILD_ENV || undefined;
 const activeCamp = resolveActiveCamp(campsData.camps || [], undefined, BUILD_ENV);
-const adminTokens = parseAdminTokens(process.env.ADMIN_TOKENS);
+const adminTokenSecret = process.env.ADMIN_TOKEN_SECRET || '';
 const sessionSecret = process.env.SESSION_SECRET || '';
 
 // Warn (don't crash) when SESSION_SECRET is set but too weak to resist
@@ -39,6 +39,13 @@ const sessionSecret = process.env.SESSION_SECRET || '';
 // entirely and fails closed, which is safe.
 if (sessionSecret && sessionSecret.length < 32) {
   console.warn('WARNING: SESSION_SECRET is shorter than 32 characters — use a long random value to protect activity-ownership signatures.');
+}
+
+// Warn (don't crash) when ADMIN_TOKEN_SECRET is set but too weak to resist
+// token forgery (02-§91.32). An unset secret disables admin functionality
+// entirely (no token validates), which fails closed and is safe.
+if (adminTokenSecret && adminTokenSecret.length < 32) {
+  console.warn('WARNING: ADMIN_TOKEN_SECRET is shorter than 32 characters — use a long random value to protect admin token signatures.');
 }
 
 // ── Middleware ───────────────────────────────────────────────────────────────
@@ -97,7 +104,7 @@ app.get('/api/health', (req, res) => {
 
 app.post('/verify-admin', verifyAdminLimiter, (req, res) => {
   const { token } = req.body || {};
-  if (verifyAdminToken(token, adminTokens)) {
+  if (verifyAdminToken(token, adminTokenSecret)) {
     return res.json({ valid: true });
   }
   return res.status(403).json({ valid: false });
@@ -111,7 +118,7 @@ app.post('/add-event', addEventLimiter, (req, res) => {
       return res.status(403).json({ success: false, error: 'Det går inte att lägga till aktiviteter just nu. Formuläret är inte öppet.' });
     }
     if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing)
-        && !verifyAdminToken(req.body.adminToken, adminTokens)) {
+        && !verifyAdminToken(req.body.adminToken, adminTokenSecret)) {
       return res.status(403).json({ success: false, error: 'Det går inte att lägga till aktiviteter just nu. Formuläret är inte öppet.' });
     }
   }
@@ -152,7 +159,7 @@ app.post('/add-event', addEventLimiter, (req, res) => {
 });
 
 app.post('/edit-event', editEventLimiter, (req, res) => {
-  const isAdmin = verifyAdminToken(req.body.adminToken, adminTokens);
+  const isAdmin = verifyAdminToken(req.body.adminToken, adminTokenSecret);
 
   // Time-gating with admin bypass (02-§26.17, 02-§26.18).
   if (activeCamp) {
@@ -192,7 +199,7 @@ app.post('/edit-event', editEventLimiter, (req, res) => {
 });
 
 app.post('/delete-event', deleteEventLimiter, (req, res) => {
-  const isAdmin = verifyAdminToken(req.body.adminToken, adminTokens);
+  const isAdmin = verifyAdminToken(req.body.adminToken, adminTokenSecret);
 
   // Time-gating with admin bypass (02-§26.17, 02-§26.18).
   if (activeCamp) {

--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -26,7 +26,7 @@ The following pages must exist:
 | `02-§2.11` | Edit activity | `/redigera.html` | Participants who submitted the event |
 | `02-§2.12` | iCal feed | `/schema.ics` | Anyone subscribing to the schedule |
 | `02-§2.13` | Calendar tips | `/kalender.html` | Participants wanting to sync the schedule |
-| `02-§2.14` | Admin activation | `/admin.html` | Administrators |
+| `02-§2.14` | Admin activation | `/token.html` | Administrators |
 
 The homepage, schedule pages, add-activity form, and archive share the same header and navigation. <!-- 02-§2.8 -->
 None require login. <!-- 02-§2.9 -->

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -567,37 +567,59 @@ administrators need the ability to edit or delete any event — for example
 to correct mistakes, remove duplicates, or update events on behalf of
 participants who lost their cookie.
 
-This requirement covers the token infrastructure: storage, activation,
-verification, and a visual status indicator. The edit/delete authorisation
-behaviour that uses this token is defined in §7, §18, and §89.
+This requirement covers the token infrastructure: the signing secret,
+activation, verification, and a visual status indicator. The edit/delete
+authorisation behaviour that uses this token is defined in §7, §18, and §89.
+
+Tokens are self-validating: each token carries a role and an expiry and is
+signed with a single server secret, so the server validates a token by
+recomputing its signature — there is no stored list of issued tokens. The same
+infrastructure carries more than one role, so a narrower "early access" role
+reuses the format, signing, and activation flow described here.
 
 ### 91.2 Admin tokens (site requirements)
 
-- The server must accept a comma-separated list of valid admin tokens
-  via the environment variable `ADMIN_TOKENS`. <!-- 02-§91.1 -->
-- Each token follows the format `namn_uuid_epoch`, where `namn` is a
-  lowercase identifier for the admin, `uuid` is a v4 UUID, and `epoch`
-  is a Unix timestamp (seconds) representing the token's expiry
-  date. <!-- 02-§91.2 -->
-- A token whose embedded epoch is in the past is rejected server-side
-  regardless of whether it appears in `ADMIN_TOKENS`. <!-- 02-§91.29 -->
-- The creation script `npm run admin:create` generates a token with
-  60 days validity and prints instructions for where to store
-  it. <!-- 02-§91.30 -->
-- When `ADMIN_TOKENS` is unset or empty, all admin functionality is
-  disabled — the site behaves exactly as before. <!-- 02-§91.3 -->
+- The server validates tokens against a single signing secret in the
+  environment variable `ADMIN_TOKEN_SECRET`. There is no list of issued
+  tokens. <!-- 02-§91.1 -->
+- Each token follows the format `namn_roll_epoch_sig`, where `namn` is a
+  lowercase identifier (`a–ö`, digits, hyphen — never an underscore),
+  `roll` is one of `admin`, `early`, or `superadmin`, `epoch` is a Unix
+  timestamp (seconds) representing the token's expiry, and `sig` is the
+  base64url-encoded HMAC-SHA256 of the string `namn_roll_epoch` keyed by
+  `ADMIN_TOKEN_SECRET`. <!-- 02-§91.2 -->
+- A token is valid only when its recomputed signature matches `sig`
+  (constant-time), its `roll` is a recognised role, and its `epoch` is in
+  the future. A token with any tampered field, an unknown role, or a past
+  epoch is rejected. <!-- 02-§91.29 -->
+- The roles `admin` and `superadmin` grant administrator privileges: they
+  bypass per-event cookie ownership and pre-camp time-gating. `superadmin`
+  additionally authorises minting new tokens. The role `early` is a
+  recognised role reserved for early-access contributors; its narrower
+  privileges are defined in their own requirement section. <!-- 02-§91.31 -->
+- `ADMIN_TOKEN_SECRET` is a high-entropy random value of at least 32 bytes.
+  Both runtimes log a warning at startup when it is shorter. <!-- 02-§91.32 -->
+- The creation script `npm run admin:create` signs a token offline against
+  `ADMIN_TOKEN_SECRET` for the chosen role — 60 days validity for `admin`,
+  180 days for `superadmin` — and prints the token to hand over. The
+  `superadmin` role is minted only by this script, never from the web
+  UI. <!-- 02-§91.30 -->
+- When `ADMIN_TOKEN_SECRET` is unset or empty, all admin functionality is
+  disabled — no token validates and the site behaves as if no one is an
+  administrator. <!-- 02-§91.3 -->
 
 ### 91.3 Token verification endpoint (API requirements)
 
 - The API must expose `POST /verify-admin`. <!-- 02-§91.4 -->
 - The request body must contain `{ "token": "<string>" }`. <!-- 02-§91.5 -->
-- If the token matches any entry in `ADMIN_TOKENS`, the response is
-  `200 { "valid": true }`. <!-- 02-§91.6 -->
-- If the token does not match, the response is
+- If the token has a valid signature, a recognised role, and an unexpired
+  epoch, the response is `200 { "valid": true }`. <!-- 02-§91.6 -->
+- If the token fails validation, the response is
   `403 { "valid": false }`. <!-- 02-§91.7 -->
-- The endpoint enforces the rate limits defined in §93 and performs
-  token comparison using constant-time string comparison to prevent
-  timing attacks. <!-- 02-§91.8 -->
+- The endpoint enforces the rate limits defined in §93 and compares the
+  recomputed and supplied signatures using constant-time comparison over
+  fixed-width digests, so neither validity nor token length leaks via
+  timing. <!-- 02-§91.8 -->
 
 ### 91.4 Admin activation page (user requirements)
 

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -1027,7 +1027,7 @@ dotfiles (so a stray copy inside the web root is still refused).
   location inside the web root. <!-- 02-§100.2 -->
 - The PHP API reads its configuration (`GITHUB_OWNER`, `GITHUB_REPO`,
   `GITHUB_BRANCH`, `GITHUB_TOKEN`, `ALLOWED_ORIGIN`, `QA_ORIGIN`,
-  `COOKIE_DOMAIN`, `BUILD_ENV`, `ADMIN_TOKENS`) from
+  `COOKIE_DOMAIN`, `BUILD_ENV`, `ADMIN_TOKEN_SECRET`) from
   `$DEPLOY_DIR/.env`. <!-- 02-§100.3 -->
 
 ### 100.3 Web server denial (site requirements)

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -623,7 +623,7 @@ reuses the format, signing, and activation flow described here.
 
 ### 91.4 Admin activation page (user requirements)
 
-- A page at `/admin.html` must allow an administrator to enter their
+- A page at `/token.html` must allow an administrator to enter their
   token. <!-- 02-§91.9 -->
 - The page must contain a single text input and a submit button. <!-- 02-§91.10 -->
 - On submit, the page must call `POST /verify-admin` with the entered
@@ -658,11 +658,11 @@ reuses the format, signing, and activation flow described here.
   indicating active admin status. <!-- 02-§91.21 -->
 - **Expired token (> 30 days)**: an open/unlocked icon is displayed,
   indicating the token needs renewal. Clicking the icon navigates to
-  `/admin.html`. <!-- 02-§91.22 -->
+  `/token.html`. <!-- 02-§91.22 -->
 - The icon must be small and unobtrusive — it is not intended for
   regular visitors. <!-- 02-§91.23 -->
 - The icon must have a `title` attribute explaining its meaning in
-  Swedish (e.g. "Admin aktiv" / "Admin utgången"). <!-- 02-§91.24 -->
+  Swedish (e.g. "Token aktiv" / "Token utgången"). <!-- 02-§91.24 -->
 
 ### 91.7 Constraints
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -321,7 +321,7 @@ though `mod_rewrite` would otherwise leave existing files untouched
 
 Same environment variables as the Node.js API: `GITHUB_OWNER`, `GITHUB_REPO`,
 `GITHUB_BRANCH`, `GITHUB_TOKEN`, `ALLOWED_ORIGIN`, `QA_ORIGIN`, `COOKIE_DOMAIN`,
-`BUILD_ENV`, `ADMIN_TOKENS`. Loaded via `vlucas/phpdotenv` from
+`BUILD_ENV`, `ADMIN_TOKEN_SECRET`. Loaded via `vlucas/phpdotenv` from
 `$DEPLOY_DIR/.env` — **outside** the web root, not from any path under
 `public_html`. `index.php` resolves the directory as `dirname(__DIR__, 2)`
 (the parent of `public_html`) and calls `Dotenv::createImmutable()` on it

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -223,7 +223,7 @@ client-side. An expired token behaves as if no token exists.
 
 ### Activation page
 
-`/admin.html` — a minimal page with a text input and submit button.
+`/token.html` — a minimal page with a text input and submit button.
 On submit, it calls `POST /verify-admin`. If valid, the token and
 timestamp are stored in `localStorage`. The page shares the site layout
 (header, navigation, footer) but is **not listed in the navigation**.
@@ -235,8 +235,8 @@ A small icon in the shared site footer shows admin status:
 | State | Display |
 | --- | --- |
 | No token in `localStorage` | Nothing shown |
-| Valid token (< 30 days) | Filled/locked icon with title "Admin aktiv" |
-| Expired token (> 30 days) | Open/unlocked icon with title "Admin utgången", links to `/admin.html` |
+| Valid token (< 30 days) | Filled/locked icon with title "Token aktiv" |
+| Expired token (> 30 days) | Open/unlocked icon with title "Token utgången", links to `/token.html` |
 
 The icon is rendered client-side by a script included in the footer
 layout, reading from `localStorage`.
@@ -245,7 +245,7 @@ layout, reading from `localStorage`.
 
 | File | Role |
 | --- | --- |
-| `source/build/render-admin.js` | Build-time render of `/admin.html` |
+| `source/build/render-admin.js` | Build-time render of `/token.html` |
 | `source/assets/js/client/admin.js` | Client-side: activation form + footer icon |
 | `source/build/layout.js` | Updated `pageFooter()` to include admin icon container |
 | `app.js` | New `POST /verify-admin` endpoint (Node.js) |

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -164,20 +164,45 @@ alternative to session-cookie ownership (OR condition).
 
 ### Token storage (server)
 
-Admin tokens are stored in the environment variable `ADMIN_TOKENS` as a
-comma-separated list of opaque strings (e.g. UUIDs). Both the Node.js
-server (`app.js`) and the PHP API (`api/`) read this variable at startup.
-When the variable is unset or empty, all admin functionality is disabled.
+The server validates tokens against a single signing secret in the
+environment variable `ADMIN_TOKEN_SECRET`; there is no stored list of
+issued tokens. A token has the form `namn_roll_epoch_sig`, where `sig` is
+the base64url HMAC-SHA256 of `namn_roll_epoch` keyed by the secret. The
+Node server (`app.js` / `source/api/admin.js`) and the PHP API
+(`api/index.php` / `api/src/Admin.php`) each read the secret at startup and
+recompute the signature to validate a token: `signToken()` produces a token
+and `verifyToken()` returns its `{ name, role, epoch }` or `null`. Both
+runtimes encode the signature as unpadded base64url so a token signed by one
+validates in the other. The token is parsed on the first three underscores
+(`namn`, `roll`, `epoch` are underscore-free; the remainder is `sig`, which
+may itself contain base64url underscores). Roles `admin` and `superadmin`
+are administrator-equivalent; `early` is a recognised role with narrower
+privileges. When the secret is unset or empty, no token validates and admin
+functionality is disabled. The runtimes log a warning when the secret is
+shorter than 32 bytes (same posture as `SESSION_SECRET`).
 
 ### Verification endpoint
 
 `POST /verify-admin` accepts `{ "token": "<string>" }` and responds:
 
-- `200 { "valid": true }` — token found in `ADMIN_TOKENS`
-- `403 { "valid": false }` — token not found
+- `200 { "valid": true }` — valid signature, recognised role, unexpired epoch
+- `403 { "valid": false }` — otherwise
 
-The comparison uses constant-time string comparison to prevent timing
-attacks.
+The supplied and recomputed signatures are compared in constant time over
+fixed-width digests (`tokenDigest()`, an HMAC keyed by a per-process random
+key, retained from #386), so neither validity nor token length leaks via
+timing.
+
+### Provisioning and revocation
+
+`npm run admin:create` signs a token offline against `ADMIN_TOKEN_SECRET`
+for the chosen role and prints it to hand over — no environment edit and no
+redeploy per person, because the secret (not a list) is what the runtimes
+read. `superadmin` is minted only by this script (it grants the right to
+mint others), never from the web UI. Because tokens are stateless, an
+individual token cannot be revoked without rotating `ADMIN_TOKEN_SECRET`
+(which invalidates all tokens at once); short embedded expiries bound the
+exposure of a leaked token.
 
 ### Token storage (client)
 

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -156,7 +156,7 @@ flowchart TD
 | `GITHUB_REPO`    | —       | GitHub repository name                                   |
 | `GITHUB_BRANCH`  | —       | Branch to commit events to (typically `main`)            |
 | `GITHUB_TOKEN`   | —       | Personal access token with repo write access             |
-| `ADMIN_TOKENS`   | —       | Comma-separated admin tokens (UUIDs). Omit to disable.   |
+| `ADMIN_TOKEN_SECRET` | —   | HMAC signing secret (≥32 bytes) that validates admin tokens. Omit to disable. |
 | `SESSION_SECRET` | —       | Secret signing key for participant ownership cookies.    |
 
 `API_URL`, `ALLOWED_ORIGIN`, `COOKIE_DOMAIN`, `GITHUB_*`, `SESSION_SECRET`, and SSH credentials are stored as GitHub Actions secrets and server environment variables. They are not needed for local development. Without `API_URL` set, the built form will have no submit endpoint — this is expected in local builds. Without `GITHUB_*` set, event submission via the API will fail; all other functionality works normally.
@@ -207,25 +207,41 @@ to fix or remove entries.
 
 Admin tokens grant one or two people the ability to edit or delete any
 event through the site UI — not just their own. The feature is optional;
-omit `ADMIN_TOKENS` to disable it entirely.
+omit `ADMIN_TOKEN_SECRET` to disable it entirely.
+
+Tokens are signed, not listed: the runtimes validate a token by recomputing
+its HMAC signature against `ADMIN_TOKEN_SECRET`, so issuing or retiring a
+person never requires an environment edit or a redeploy.
+
+### One-time setup of the signing secret
+
+Generate a high-entropy secret once and store it like any other server
+secret — in `.env` (local), `$DEPLOY_DIR/.env` on the server (outside the
+web root), and the GitHub Environment secrets for QA/Production:
+
+```bash
+openssl rand -base64 48
+```
+
+Rotating this secret invalidates every existing token at once.
 
 ### Issuing a token
 
-1. Run `npm run admin:create` and follow the prompts. The script
-   generates a token in the format `namn_uuid_epoch` (where `epoch` is
-   a Unix timestamp 60 days in the future) and prints instructions.
-   The token is shown only once — save it immediately.
-2. Add the token to `ADMIN_TOKENS` in all three locations (see script
-   output): `.env` (local), `$DEPLOY_DIR/.env` on the server (outside the
-   web root), and GitHub Environment secrets for QA/Production.
-3. Share the token privately with the admin (e.g. via SMS or in person).
-4. The admin visits `/admin.html`, enters the token, and gains admin
-   status for 30 days.
+1. Run `npm run admin:create` and follow the prompts (name + role). The
+   script signs a token in the format `namn_roll_epoch_sig` against
+   `ADMIN_TOKEN_SECRET` — 60 days validity for `admin`, 180 days for
+   `superadmin`. The token is shown only once — save it immediately.
+2. Share the token privately with the admin (e.g. via SMS or in person).
+   No environment edit and no redeploy are needed.
+3. The admin visits `/admin.html`, enters the token, and gains admin
+   status until the token's embedded expiry.
 
-### Revoking a token
+### Revoking access
 
-Remove the token from `ADMIN_TOKENS` and redeploy. No code change is
-needed.
+Because tokens are stateless, an individual token cannot be revoked on its
+own. To revoke everyone, rotate `ADMIN_TOKEN_SECRET` and redeploy, then
+re-issue tokens to the people who should keep access. Short expiries bound
+the exposure of a leaked token in the meantime.
 
 ---
 

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -233,7 +233,7 @@ Rotating this secret invalidates every existing token at once.
    `superadmin`. The token is shown only once — save it immediately.
 2. Share the token privately with the admin (e.g. via SMS or in person).
    No environment edit and no redeploy are needed.
-3. The admin visits `/admin.html`, enters the token, and gains admin
+3. The admin visits `/token.html`, enters the token, and gains admin
    status until the token's embedded expiry.
 
 ### Revoking access

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -103,7 +103,7 @@ the secrets.
 | `SERVER_SSH_KEY`        | QA SSH private key                                                                                                                                      |
 | `SERVER_SSH_PORT`       | QA SSH port                                                                                                                                             |
 | `DEPLOY_DIR`            | QA deploy directory                                                                                                                                     |
-| `ADMIN_TOKENS`          | Comma-separated list of admin tokens (format: `namn_uuid_epoch`). Optional — omit to disable admin features. Create tokens with `npm run admin:create`. |
+| `ADMIN_TOKEN_SECRET`    | HMAC signing secret (≥32 bytes) that validates admin tokens (format: `namn_roll_epoch_sig`). Optional — omit to disable admin features. Generate with `openssl rand -base64 48`; mint tokens with `npm run admin:create`. Must differ between QA and Production. |
 | `SESSION_SECRET`        | Secret signing key for participant event-ownership cookies. Must differ between QA and Production.                                                       |
 
 Example values: `SITE_URL=https://qa.sbsommar.se`,
@@ -113,12 +113,12 @@ The PHP API is deployed alongside the static site via SCP. Its `.env` file
 on the server is managed manually and lives at `$DEPLOY_DIR/.env` — outside
 the web root, never under `public_html/api` (§100). It contains the
 `GITHUB_*`, `ALLOWED_ORIGIN`, `QA_ORIGIN`, `COOKIE_DOMAIN`, `BUILD_ENV`,
-`ADMIN_TOKENS`, and `SESSION_SECRET` variables needed by the PHP API at
+`ADMIN_TOKEN_SECRET`, and `SESSION_SECRET` variables needed by the PHP API at
 runtime.
 
 ### GitHub Environment: `production`
 
-Same secret names as `qa` (including `ADMIN_TOKENS`), but with production values:
+Same secret names as `qa` (including `ADMIN_TOKEN_SECRET`), but with production values:
 
 | Secret            | Purpose                                               |
 | ----------------- | ----------------------------------------------------- |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1262,7 +1262,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.12` | implemented | manual: `admin.js` stores token in localStorage on success |
 | `02-§91.13` | implemented | manual: `admin.js` shows error message on failure |
 | `02-§91.14` | covered | ADM-14: page includes page-nav and site-footer |
-| `02-§91.15` | covered | ADM-15: admin.html not in nav links |
+| `02-§91.15` | covered | ADM-15: token.html not in nav links |
 | `02-§91.16` | covered | ADM-21, ADM-24: `isAdminExpired` returns true after 30 days |
 | `02-§91.17` | covered | ADM-19..23: expiry checked via `isAdminExpired` function |
 | `02-§91.18` | covered | ADM-22, ADM-23: undefined/zero treated as expired |
@@ -1271,7 +1271,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.21` | implemented | manual: `admin.js` renders filled lock icon for valid token |
 | `02-§91.22` | implemented | manual: `admin.js` renders open lock icon with link for expired |
 | `02-§91.23` | implemented | CSS: 16×16 SVG icon, inline-block in footer |
-| `02-§91.24` | implemented | `admin.js` sets title="Admin aktiv" / "Admin utgången" |
+| `02-§91.24` | implemented | `admin.js` sets title="Token aktiv" / "Token utgången" |
 | `02-§91.25` | covered | ADM-16: `lang="sv"` on admin page |
 | `02-§91.26` | implemented | CSS uses --color-*, --space-*, --font-size-*, --radius-* tokens |
 | `02-§91.27` | implemented | Form has label, input, aria-live on message; icon has title attr |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1244,18 +1244,18 @@ its requirement rows together with the test-legend rows that evidence them.
 
 | Requirement | Status | Test / Evidence |
 | ----------- | ------ | --------------- |
-| `02-§91.1` | gap | Single `ADMIN_TOKEN_SECRET` model (no list); `verifyToken` tests in `admin-token.test.js` |
-| `02-§91.2` | gap | Format `namn_roll_epoch_sig`; `signToken`/`verifyToken` round-trip + tamper tests |
-| `02-§91.3` | gap | `verifyToken` returns null / verify-admin disabled when secret empty |
-| `02-§91.29` | gap | Tamper, expiry, and unknown-role rejection (Node + PHP parity tests) |
-| `02-§91.30` | gap | `npm run admin:create` signs offline for `admin`/`superadmin` (60/180 days) |
-| `02-§91.31` | gap | `admin`/`superadmin` admin-equivalent; `early` a recognised role |
-| `02-§91.32` | gap | Runtimes warn at startup when `ADMIN_TOKEN_SECRET` < 32 bytes |
+| `02-§91.1` | covered | TOK-01..12: single `ADMIN_TOKEN_SECRET` model, `verifyToken` in `admin-token.test.js` |
+| `02-§91.2` | covered | TOK-01 fixed vector (Node + PHP `AdminTokenTest.php`); TOK-03/12 round-trips; `source/api/admin.js`, `api/src/Admin.php` |
+| `02-§91.3` | covered | TOK-10: `verifyToken` returns null when the secret is empty |
+| `02-§91.29` | covered | TOK-05..09: tampered field, unknown role, expired rejected (PHP parity in `AdminTokenTest.php`) |
+| `02-§91.30` | implemented | `npm run admin:create` signs offline for `admin`/`superadmin` (60/180 days); manual: minted token round-trips |
+| `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
+| `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
-| `02-§91.6` | gap | `verifyToken` accepts valid signature + recognised role + future epoch |
-| `02-§91.7` | gap | `verifyToken` rejects tampered/expired token |
-| `02-§91.8` | gap | Constant-time digest comparison (`tokenDigest` + `timingSafeEqual` / `hash_equals`) |
+| `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |
+| `02-§91.7` | covered | TOK-05..09: tampered/expired token rejected |
+| `02-§91.8` | covered | SEC-386-03: constant-time `tokenDigest` + `timingSafeEqual` / `hash_equals(self::tokenDigest)` |
 | `02-§91.9` | covered | ADM-11: `renderAdminPage` produces valid HTML document |
 | `02-§91.10` | covered | ADM-12, ADM-13: text input + submit button in rendered output |
 | `02-§91.11` | implemented | manual: `admin.js` calls `POST /verify-admin` on form submit |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1244,16 +1244,18 @@ its requirement rows together with the test-legend rows that evidence them.
 
 | Requirement | Status | Test / Evidence |
 | ----------- | ------ | --------------- |
-| `02-§91.1` | covered | ADM-01..05: `parseAdminTokens` tests in `admin-token.test.js` |
-| `02-§91.2` | covered | Format `namn_uuid_epoch`; `create-admin-token.js` generates; ADM-09..10 validate expiry |
-| `02-§91.3` | covered | ADM-08: `verifyAdminToken` returns false for empty list |
-| `02-§91.29` | covered | ADM-09, ADM-10: `isTokenExpired` / `verifyAdminToken` reject expired tokens server-side |
-| `02-§91.30` | implemented | `npm run admin:create` runs `source/scripts/create-admin-token.js` |
+| `02-§91.1` | gap | Single `ADMIN_TOKEN_SECRET` model (no list); `verifyToken` tests in `admin-token.test.js` |
+| `02-§91.2` | gap | Format `namn_roll_epoch_sig`; `signToken`/`verifyToken` round-trip + tamper tests |
+| `02-§91.3` | gap | `verifyToken` returns null / verify-admin disabled when secret empty |
+| `02-§91.29` | gap | Tamper, expiry, and unknown-role rejection (Node + PHP parity tests) |
+| `02-§91.30` | gap | `npm run admin:create` signs offline for `admin`/`superadmin` (60/180 days) |
+| `02-§91.31` | gap | `admin`/`superadmin` admin-equivalent; `early` a recognised role |
+| `02-§91.32` | gap | Runtimes warn at startup when `ADMIN_TOKEN_SECRET` < 32 bytes |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
-| `02-§91.6` | covered | ADM-06: `verifyAdminToken` returns true for matching token |
-| `02-§91.7` | covered | ADM-07: `verifyAdminToken` returns false for non-matching token |
-| `02-§91.8` | implemented | `crypto.timingSafeEqual` (Node.js), `hash_equals` (PHP) |
+| `02-§91.6` | gap | `verifyToken` accepts valid signature + recognised role + future epoch |
+| `02-§91.7` | gap | `verifyToken` rejects tampered/expired token |
+| `02-§91.8` | gap | Constant-time digest comparison (`tokenDigest` + `timingSafeEqual` / `hash_equals`) |
 | `02-§91.9` | covered | ADM-11: `renderAdminPage` produces valid HTML document |
 | `02-§91.10` | covered | ADM-12, ADM-13: text input + submit button in rendered output |
 | `02-§91.11` | implemented | manual: `admin.js` calls `POST /verify-admin` on form submit |
@@ -1489,7 +1491,7 @@ refactor of `render-lokaler.js` onto the shared module).
 | --- | --- | --- |
 | `02-§100.1` | covered | ENVLOC-02: workflow writes no `.env` into `$API_STAGING`/`$PUBLIC_DIR/api`; `.github/workflows/deploy-reusable.yml`. Manual: `ls $DEPLOY_DIR/public_html/api/.env` absent after deploy |
 | `02-§100.2` | covered | HTACC-05, HTACC-06: `api/index.php` loads via `Dotenv::createImmutable(dirname(__DIR__, 2))` and never `createImmutable(__DIR__)` |
-| `02-§100.3` | implemented | PHP runtime reads `GITHUB_*`, origins, `COOKIE_DOMAIN`, `BUILD_ENV`, `ADMIN_TOKENS` from `$DEPLOY_DIR/.env`; no PHP test harness — manual server verification (submit an event end-to-end) |
+| `02-§100.3` | implemented | PHP runtime reads `GITHUB_*`, origins, `COOKIE_DOMAIN`, `BUILD_ENV`, `ADMIN_TOKEN_SECRET` from `$DEPLOY_DIR/.env`; no PHP test harness — manual server verification (submit an event end-to-end) |
 | `02-§100.4` | covered | HTACC-01, HTACC-02, HTACC-03: `api/.htaccess` denies dotfiles (2.4 + 2.2) before the rewrite. Manual: `curl -sI .../api/.env` → 403 |
 | `02-§100.5` | covered | HTACC-04: `source/static/.htaccess` denies `.env` (2.4 + 2.2); build copies it to `public/.htaccess` |
 | `02-§100.6` | implemented | Manual checkpoint — `curl -sI https://sbsommar.se/api/.env` and QA return 403/404 (live Apache/LiteSpeed only) |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:yaml": "node source/scripts/lint-yaml.js",
     "validate:camps": "node source/scripts/validate-camps.js",
     "check:security": "node source/scripts/check-yaml-security.js",
-    "admin:create": "node source/scripts/create-admin-token.js",
+    "admin:create": "node --env-file-if-exists=.env source/scripts/create-admin-token.js",
     "lint:md": "markdownlint \"content/**/*.md\" \"docs/**/*.md\" README.md CLAUDE.md",
     "lint:css": "stylelint \"source/assets/cs/**/*.css\"",
     "lint:html": "html-validate \"public/**/*.html\"",

--- a/source/api/admin.js
+++ b/source/api/admin.js
@@ -2,67 +2,107 @@
 
 const crypto = require('crypto');
 
-// ── parseAdminTokens ────────────────────────────────────────────────────────
+// Tokens are self-validating: each carries its claims and an HMAC signature
+// keyed by ADMIN_TOKEN_SECRET, so the server validates a token by recomputing
+// its signature — there is no stored list of issued tokens (02-§91.1, §91.2).
+//
+// Format: namn_roll_epoch_sig
+//   namn  — lowercase identifier, never contains an underscore
+//   roll  — one of admin | early | superadmin
+//   epoch — Unix expiry (seconds)
+//   sig   — base64url HMAC-SHA256 of "namn_roll_epoch" keyed by the secret
 
-// Parse the ADMIN_TOKENS environment variable (comma-separated string)
-// into an array of non-empty trimmed strings.
-function parseAdminTokens(raw) {
-  if (!raw || typeof raw !== 'string') return [];
-  return raw.split(',').map((s) => s.trim()).filter(Boolean);
-}
+const VALID_ROLES = new Set(['admin', 'early', 'superadmin']);
+const ADMIN_ROLES = new Set(['admin', 'superadmin']);
 
-// ── Token expiry ────────────────────────────────────────────────────────────
-
-// Extract the Unix epoch (seconds) from the last segment of a token.
-// Token format: namn_uuid_epoch — e.g. "erik_e0d6229c-...-xxxx_1752710400"
-// Returns the epoch as a number, or 0 if the token has no valid epoch suffix.
-function extractTokenExpiry(token) {
-  if (!token || typeof token !== 'string') return 0;
-  const lastUnderscore = token.lastIndexOf('_');
-  if (lastUnderscore === -1) return 0;
-  const epoch = Number(token.slice(lastUnderscore + 1));
-  return Number.isFinite(epoch) && epoch > 0 ? epoch : 0;
-}
-
-// Check if a token's embedded expiry has passed.
-// Returns true (= expired) when: no epoch found, or epoch is in the past.
-function isTokenExpired(token) {
-  const expiry = extractTokenExpiry(token);
-  if (expiry === 0) return true;
-  return Math.floor(Date.now() / 1000) > expiry;
-}
-
-// ── verifyAdminToken ────────────────────────────────────────────────────────
+// ── Constant-time comparison helper (retained from #386) ─────────────────────
 
 // Per-process random key used only to equalise lengths before comparison.
-// Hashing both sides to a fixed-width digest lets us run timingSafeEqual on
-// every candidate/valid pair without a length pre-check, so the comparison
-// leaks neither the match nor the token length via timing (02-§91.8, #386).
+// Hashing both sides to a fixed-width digest lets us run timingSafeEqual on any
+// pair without a length pre-check, so the comparison leaks neither validity nor
+// value length via timing (02-§91.8).
 const COMPARE_KEY = crypto.randomBytes(32);
 
 function tokenDigest(value) {
   return crypto.createHmac('sha256', COMPARE_KEY).update(String(value)).digest();
 }
 
-// Check if a candidate token matches any entry in the valid tokens list.
-// Uses constant-time comparison to prevent timing attacks (02-§91.8).
-// Rejects tokens whose embedded expiry epoch has passed.
-function verifyAdminToken(candidate, validTokens) {
-  if (!candidate || typeof candidate !== 'string' || !Array.isArray(validTokens)) return false;
+// ── Signing ──────────────────────────────────────────────────────────────────
 
-  // Check embedded expiry before comparing
-  if (isTokenExpired(candidate)) return false;
-
-  const candidateDigest = tokenDigest(candidate);
-  let match = false;
-  // Compare against every token (no early return) so neither which token
-  // matched nor the candidate's length is observable through timing.
-  for (const valid of validTokens) {
-    if (crypto.timingSafeEqual(tokenDigest(valid), candidateDigest)) {
-      match = true;
-    }
-  }
-  return match;
+// Compute the base64url HMAC-SHA256 signature of the claim string.
+function signClaims(message, secret) {
+  return crypto.createHmac('sha256', secret).update(message).digest('base64url');
 }
 
-module.exports = { parseAdminTokens, verifyAdminToken, isTokenExpired, extractTokenExpiry };
+// Produce a signed token for the given claims (02-§91.2).
+function signToken(name, role, epoch, secret) {
+  const message = `${name}_${role}_${epoch}`;
+  return `${message}_${signClaims(message, secret)}`;
+}
+
+// ── Parsing ──────────────────────────────────────────────────────────────────
+
+// Split on the first three underscores: namn/roll/epoch are underscore-free,
+// while the base64url signature may itself contain '_' or '-'.
+function parseToken(token) {
+  if (!token || typeof token !== 'string') return null;
+  const parts = token.split('_');
+  if (parts.length < 4) return null;
+  const [name, role, epochStr] = parts;
+  const sig = parts.slice(3).join('_');
+  if (!name || !role || !sig) return null;
+  if (!/^\d+$/.test(epochStr)) return null;
+  const epoch = Number(epochStr);
+  if (!Number.isInteger(epoch) || epoch <= 0) return null;
+  return { name, role, epoch, sig, message: `${name}_${role}_${epoch}` };
+}
+
+// ── Embedded expiry ──────────────────────────────────────────────────────────
+
+// Extract the embedded expiry epoch (seconds) from a token, or 0 if malformed.
+function extractTokenExpiry(token) {
+  const parsed = parseToken(token);
+  return parsed ? parsed.epoch : 0;
+}
+
+// Check if a token's embedded expiry has passed. A malformed token (expiry 0)
+// is treated as expired (fail-closed).
+function isTokenExpired(token) {
+  const expiry = extractTokenExpiry(token);
+  if (expiry === 0) return true;
+  return Math.floor(Date.now() / 1000) > expiry;
+}
+
+// ── Verification ─────────────────────────────────────────────────────────────
+
+// Validate a token against the signing secret. Returns { name, role, epoch }
+// when the recomputed signature matches (constant-time), the role is recognised,
+// and the epoch is in the future; otherwise null (02-§91.2, §91.29).
+function verifyToken(candidate, secret) {
+  if (!secret || typeof secret !== 'string') return null;
+  const parsed = parseToken(candidate);
+  if (!parsed) return null;
+  if (!VALID_ROLES.has(parsed.role)) return null;
+  if (Math.floor(Date.now() / 1000) > parsed.epoch) return null;
+
+  const expected = signClaims(parsed.message, secret);
+  if (!crypto.timingSafeEqual(tokenDigest(expected), tokenDigest(parsed.sig))) return null;
+
+  return { name: parsed.name, role: parsed.role, epoch: parsed.epoch };
+}
+
+// True only for administrator-equivalent roles (admin, superadmin). Preserves
+// the boolean contract used by the add/edit/delete handlers (02-§91.31).
+function verifyAdminToken(candidate, secret) {
+  const token = verifyToken(candidate, secret);
+  return !!token && ADMIN_ROLES.has(token.role);
+}
+
+module.exports = {
+  signToken,
+  verifyToken,
+  verifyAdminToken,
+  isTokenExpired,
+  extractTokenExpiry,
+  VALID_ROLES,
+};

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -15,13 +15,14 @@
     }
   }
 
-  // Extract epoch (seconds) from the last underscore-segment of a token.
-  // Token format: namn_uuid_epoch
+  // Extract epoch (seconds) from a token. Format: namn_roll_epoch_sig — the
+  // epoch is the third underscore-segment (the base64url sig may contain
+  // underscores, so we read by position rather than from the end).
   function extractExpiry(token) {
     if (!token || typeof token !== 'string') return 0;
-    var i = token.lastIndexOf('_');
-    if (i === -1) return 0;
-    var n = Number(token.slice(i + 1));
+    var parts = token.split('_');
+    if (parts.length < 4) return 0;
+    var n = Number(parts[2]);
     return isFinite(n) && n > 0 ? n : 0;
   }
 

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -49,14 +49,14 @@
 
     if (isExpired(data)) {
       // Expired → open lock, link to /admin.html (02-§91.22)
-      container.innerHTML = '<a href="admin.html" class="admin-icon admin-icon--expired" title="Admin utgången — efterfråga ny token">' +
+      container.innerHTML = '<a href="token.html" class="admin-icon admin-icon--expired" title="Token utgången — efterfråga ny">' +
         '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">' +
         '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>' +
         '<path d="M7 11V7a5 5 0 0 1 9.9-1"/>' +
         '</svg></a>';
     } else {
       // Valid → filled lock, link to admin page (02-§91.21)
-      container.innerHTML = '<a href="admin.html" class="admin-icon admin-icon--active" title="Admin aktiv">' +
+      container.innerHTML = '<a href="token.html" class="admin-icon admin-icon--active" title="Token aktiv">' +
         '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">' +
         '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>' +
         '<path d="M7 11V7a5 5 0 0 1 10 0v4"/>' +
@@ -79,11 +79,14 @@
     if (existing && !isExpired(existing)) {
       var expiry = extractExpiry(existing.token);
       var expiryDate = expiry ? new Date(expiry * 1000).toLocaleDateString('sv-SE') : '';
-      message.textContent = 'Admin-token är aktiv' + (expiryDate ? ' till ' + expiryDate : '') + '. Du kan byta genom att ange en ny token nedan.';
+      var activatedAt = existing.activated ? new Date(existing.activated).toLocaleString('sv-SE') : '';
+      message.textContent = 'Din token är aktiv' + (expiryDate ? ' till ' + expiryDate : '')
+        + (activatedAt ? ' (aktiverad ' + activatedAt + ')' : '')
+        + '. Du kan byta genom att ange en ny token nedan.';
       message.hidden = false;
       message.classList.add('admin-message--success');
     } else if (existing && isExpired(existing)) {
-      message.textContent = 'Din admin-token har gått ut. Efterfråga en ny token och aktivera den här.';
+      message.textContent = 'Din token har gått ut. Efterfråga en ny token och aktivera den här.';
       message.hidden = false;
       message.classList.add('admin-message--error');
     }
@@ -130,8 +133,9 @@
           if (data.valid) {
             localStorage.setItem(STORAGE_KEY, JSON.stringify({
               token: token,
+              activated: Date.now(),
             }));
-            message.textContent = 'Admin-token aktiverad!';
+            message.textContent = 'Token aktiverad ' + new Date().toLocaleString('sv-SE') + '.';
             message.classList.add('admin-message--success');
             message.hidden = false;
             if (removeBtn) removeBtn.hidden = false;

--- a/source/assets/js/client/lagg-till.js
+++ b/source/assets/js/client/lagg-till.js
@@ -405,9 +405,11 @@
       if (!raw) return null;
       var data = JSON.parse(raw);
       if (!data || !data.token || typeof data.token !== 'string') return null;
-      var i = data.token.lastIndexOf('_');
-      if (i === -1) return null;
-      var epoch = Number(data.token.slice(i + 1));
+      // Token format: namn_roll_epoch_sig — the epoch is the third segment
+      // (the base64url signature may contain underscores, so read by position).
+      var parts = data.token.split('_');
+      if (parts.length < 4) return null;
+      var epoch = Number(parts[2]);
       if (!isFinite(epoch) || epoch <= 0) return null;
       return Math.floor(Date.now() / 1000) <= epoch ? data.token : null;
     } catch {

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -257,9 +257,11 @@
       if (!raw) return null;
       var data = JSON.parse(raw);
       if (!data || !data.token || typeof data.token !== 'string') return null;
-      var i = data.token.lastIndexOf('_');
-      if (i === -1) return null;
-      var epoch = Number(data.token.slice(i + 1));
+      // Token format: namn_roll_epoch_sig — the epoch is the third segment
+      // (the base64url signature may contain underscores, so read by position).
+      var parts = data.token.split('_');
+      if (parts.length < 4) return null;
+      var epoch = Number(parts[2]);
       if (!isFinite(epoch) || epoch <= 0) return null;
       return Math.floor(Date.now() / 1000) <= epoch ? data.token : null;
     } catch {

--- a/source/assets/js/client/session.js
+++ b/source/assets/js/client/session.js
@@ -109,9 +109,11 @@
       if (!raw) return false;
       var data = JSON.parse(raw);
       if (!data || !data.token || typeof data.token !== 'string') return false;
-      var i = data.token.lastIndexOf('_');
-      if (i === -1) return false;
-      var epoch = Number(data.token.slice(i + 1));
+      // Token format: namn_roll_epoch_sig — the epoch is the third segment
+      // (the base64url signature may contain underscores, so read by position).
+      var parts = data.token.split('_');
+      if (parts.length < 4) return false;
+      var epoch = Number(parts[2]);
       if (!isFinite(epoch) || epoch <= 0) return false;
       return Math.floor(Date.now() / 1000) <= epoch;
     } catch {

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -282,10 +282,10 @@ async function main() {
   fs.writeFileSync(path.join(OUTPUT_DIR, 'kalender.html'), kalenderHtml, 'utf8');
   console.log('Built: public/kalender.html');
 
-  // ── Render admin activation page ─────────────────────────────────────────
+  // ── Render token activation page ─────────────────────────────────────────
   const adminHtml = renderAdminPage(camp, footerWithVersion, navSections, GOATCOUNTER_CODE);
-  fs.writeFileSync(path.join(OUTPUT_DIR, 'admin.html'), adminHtml, 'utf8');
-  console.log('Built: public/admin.html');
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'token.html'), adminHtml, 'utf8');
+  console.log('Built: public/token.html');
 
   // ── Render offline fallback page ────────────────────────────────────────
   const offlineHtml = renderOfflinePage(footerWithVersion, navSections, GOATCOUNTER_CODE);

--- a/source/build/render-admin.js
+++ b/source/build/render-admin.js
@@ -16,7 +16,7 @@ function renderAdminPage(camp, footerHtml = '', navSections = [], goatcounterCod
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
-  <title>Admin – ${camp.name || 'SB Sommar'}</title>
+  <title>Bakom kulisserna – ${camp.name || 'SB Sommar'}</title>
   <link rel="stylesheet" href="style.css">
 ${pwa}
 </head>
@@ -24,12 +24,12 @@ ${pwa}
 ${nav}
   <main>
     <h1>Bakom kulisserna</h1>
-    <p class="admin-intro">Här aktiverar du din admin-token. Med en aktiv token kan du redigera och ta bort alla aktiviteter i schemat — inte bara dina egna.</p>
+    <p class="admin-intro">Här aktiverar du din token. Vilka aktiviteter du kan ändra beror på vilken token du har.</p>
     <div id="admin-form" class="admin-form">
       <p id="admin-message" class="admin-message" aria-live="polite" hidden></p>
       <form id="admin-activate">
-        <label for="admin-token">Ange din admin-token</label>
-        <input type="text" id="admin-token" name="token" required autocomplete="off" placeholder="namn_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx_0000000000">
+        <label for="admin-token">Ange din token</label>
+        <input type="text" id="admin-token" name="token" required autocomplete="off" placeholder="namn_roll_epoch_signatur">
         <button type="submit" class="btn btn--primary">Aktivera</button>
       </form>
       <button type="button" id="admin-remove" class="btn btn--secondary admin-remove" hidden>Ta bort min token</button>

--- a/source/scripts/create-admin-token.js
+++ b/source/scripts/create-admin-token.js
@@ -79,7 +79,7 @@ async function main() {
   console.log('Inget behöver läggas till i miljövariabler — token valideras mot');
   console.log('ADMIN_TOKEN_SECRET. Ge bara tokenen till rätt person.');
   console.log('');
-  console.log(`Ge tokenen till ${rawName.trim()} — hen aktiverar den på /admin.html`);
+  console.log(`Ge tokenen till ${rawName.trim()} — hen aktiverar den på /token.html`);
   console.log('');
 }
 

--- a/source/scripts/create-admin-token.js
+++ b/source/scripts/create-admin-token.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const crypto = require('crypto');
 const readline = require('readline');
+const { signToken } = require('../api/admin');
+
+// Validity per role, in days (02-§91.30).
+const ROLE_DAYS = { admin: 60, superadmin: 180 };
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -15,24 +18,52 @@ function ask(question) {
 }
 
 async function main() {
+  const secret = process.env.ADMIN_TOKEN_SECRET || '';
+
   console.log('');
   console.log('Skapa admin-token');
   console.log('─────────────────');
   console.log('');
 
+  if (!secret) {
+    console.error('Fel: ADMIN_TOKEN_SECRET är inte satt.');
+    console.error('');
+    console.error('Generera en hemlighet en gång och lägg den i .env (samt på servern');
+    console.error('och i GitHub Environments för QA/Produktion):');
+    console.error('');
+    console.error('  openssl rand -base64 48');
+    console.error('');
+    rl.close();
+    process.exit(1);
+  }
+  if (secret.length < 32) {
+    console.warn('Varning: ADMIN_TOKEN_SECRET är kortare än 32 tecken — använd ett');
+    console.warn('långt slumpmässigt värde för att skydda tokensignaturerna.');
+    console.warn('');
+  }
+
   const rawName = await ask('Namn på admin: ');
-  rl.close();
-
-  const name = rawName.trim().toLowerCase().replace(/\s+/g, '_').replace(/[^a-zåäö0-9_-]/g, '');
-
+  // Hyphen-separated identifier, no underscores (underscore is the token
+  // field delimiter, so the name must never contain one).
+  const name = rawName.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-zåäö0-9-]/g, '');
   if (!name) {
-    console.error('\nFel: namn krävs (a-ö, siffror, understreck).');
+    console.error('\nFel: namn krävs (a-ö, siffror, bindestreck).');
+    rl.close();
     process.exit(1);
   }
 
-  const uuid = crypto.randomUUID();
-  const expirySeconds = Math.floor(Date.now() / 1000) + (60 * 24 * 60 * 60);
-  const token = `${name}_${uuid}_${expirySeconds}`;
+  const rawRole = (await ask('Roll [admin/superadmin] (admin): ')).trim().toLowerCase();
+  rl.close();
+  const role = rawRole || 'admin';
+  if (!Object.prototype.hasOwnProperty.call(ROLE_DAYS, role)) {
+    console.error(`\nFel: okänd roll "${role}". Välj admin eller superadmin.`);
+    console.error('(Rollen "early" delas ut separat; superadmin skapas bara här, aldrig i webb-UI.)');
+    process.exit(1);
+  }
+
+  const days = ROLE_DAYS[role];
+  const expirySeconds = Math.floor(Date.now() / 1000) + (days * 24 * 60 * 60);
+  const token = signToken(name, role, expirySeconds, secret);
   const expiryDate = new Date(expirySeconds * 1000).toISOString().slice(0, 10);
 
   console.log('');
@@ -41,18 +72,12 @@ async function main() {
   console.log(`  Token: ${token}`);
   console.log('');
   console.log('  SPARA DENNA TOKEN NU — den visas inte igen.');
-  console.log(`  Giltig till: ${expiryDate} (60 dagar)`);
+  console.log(`  Roll: ${role} — giltig till ${expiryDate} (${days} dagar)`);
   console.log('');
   console.log('═══════════════════════════════════════════════════');
   console.log('');
-  console.log('Lägg till tokenen i ADMIN_TOKENS på dessa tre ställen:');
-  console.log('');
-  console.log('  1. .env (lokal utveckling)');
-  console.log('  2. api/.env (produktionsservern)');
-  console.log('  3. GitHub → Settings → Environments → qa/production → Secrets');
-  console.log('');
-  console.log('Om ADMIN_TOKENS redan har värden, lägg till med komma:');
-  console.log(`  ADMIN_TOKENS=befintlig-token,${token}`);
+  console.log('Inget behöver läggas till i miljövariabler — token valideras mot');
+  console.log('ADMIN_TOKEN_SECRET. Ge bara tokenen till rätt person.');
   console.log('');
   console.log(`Ge tokenen till ${rawName.trim()} — hen aktiverar den på /admin.html`);
   console.log('');

--- a/tests/admin-edit-delete.test.js
+++ b/tests/admin-edit-delete.test.js
@@ -16,21 +16,22 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { verifyAdminToken } = require('../source/api/admin');
+const { verifyAdminToken, signToken } = require('../source/api/admin');
 const { createOwnershipEntry, parseVerifiedSessionIds } = require('../source/api/session');
 
-// Future epoch so tokens are not rejected by expiry check
+// Future epoch so tokens are not rejected by expiry check.
 const futureEpoch = Math.floor(Date.now() / 1000) + 86400;
-const VALID_TOKEN = `admin_test-uuid_${futureEpoch}`;
-const ADMIN_TOKENS = [VALID_TOKEN];
+const SECRET = 'edit-delete-test-secret-value!!!';
+const VALID_TOKEN = signToken('admin', 'admin', futureEpoch, SECRET);
 const SESSION_SECRET = 'test-session-secret';
 
-// Simulates the OR condition that app.js will use:
-// authorised if event ID has valid signed ownership OR admin token is valid.
-function isAuthorised(cookieHeader, eventId, adminToken, validTokens, sessionSecret = SESSION_SECRET) {
+// Simulates the OR condition app.js uses: authorised if the event ID has valid
+// signed ownership OR the request carries a valid admin token (verified against
+// the signing secret).
+function isAuthorised(cookieHeader, eventId, adminToken, secret, sessionSecret = SESSION_SECRET) {
   const ownedIds = parseVerifiedSessionIds(cookieHeader, sessionSecret);
   if (ownedIds.includes(eventId)) return true;
-  if (adminToken && verifyAdminToken(adminToken, validTokens)) return true;
+  if (adminToken && verifyAdminToken(adminToken, secret)) return true;
   return false;
 }
 
@@ -44,41 +45,41 @@ describe('edit/delete authorisation OR condition (02-§7.3, §18.31, §89.13)', 
   const noCookie = '';
 
   it('ADED-01: authorised when event has signed ownership in session cookie (no admin token)', () => {
-    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, undefined, []), true);
+    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, undefined, ''), true);
   });
 
   it('ADED-01b: rejected when cookie only contains a legacy raw event ID', () => {
-    assert.strictEqual(isAuthorised(cookieWithLegacyId, eventId, undefined, []), false);
+    assert.strictEqual(isAuthorised(cookieWithLegacyId, eventId, undefined, ''), false);
   });
 
   it('ADED-02: authorised when admin token is valid (event ID not in cookie)', () => {
-    assert.strictEqual(isAuthorised(cookieWithoutId, eventId, VALID_TOKEN, ADMIN_TOKENS), true);
+    assert.strictEqual(isAuthorised(cookieWithoutId, eventId, VALID_TOKEN, SECRET), true);
   });
 
   it('ADED-03: authorised when both cookie ownership and admin token are present', () => {
-    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, VALID_TOKEN, ADMIN_TOKENS), true);
+    assert.strictEqual(isAuthorised(cookieWithOwnership, eventId, VALID_TOKEN, SECRET), true);
   });
 
   it('ADED-04: rejected when neither cookie ownership nor admin token', () => {
-    assert.strictEqual(isAuthorised(cookieWithoutId, eventId, undefined, []), false);
+    assert.strictEqual(isAuthorised(cookieWithoutId, eventId, undefined, ''), false);
   });
 
-  it('ADED-05: rejected when admin token is invalid', () => {
-    const badToken = `wrong_token_${futureEpoch}`;
-    assert.strictEqual(isAuthorised(noCookie, eventId, badToken, ADMIN_TOKENS), false);
+  it('ADED-05: rejected when admin token signature is invalid', () => {
+    const badToken = signToken('admin', 'admin', futureEpoch, 'a-different-secret');
+    assert.strictEqual(isAuthorised(noCookie, eventId, badToken, SECRET), false);
   });
 
   it('ADED-06: rejected when admin token is expired', () => {
     const pastEpoch = Math.floor(Date.now() / 1000) - 86400;
-    const expired = `admin_test-uuid_${pastEpoch}`;
-    assert.strictEqual(isAuthorised(noCookie, eventId, expired, [expired]), false);
+    const expired = signToken('admin', 'admin', pastEpoch, SECRET);
+    assert.strictEqual(isAuthorised(noCookie, eventId, expired, SECRET), false);
   });
 
-  it('ADED-07: rejected when ADMIN_TOKENS is empty (§91.3)', () => {
-    assert.strictEqual(isAuthorised(noCookie, eventId, VALID_TOKEN, []), false);
+  it('ADED-07: rejected when the signing secret is unset (§91.3)', () => {
+    assert.strictEqual(isAuthorised(noCookie, eventId, VALID_TOKEN, ''), false);
   });
 
   it('ADED-08: authorised via admin even with no cookie at all', () => {
-    assert.strictEqual(isAuthorised(noCookie, eventId, VALID_TOKEN, ADMIN_TOKENS), true);
+    assert.strictEqual(isAuthorised(noCookie, eventId, VALID_TOKEN, SECRET), true);
   });
 });

--- a/tests/admin-time-gate-bypass.test.js
+++ b/tests/admin-time-gate-bypass.test.js
@@ -23,21 +23,21 @@ const {
   isBeforeEditingPeriod,
   isAfterEditingPeriod,
 } = require('../source/api/time-gate');
-const { verifyAdminToken } = require('../source/api/admin');
+const { verifyAdminToken, signToken } = require('../source/api/admin');
 
 const futureEpoch = Math.floor(Date.now() / 1000) + 86400;
-const VALID_TOKEN = `admin_test-uuid_${futureEpoch}`;
-const ADMIN_TOKENS = [VALID_TOKEN];
+const SECRET = 'time-gate-test-secret-value-!!!!';
+const VALID_TOKEN = signToken('admin', 'admin', futureEpoch, SECRET);
 
 const OPENS = '2026-06-14';
 const END_DATE = '2026-06-27';
 // end_date + 1 = 2026-06-28 = last allowed day
 
-// Mirrors the time-gate admission logic the endpoints will use.
-function isTimeGateAccepted(today, opens, endDate, adminToken, validTokens) {
+// Mirrors the time-gate admission logic the endpoints use.
+function isTimeGateAccepted(today, opens, endDate, adminToken, secret) {
   if (isAfterEditingPeriod(today, endDate)) return false;
   if (!isBeforeEditingPeriod(today, opens)) return true;
-  return !!adminToken && verifyAdminToken(adminToken, validTokens);
+  return !!adminToken && verifyAdminToken(adminToken, secret);
 }
 
 // ── Admin bypasses pre-period lock (02-§26.17) ─────────────────────────────
@@ -45,45 +45,45 @@ function isTimeGateAccepted(today, opens, endDate, adminToken, validTokens) {
 describe('admin bypass — before opens_for_editing (02-§26.17)', () => {
   it('ABYP-01: non-admin rejected before opens_for_editing', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, undefined, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, undefined, SECRET),
       false,
     );
   });
 
   it('ABYP-02: admin accepted before opens_for_editing', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, VALID_TOKEN, SECRET),
       true,
     );
   });
 
   it('ABYP-03: admin accepted well before opens_for_editing', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-01-01', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-01-01', OPENS, END_DATE, VALID_TOKEN, SECRET),
       true,
     );
   });
 
   it('ABYP-04: invalid admin token rejected before opens', () => {
-    const bad = `wrong_token_${futureEpoch}`;
+    const bad = signToken('admin', 'admin', futureEpoch, 'a-different-secret');
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, bad, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, bad, SECRET),
       false,
     );
   });
 
   it('ABYP-05: expired admin token rejected before opens', () => {
     const pastEpoch = Math.floor(Date.now() / 1000) - 86400;
-    const expired = `admin_test-uuid_${pastEpoch}`;
+    const expired = signToken('admin', 'admin', pastEpoch, SECRET);
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, expired, [expired]),
+      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, expired, SECRET),
       false,
     );
   });
 
   it('ABYP-06: admin accepted on day before opens', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-13', OPENS, END_DATE, VALID_TOKEN, SECRET),
       true,
     );
   });
@@ -94,28 +94,28 @@ describe('admin bypass — before opens_for_editing (02-§26.17)', () => {
 describe('admin does NOT bypass post-period lock (02-§26.18)', () => {
   it('ABYP-07: admin rejected on end_date + 2 days', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-29', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-29', OPENS, END_DATE, VALID_TOKEN, SECRET),
       false,
     );
   });
 
   it('ABYP-08: admin rejected long after camp end', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2027-01-01', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2027-01-01', OPENS, END_DATE, VALID_TOKEN, SECRET),
       false,
     );
   });
 
   it('ABYP-09: non-admin also rejected after period', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-29', OPENS, END_DATE, undefined, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-29', OPENS, END_DATE, undefined, SECRET),
       false,
     );
   });
 
   it('ABYP-10: admin accepted on end_date + 1 (last allowed day)', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-28', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-28', OPENS, END_DATE, VALID_TOKEN, SECRET),
       true,
     );
   });
@@ -126,21 +126,21 @@ describe('admin does NOT bypass post-period lock (02-§26.18)', () => {
 describe('admin bypass has no effect inside the open window', () => {
   it('ABYP-11: non-admin accepted inside the window', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-21', OPENS, END_DATE, undefined, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-21', OPENS, END_DATE, undefined, SECRET),
       true,
     );
   });
 
   it('ABYP-12: admin accepted inside the window', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-21', OPENS, END_DATE, VALID_TOKEN, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-21', OPENS, END_DATE, VALID_TOKEN, SECRET),
       true,
     );
   });
 
   it('ABYP-13: non-admin accepted on opens_for_editing date', () => {
     assert.strictEqual(
-      isTimeGateAccepted('2026-06-14', OPENS, END_DATE, undefined, ADMIN_TOKENS),
+      isTimeGateAccepted('2026-06-14', OPENS, END_DATE, undefined, SECRET),
       true,
     );
   });

--- a/tests/admin-token.test.js
+++ b/tests/admin-token.test.js
@@ -193,6 +193,15 @@ describe('client token-expiry parsers read the role-format epoch (02-§91.2)', (
   }
 });
 
+// ── Secret-strength startup warning ─────────────────────────────────────────
+
+describe('startup secret-strength warning (02-§91.32)', () => {
+  it('TOK-22: both runtimes warn when ADMIN_TOKEN_SECRET is shorter than 32', () => {
+    assert.match(read('app.js'), /ADMIN_TOKEN_SECRET is shorter than 32/);
+    assert.match(read('api/index.php'), /ADMIN_TOKEN_SECRET is shorter than 32/);
+  });
+});
+
 // ── render-admin page ───────────────────────────────────────────────────────
 
 const { renderAdminPage } = require('../source/build/render-admin');

--- a/tests/admin-token.test.js
+++ b/tests/admin-token.test.js
@@ -1,80 +1,175 @@
 'use strict';
 
-// Tests for admin token infrastructure — 02-§91.1–91.28.
+// Tests for admin token infrastructure — 02-§91.1–91.32.
 //
 // Testable in Node.js:
-//   - verify-admin module: token validation, constant-time comparison,
-//     disabled when ADMIN_TOKENS is unset (ADM-01..07)
-//   - render-admin.js: page structure, layout, form elements (ADM-08..12)
-//   - layout.js: footer includes admin-icon container (ADM-13..14)
-//   - token-embedded expiry: extractTokenExpiry, isTokenExpired (ADM-25..35)
+//   - admin module: signToken/verifyToken/verifyAdminToken, role gating,
+//     tamper/expiry rejection, embedded-expiry helpers (TOK-01..TOK-20)
+//   - cross-runtime parity: a fixed (secret, claims) → one known token string
+//     that both Node and PHP must reproduce (TOK-01); PHP behaviour is covered
+//     by api/tests/AdminTokenTest.php, which asserts the SAME vector
+//   - render-admin.js: page structure, layout, form elements (ADM-11..17)
 //
 // Browser-only (manual checkpoints documented in traceability):
 //   - 02-§91.11: Calls POST /verify-admin on submit
 //   - 02-§91.12: Valid → store token in localStorage, show success
 //   - 02-§91.13: Invalid → show error, store nothing
-//   - 02-§91.19: Footer shows admin icon when token in localStorage
-//   - 02-§91.20: No token → nothing displayed
-//   - 02-§91.21: Valid token → filled/locked icon
-//   - 02-§91.22: Expired token → open/unlocked icon, links to /admin.html
+//   - 02-§91.19..22: Footer admin-icon states
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
-// ── verify-admin module ─────────────────────────────────────────────────────
+const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
 
-const { verifyAdminToken, parseAdminTokens } = require('../source/api/admin');
+const {
+  signToken,
+  verifyToken,
+  verifyAdminToken,
+  isTokenExpired,
+  extractTokenExpiry,
+} = require('../source/api/admin');
 
-describe('parseAdminTokens (02-§91.1, §91.2)', () => {
-  it('ADM-01: parses comma-separated tokens', () => {
-    const tokens = parseAdminTokens('aaa,bbb,ccc');
-    assert.deepStrictEqual(tokens, ['aaa', 'bbb', 'ccc']);
+// ── Deterministic cross-runtime vector ───────────────────────────────────────
+// Fixed secret + claims → one known token. api/tests/AdminTokenTest.php asserts
+// the identical strings, proving Node and PHP sign byte-for-byte the same.
+const VEC_SECRET = '0123456789abcdef0123456789abcdef';
+const VEC_EPOCH = 2000000000;
+const VEC = {
+  admin: 'erik_admin_2000000000_BxCLVBJtH61eKTpsn8zsTvYzhL83yf-nF-2HwbBIBVI',
+  early: 'anna_early_2000000000_0jz-8E6aG-x-z2jjKaEY2YgV6Me9qFAJyG5s4mLl61w',
+  superadmin: 'sigge_superadmin_2000000000_4oTZ8CsILnVAvDRIqO8ZZj1tuVF52KAxRDKjPs7xyAQ',
+};
+
+const SECRET = 'unit-test-secret-32-bytes-long!!';
+const future = () => Math.floor(Date.now() / 1000) + 86400;
+const past = () => Math.floor(Date.now() / 1000) - 86400;
+
+// ── Signing ──────────────────────────────────────────────────────────────────
+
+describe('signToken (02-§91.2)', () => {
+  it('TOK-01: produces namn_roll_epoch_sig and matches the fixed vector', () => {
+    assert.strictEqual(signToken('erik', 'admin', VEC_EPOCH, VEC_SECRET), VEC.admin);
+    assert.strictEqual(signToken('anna', 'early', VEC_EPOCH, VEC_SECRET), VEC.early);
+    assert.strictEqual(signToken('sigge', 'superadmin', VEC_EPOCH, VEC_SECRET), VEC.superadmin);
   });
 
-  it('ADM-02: returns empty array when input is empty string', () => {
-    assert.deepStrictEqual(parseAdminTokens(''), []);
-  });
-
-  it('ADM-03: returns empty array when input is undefined', () => {
-    assert.deepStrictEqual(parseAdminTokens(undefined), []);
-  });
-
-  it('ADM-04: trims whitespace around tokens', () => {
-    const tokens = parseAdminTokens(' aaa , bbb ');
-    assert.deepStrictEqual(tokens, ['aaa', 'bbb']);
-  });
-
-  it('ADM-05: filters out empty entries from trailing commas', () => {
-    const tokens = parseAdminTokens('aaa,,bbb,');
-    assert.deepStrictEqual(tokens, ['aaa', 'bbb']);
+  it('TOK-02: a different secret yields a different signature', () => {
+    assert.notStrictEqual(signToken('erik', 'admin', VEC_EPOCH, 'a-different-secret'), VEC.admin);
   });
 });
 
-describe('verifyAdminToken (02-§91.3, §91.6, §91.7, §91.8)', () => {
-  // Use future epoch so tokens are not rejected by expiry check
-  const futureEpoch = Math.floor(Date.now() / 1000) + 86400;
+// ── Verification ─────────────────────────────────────────────────────────────
 
-  it('ADM-06: returns true when token matches one in the list', () => {
-    const tok = `my_token_${futureEpoch}`;
-    assert.strictEqual(verifyAdminToken(tok, ['other', tok]), true);
+describe('verifyToken (02-§91.2, §91.29)', () => {
+  it('TOK-03: accepts a freshly signed token and returns its claims', () => {
+    const epoch = future();
+    assert.deepStrictEqual(verifyToken(signToken('erik', 'admin', epoch, SECRET), SECRET),
+      { name: 'erik', role: 'admin', epoch });
   });
 
-  it('ADM-07: returns false when token does not match', () => {
-    const tok = `wrong_${futureEpoch}`;
-    assert.strictEqual(verifyAdminToken(tok, ['aaa', 'bbb']), false);
+  it('TOK-04: validates the fixed vector', () => {
+    assert.strictEqual(verifyToken(VEC.admin, VEC_SECRET).role, 'admin');
+    assert.strictEqual(verifyToken(VEC.early, VEC_SECRET).role, 'early');
   });
 
-  it('ADM-08: returns false when token list is empty (§91.3)', () => {
-    const tok = `anything_${futureEpoch}`;
-    assert.strictEqual(verifyAdminToken(tok, []), false);
+  it('TOK-05: rejects a token signed with a different secret', () => {
+    assert.strictEqual(verifyToken(signToken('erik', 'admin', future(), 'a-secret'), SECRET), null);
   });
 
-  it('ADM-09: returns false when token is empty string', () => {
-    assert.strictEqual(verifyAdminToken('', ['aaa']), false);
+  it('TOK-06: rejects a tampered role (signature no longer matches)', () => {
+    const tok = signToken('erik', 'early', future(), SECRET);
+    assert.strictEqual(verifyToken(tok.replace('_early_', '_admin_'), SECRET), null);
   });
 
-  it('ADM-10: returns false when token is undefined', () => {
-    assert.strictEqual(verifyAdminToken(undefined, ['aaa']), false);
+  it('TOK-07: rejects a tampered epoch', () => {
+    const epoch = future();
+    const tok = signToken('erik', 'admin', epoch, SECRET);
+    assert.strictEqual(verifyToken(tok.replace(`_${epoch}_`, `_${epoch + 1}_`), SECRET), null);
+  });
+
+  it('TOK-08: rejects an unknown role even with a valid signature', () => {
+    // signToken will happily sign any role; verifyToken must reject unknown ones.
+    assert.strictEqual(verifyToken(signToken('erik', 'root', future(), SECRET), SECRET), null);
+  });
+
+  it('TOK-09: rejects an expired token', () => {
+    assert.strictEqual(verifyToken(signToken('erik', 'admin', past(), SECRET), SECRET), null);
+  });
+
+  it('TOK-10: returns null when the secret is empty (admin disabled)', () => {
+    assert.strictEqual(verifyToken(VEC.admin, ''), null);
+  });
+
+  it('TOK-11: returns null for malformed tokens', () => {
+    for (const bad of ['', null, undefined, 'noseparators', 'a_b_c', 'a_b_notnum_sig']) {
+      assert.strictEqual(verifyToken(bad, SECRET), null);
+    }
+  });
+
+  it('TOK-12: round-trips names whose signatures contain "_" and "-" (base64url)', () => {
+    for (let i = 0; i < 50; i++) {
+      const epoch = future();
+      assert.deepStrictEqual(verifyToken(signToken(`user${i}`, 'admin', epoch, SECRET), SECRET),
+        { name: `user${i}`, role: 'admin', epoch });
+    }
+  });
+});
+
+// ── Admin role gating ────────────────────────────────────────────────────────
+
+describe('verifyAdminToken (02-§91.31)', () => {
+  it('TOK-13: true for admin and superadmin', () => {
+    assert.strictEqual(verifyAdminToken(signToken('a', 'admin', future(), SECRET), SECRET), true);
+    assert.strictEqual(verifyAdminToken(signToken('s', 'superadmin', future(), SECRET), SECRET), true);
+  });
+
+  it('TOK-14: false for early (recognised role, but not admin-equivalent)', () => {
+    assert.strictEqual(verifyAdminToken(signToken('e', 'early', future(), SECRET), SECRET), false);
+  });
+
+  it('TOK-15: false for wrong secret / empty token', () => {
+    assert.strictEqual(verifyAdminToken(VEC.admin, 'wrong-secret'), false);
+    assert.strictEqual(verifyAdminToken('', SECRET), false);
+  });
+});
+
+// ── Embedded-expiry helpers ──────────────────────────────────────────────────
+
+describe('embedded expiry helpers (02-§91.29)', () => {
+  it('TOK-16: extractTokenExpiry reads the epoch segment of the new format', () => {
+    assert.strictEqual(extractTokenExpiry(VEC.admin), VEC_EPOCH);
+  });
+
+  it('TOK-17: extractTokenExpiry returns 0 for malformed tokens', () => {
+    assert.strictEqual(extractTokenExpiry('a_b_c'), 0);
+    assert.strictEqual(extractTokenExpiry(''), 0);
+  });
+
+  it('TOK-18: isTokenExpired true for past epoch, false for future', () => {
+    assert.strictEqual(isTokenExpired(signToken('e', 'admin', past(), SECRET)), true);
+    assert.strictEqual(isTokenExpired(signToken('e', 'admin', future(), SECRET)), false);
+  });
+
+  it('TOK-19: isTokenExpired true (fail-closed) for malformed tokens', () => {
+    assert.strictEqual(isTokenExpired('a_b_c'), true);
+    assert.strictEqual(isTokenExpired(''), true);
+  });
+});
+
+// ── PHP parity (structural; behavioural vector parity in AdminTokenTest.php) ──
+
+describe('PHP token parity (structural) (02-§91.8)', () => {
+  const php = read('api/src/Admin.php');
+
+  it('TOK-20: Admin.php exposes the same helpers and primitives', () => {
+    assert.match(php, /function\s+signToken\b/);
+    assert.match(php, /function\s+verifyToken\b/);
+    assert.match(php, /function\s+verifyAdminToken\b/);
+    assert.match(php, /hash_hmac\('sha256'/);
+    assert.match(php, /strtr\(base64_encode/);
+    assert.match(php, /hash_equals\(self::tokenDigest/);
   });
 });
 
@@ -117,7 +212,6 @@ describe('renderAdminPage (02-§91.9, §91.10, §91.14, §91.15)', () => {
 
   it('ADM-15: page is not listed in navigation links', () => {
     const html = renderAdminPage(CAMP, FOOTER_HTML);
-    // The nav links should not contain admin.html
     const navMatch = html.match(/<nav[^>]*>[\s\S]*?<\/nav>/);
     assert.ok(navMatch, 'Expected nav element');
     assert.ok(!navMatch[0].includes('admin.html'), 'admin.html must not be in nav');
@@ -135,66 +229,5 @@ describe('renderAdminPage (02-§91.9, §91.10, §91.14, §91.15)', () => {
 });
 
 // ── Footer admin-icon container ─────────────────────────────────────────────
-// ADM-18: admin-status is now injected by build.js inside the version
-// paragraph, not by pageFooter. Verified by snapshot tests.
-
-// ── Token-embedded expiry ───────────────────────────────────────────────────
-
-const { isTokenExpired, extractTokenExpiry } = require('../source/api/admin');
-
-describe('extractTokenExpiry', () => {
-  it('ADM-25: extracts epoch from valid token format', () => {
-    assert.strictEqual(extractTokenExpiry('erik_abc123_1752710400'), 1752710400);
-  });
-
-  it('ADM-26: returns 0 for token without epoch suffix', () => {
-    assert.strictEqual(extractTokenExpiry('erik_abc123'), 0);
-  });
-
-  it('ADM-27: returns 0 for empty string', () => {
-    assert.strictEqual(extractTokenExpiry(''), 0);
-  });
-
-  it('ADM-28: returns 0 for undefined', () => {
-    assert.strictEqual(extractTokenExpiry(undefined), 0);
-  });
-
-  it('ADM-29: returns 0 when last segment is not a number', () => {
-    assert.strictEqual(extractTokenExpiry('erik_abc123_notanumber'), 0);
-  });
-});
-
-describe('isTokenExpired', () => {
-  it('ADM-30: returns false for token with future epoch', () => {
-    const future = Math.floor(Date.now() / 1000) + 86400;
-    assert.strictEqual(isTokenExpired(`test_uuid_${future}`), false);
-  });
-
-  it('ADM-31: returns true for token with past epoch', () => {
-    const past = Math.floor(Date.now() / 1000) - 86400;
-    assert.strictEqual(isTokenExpired(`test_uuid_${past}`), true);
-  });
-
-  it('ADM-32: returns true for token without epoch', () => {
-    assert.strictEqual(isTokenExpired('test_uuid'), true);
-  });
-
-  it('ADM-33: returns true for undefined', () => {
-    assert.strictEqual(isTokenExpired(undefined), true);
-  });
-});
-
-describe('verifyAdminToken with embedded expiry', () => {
-  it('ADM-34: rejects expired token even if it matches list', () => {
-    const past = Math.floor(Date.now() / 1000) - 86400;
-    const token = `test_uuid_${past}`;
-    assert.strictEqual(verifyAdminToken(token, [token]), false);
-  });
-
-  it('ADM-35: accepts valid non-expired token', () => {
-    const future = Math.floor(Date.now() / 1000) + 86400;
-    const token = `test_uuid_${future}`;
-    assert.strictEqual(verifyAdminToken(token, [token]), true);
-  });
-});
-
+// ADM-18: admin-status is injected by build.js inside the version paragraph,
+// not by pageFooter. Verified by snapshot tests.

--- a/tests/admin-token.test.js
+++ b/tests/admin-token.test.js
@@ -173,6 +173,26 @@ describe('PHP token parity (structural) (02-§91.8)', () => {
   });
 });
 
+// ── Client parsers read the role-format epoch (regression for the browser-only
+//    bug where the epoch was read from the last segment = the signature) ──────
+
+describe('client token-expiry parsers read the role-format epoch (02-§91.2)', () => {
+  const clientFiles = [
+    'source/assets/js/client/admin.js',
+    'source/assets/js/client/session.js',
+    'source/assets/js/client/redigera.js',
+    'source/assets/js/client/lagg-till.js',
+  ];
+  for (const rel of clientFiles) {
+    it(`TOK-21: ${rel} reads epoch by segment, not the last underscore`, () => {
+      const src = read(rel);
+      assert.match(src, /split\('_'\)/, 'should split the token into fields');
+      assert.match(src, /parts\[2\]/, 'epoch is the third segment');
+      assert.doesNotMatch(src, /lastIndexOf\('_'\)/, 'last segment is the signature, not the epoch');
+    });
+  }
+});
+
 // ── render-admin page ───────────────────────────────────────────────────────
 
 const { renderAdminPage } = require('../source/build/render-admin');
@@ -214,7 +234,7 @@ describe('renderAdminPage (02-§91.9, §91.10, §91.14, §91.15)', () => {
     const html = renderAdminPage(CAMP, FOOTER_HTML);
     const navMatch = html.match(/<nav[^>]*>[\s\S]*?<\/nav>/);
     assert.ok(navMatch, 'Expected nav element');
-    assert.ok(!navMatch[0].includes('admin.html'), 'admin.html must not be in nav');
+    assert.ok(!navMatch[0].includes('token.html'), 'token.html must not be in nav');
   });
 
   it('ADM-16: user-facing text is in Swedish (§91.25)', () => {

--- a/tests/php-session-ownership.test.js
+++ b/tests/php-session-ownership.test.js
@@ -32,7 +32,7 @@ describe('PHP signed session ownership parity (02-§44.15, §44.17, §101)', () 
     const src = read('api/index.php');
     assert.match(src, /\$_ENV\['SESSION_SECRET'\]/);
     assert.match(src, /Session::createOwnershipEntry/);
-    assert.match(src, /handleAddEvent\(\$activeCamp,\s*\$adminTokens,\s*\$sessionSecret\)/);
+    assert.match(src, /handleAddEvent\(\$activeCamp,\s*\$adminTokenSecret,\s*\$sessionSecret\)/);
     assert.match(src, /function\s+handleAddEvent\([^)]*string\s+\$sessionSecret/);
   });
 });

--- a/tests/security-hardening.test.js
+++ b/tests/security-hardening.test.js
@@ -123,23 +123,21 @@ describe('#385 — link protocol validation', () => {
 
 // ── #386 Constant-time admin-token comparison ────────────────────────────────
 
-const { verifyAdminToken } = require('../source/api/admin');
+const { verifyAdminToken, signToken } = require('../source/api/admin');
 
-describe('#386 — admin token comparison has no length pre-check', () => {
+describe('#386 — admin token comparison is constant-time', () => {
+  const SECRET = 'hardening-test-secret-value-xyz!';
   const future = Math.floor(Date.now() / 1000) + 86400;
 
-  it('SEC-386-01: accepts a matching token regardless of other tokens length', () => {
-    const tok = `admin_${'a'.repeat(20)}_${future}`;
-    assert.strictEqual(verifyAdminToken(tok, ['short', tok, 'another_longer_token_value']), true);
+  it('SEC-386-01: accepts a validly signed admin token', () => {
+    assert.strictEqual(verifyAdminToken(signToken('admin', 'admin', future, SECRET), SECRET), true);
   });
 
-  it('SEC-386-02: rejects a non-matching token of equal length', () => {
-    const a = `aaaaa_${future}`;
-    const b = `bbbbb_${future}`;
-    assert.strictEqual(verifyAdminToken(a, [b]), false);
+  it('SEC-386-02: rejects a token signed with a different secret', () => {
+    assert.strictEqual(verifyAdminToken(signToken('admin', 'admin', future, 'other-secret'), SECRET), false);
   });
 
-  it('SEC-386-03: source has no length equality short-circuit', () => {
+  it('SEC-386-03: source compares fixed-width digests, no length short-circuit', () => {
     const src = read('source/api/admin.js');
     assert.doesNotMatch(src, /candidate\.length === valid\.length/);
     assert.match(src, /timingSafeEqual/);


### PR DESCRIPTION
## Summary

Replaces the `ADMIN_TOKENS` allowlist with a single signing secret
(`ADMIN_TOKEN_SECRET`). Tokens are self-validating — `namn_roll_epoch_sig`,
where `sig` is the base64url HMAC-SHA256 of `namn_roll_epoch`. Adding or
retiring a person no longer needs an env edit or redeploy, and there is no
runtime-writable credential store (preserves "no database / no hidden state").

- **Roles**: `admin` and `superadmin` (administrator-equivalent), plus `early`
  (recognised; its narrower behaviour lands with #380 in WP2). `superadmin` is
  minted only by the CLI, never from the web UI.
- **Both runtimes**: `signToken` / `verifyToken` / `verifyAdminToken` in
  `source/api/admin.js` and `api/src/Admin.php`, byte-identical, with the
  constant-time digest comparison retained from #386.
- **CLI**: `npm run admin:create` signs offline against the secret (admin 60 d /
  superadmin 180 d); names are sanitised without underscores.
- **Activation page** renamed `admin.html` → `token.html`, de-"admin" wording,
  role-neutral intro, activation time shown.
- **Secret strength**: both runtimes warn when `ADMIN_TOKEN_SECRET` < 32 bytes.

This is **WP1** (foundation). WP2 adds the `early` role behaviour (closes #380);
WP3 adds the self-service mint UI.

## Cross-runtime parity

A fixed (secret, claims) vector produces one known token string that **both**
Node and PHP must reproduce (`TOK-01` / `AdminTokenTest::testSignTokenMatchesNodeVector`)
— proving a token minted by one validates in the other.

## Test plan

- [x] `npm run lint` (eslint) clean
- [x] `npm run lint:md` clean
- [x] `npm test` — 1841 Node tests pass
- [x] `cd api && composer test` — 59 PHP tests pass
- [x] Local browser: activate at `/token.html`, footer shows **Token aktiv**,
      edit links appear; `/verify-admin` returns 200 (valid admin) and 403
      (tampered / early-role / garbage)

Part of #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)