### PR TITLE
feat: tidig åtkomst-roll (early access) för pre-läger-schemaläggning

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -232,14 +232,15 @@ function handleAddEvent(?array $activeCamp, string $adminTokenSecret, string $se
 
     $body = getJsonBody();
 
-    // Time-gating with admin bypass (02-§26.17, 02-§26.18)
+    // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+    // 02-§26.18, 02-§105.1, 02-§105.3)
     if ($activeCamp !== null) {
         $today   = date('Y-m-d');
         $opens   = (string) ($activeCamp['opens_for_editing'] ?? '');
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
             || (TimeGate::isBeforeEditingPeriod($today, $opens)
-                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret))
+                && !Admin::verifyPreCampBypassToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -319,14 +320,15 @@ function handleAddEvents(?array $activeCamp, string $adminTokenSecret, string $s
 
     $body = getJsonBody();
 
-    // Time-gating with admin bypass (02-§26.17, 02-§26.18)
+    // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+    // 02-§26.18, 02-§105.1, 02-§105.3)
     if ($activeCamp !== null) {
         $today   = date('Y-m-d');
         $opens   = (string) ($activeCamp['opens_for_editing'] ?? '');
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
             || (TimeGate::isBeforeEditingPeriod($today, $opens)
-                && !Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret))
+                && !Admin::verifyPreCampBypassToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -403,13 +405,15 @@ function handleEditEvent(?array $activeCamp, string $adminTokenSecret, string $s
     $body    = getJsonBody();
     $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret);
 
-    // Time-gating with admin bypass (02-§26.17, 02-§26.18)
+    // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+    // 02-§26.18, 02-§105.1, 02-§105.3)
     if ($activeCamp !== null) {
         $today   = date('Y-m-d');
         $opens   = (string) ($activeCamp['opens_for_editing'] ?? '');
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
-            || (TimeGate::isBeforeEditingPeriod($today, $opens) && !$isAdmin)
+            || (TimeGate::isBeforeEditingPeriod($today, $opens)
+                && !Admin::verifyPreCampBypassToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -429,8 +433,8 @@ function handleEditEvent(?array $activeCamp, string $adminTokenSecret, string $s
 
     $eventId = trim((string) ($body['id'] ?? ''));
 
-    // Verify ownership: signed session ownership OR valid admin token
-    // (02-§7.3, §18.31).
+    // Verify ownership: signed session ownership OR an admin-role token —
+    // the early role does not bypass ownership (02-§7.3, §18.31, 02-§105.2).
     $ownedIds = Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret);
     if (!in_array($eventId, $ownedIds, true) && !$isAdmin) {
         jsonResponse([
@@ -484,13 +488,15 @@ function handleDeleteEvent(?array $activeCamp, string $adminTokenSecret, string 
     $body    = getJsonBody();
     $isAdmin = Admin::verifyAdminToken($body['adminToken'] ?? null, $adminTokenSecret);
 
-    // Time-gating with admin bypass (02-§26.17, 02-§26.18)
+    // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+    // 02-§26.18, 02-§105.1, 02-§105.3)
     if ($activeCamp !== null) {
         $today   = date('Y-m-d');
         $opens   = (string) ($activeCamp['opens_for_editing'] ?? '');
         $endDate = (string) ($activeCamp['end_date'] ?? '');
         if (TimeGate::isAfterEditingPeriod($today, $endDate)
-            || (TimeGate::isBeforeEditingPeriod($today, $opens) && !$isAdmin)
+            || (TimeGate::isBeforeEditingPeriod($today, $opens)
+                && !Admin::verifyPreCampBypassToken($body['adminToken'] ?? null, $adminTokenSecret))
         ) {
             jsonResponse([
                 'success' => false,
@@ -508,8 +514,8 @@ function handleDeleteEvent(?array $activeCamp, string $adminTokenSecret, string 
         return;
     }
 
-    // Verify ownership: signed session ownership OR valid admin token
-    // (02-§7.3, §89.13).
+    // Verify ownership: signed session ownership OR an admin-role token —
+    // the early role does not bypass ownership (02-§7.3, §89.13, 02-§105.2).
     $ownedIds = Session::parseVerifiedSessionIds($_SERVER['HTTP_COOKIE'] ?? '', $sessionSecret);
     if (!in_array($eventId, $ownedIds, true) && !$isAdmin) {
         jsonResponse([
@@ -600,7 +606,10 @@ function handleVerifyAdmin(string $adminTokenSecret): void
     $body  = getJsonBody();
     $token = trim((string) ($body['token'] ?? ''));
 
-    if (Admin::verifyAdminToken($token, $adminTokenSecret)) {
+    // Any recognised role validates here — including early — so every token
+    // kind activates through the same /token.html flow (02-§91.6, 02-§105.4).
+    // Each privileged action applies its own role check.
+    if (Admin::verifyToken($token, $adminTokenSecret) !== null) {
         jsonResponse(['valid' => true]);
     } else {
         jsonResponse(['valid' => false], 403);

--- a/api/src/Admin.php
+++ b/api/src/Admin.php
@@ -22,6 +22,9 @@ final class Admin
     /** @var list<string> */
     private const ADMIN_ROLES = ['admin', 'superadmin'];
 
+    /** @var list<string> */
+    private const PRE_CAMP_BYPASS_ROLES = ['admin', 'early', 'superadmin'];
+
     /**
      * Per-process random key used only to equalise lengths before comparison,
      * so the comparison leaks neither validity nor value length via timing
@@ -142,5 +145,19 @@ final class Admin
         $token = self::verifyToken($candidate, $secret);
 
         return $token !== null && in_array($token['role'], self::ADMIN_ROLES, true);
+    }
+
+    /**
+     * True for roles allowed to bypass the pre-camp time gate: administrators
+     * plus early-access contributors (02-§105.1). Unlike verifyAdminToken,
+     * passing this check grants no ownership bypass — an early holder still
+     * only edits and deletes their own cookie-owned events (02-§105.2,
+     * §105.5).
+     */
+    public static function verifyPreCampBypassToken(?string $candidate, string $secret): bool
+    {
+        $token = self::verifyToken($candidate, $secret);
+
+        return $token !== null && in_array($token['role'], self::PRE_CAMP_BYPASS_ROLES, true);
     }
 }

--- a/api/tests/AdminTokenTest.php
+++ b/api/tests/AdminTokenTest.php
@@ -106,4 +106,22 @@ final class AdminTokenTest extends TestCase
         self::assertFalse(Admin::isTokenExpired(Admin::signToken('e', 'admin', self::future(), self::SECRET)));
         self::assertTrue(Admin::isTokenExpired('a_b_c'));
     }
+
+    public function testVerifyPreCampBypassTokenAcceptsAllRoles(): void
+    {
+        // 02-§105.1, §105.5 — early bypasses the pre-camp gate like admins.
+        self::assertTrue(Admin::verifyPreCampBypassToken(Admin::signToken('a', 'admin', self::future(), self::SECRET), self::SECRET));
+        self::assertTrue(Admin::verifyPreCampBypassToken(Admin::signToken('e', 'early', self::future(), self::SECRET), self::SECRET));
+        self::assertTrue(Admin::verifyPreCampBypassToken(Admin::signToken('s', 'superadmin', self::future(), self::SECRET), self::SECRET));
+        self::assertTrue(Admin::verifyPreCampBypassToken(self::VEC_EARLY, self::VEC_SECRET));
+    }
+
+    public function testVerifyPreCampBypassTokenRejectsInvalid(): void
+    {
+        self::assertFalse(Admin::verifyPreCampBypassToken(Admin::signToken('x', 'root', self::future(), self::SECRET), self::SECRET));
+        self::assertFalse(Admin::verifyPreCampBypassToken(Admin::signToken('e', 'early', time() - 10, self::SECRET), self::SECRET));
+        self::assertFalse(Admin::verifyPreCampBypassToken(Admin::signToken('e', 'early', self::future(), 'other'), self::SECRET));
+        self::assertFalse(Admin::verifyPreCampBypassToken(self::VEC_EARLY, ''));
+        self::assertFalse(Admin::verifyPreCampBypassToken(null, self::SECRET));
+    }
 }

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const {
 } = require('./source/api/session');
 const { isBeforeEditingPeriod, isAfterEditingPeriod }            = require('./source/api/time-gate');
 const { validateFeedbackRequest, createFeedbackIssue }           = require('./source/api/feedback');
-const { verifyAdminToken }                                       = require('./source/api/admin');
+const { verifyToken, verifyAdminToken, verifyPreCampBypassToken } = require('./source/api/admin');
 const { resolveActiveCamp }                                      = require('./source/scripts/resolve-active-camp');
 
 const app = express();
@@ -104,21 +104,25 @@ app.get('/api/health', (req, res) => {
 
 app.post('/verify-admin', verifyAdminLimiter, (req, res) => {
   const { token } = req.body || {};
-  if (verifyAdminToken(token, adminTokenSecret)) {
+  // Any recognised role validates here — including early — so every token
+  // kind activates through the same /token.html flow (02-§91.6, 02-§105.4).
+  // Each privileged action applies its own role check.
+  if (verifyToken(token, adminTokenSecret)) {
     return res.json({ valid: true });
   }
   return res.status(403).json({ valid: false });
 });
 
 app.post('/add-event', addEventLimiter, (req, res) => {
-  // Time-gating with admin bypass (02-§26.17, 02-§26.18).
+  // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+  // 02-§26.18, 02-§105.1, 02-§105.3).
   if (activeCamp) {
     const today = new Date().toISOString().slice(0, 10);
     if (isAfterEditingPeriod(today, activeCamp.end_date)) {
       return res.status(403).json({ success: false, error: 'Det går inte att lägga till aktiviteter just nu. Formuläret är inte öppet.' });
     }
     if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing)
-        && !verifyAdminToken(req.body.adminToken, adminTokenSecret)) {
+        && !verifyPreCampBypassToken(req.body.adminToken, adminTokenSecret)) {
       return res.status(403).json({ success: false, error: 'Det går inte att lägga till aktiviteter just nu. Formuläret är inte öppet.' });
     }
   }
@@ -161,13 +165,15 @@ app.post('/add-event', addEventLimiter, (req, res) => {
 app.post('/edit-event', editEventLimiter, (req, res) => {
   const isAdmin = verifyAdminToken(req.body.adminToken, adminTokenSecret);
 
-  // Time-gating with admin bypass (02-§26.17, 02-§26.18).
+  // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+  // 02-§26.18, 02-§105.1, 02-§105.3).
   if (activeCamp) {
     const today = new Date().toISOString().slice(0, 10);
     if (isAfterEditingPeriod(today, activeCamp.end_date)) {
       return res.status(403).json({ success: false, error: 'Det går inte att redigera aktiviteter just nu. Formuläret är inte öppet.' });
     }
-    if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing) && !isAdmin) {
+    if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing)
+        && !verifyPreCampBypassToken(req.body.adminToken, adminTokenSecret)) {
       return res.status(403).json({ success: false, error: 'Det går inte att redigera aktiviteter just nu. Formuläret är inte öppet.' });
     }
   }
@@ -179,8 +185,9 @@ app.post('/edit-event', editEventLimiter, (req, res) => {
 
   const eventId = String(req.body.id).trim();
 
-  // Verify ownership: event ID must have signed session ownership OR
-  // the request must carry a valid admin token (02-§7.3, §18.31).
+  // Verify ownership: event ID must have signed session ownership OR the
+  // request must carry an admin-role token — the early role does not bypass
+  // ownership (02-§7.3, §18.31, 02-§105.2).
   const ownedIds = parseVerifiedSessionIds(req.headers.cookie || '', sessionSecret);
   if (!ownedIds.includes(eventId) && !isAdmin) {
     return res.status(403).json({ success: false, error: 'Ej behörig att redigera denna aktivitet.' });
@@ -201,13 +208,15 @@ app.post('/edit-event', editEventLimiter, (req, res) => {
 app.post('/delete-event', deleteEventLimiter, (req, res) => {
   const isAdmin = verifyAdminToken(req.body.adminToken, adminTokenSecret);
 
-  // Time-gating with admin bypass (02-§26.17, 02-§26.18).
+  // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
+  // 02-§26.18, 02-§105.1, 02-§105.3).
   if (activeCamp) {
     const today = new Date().toISOString().slice(0, 10);
     if (isAfterEditingPeriod(today, activeCamp.end_date)) {
       return res.status(400).json({ success: false, error: 'Det går inte att radera aktiviteter just nu. Formuläret är inte öppet.' });
     }
-    if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing) && !isAdmin) {
+    if (isBeforeEditingPeriod(today, activeCamp.opens_for_editing)
+        && !verifyPreCampBypassToken(req.body.adminToken, adminTokenSecret)) {
       return res.status(400).json({ success: false, error: 'Det går inte att radera aktiviteter just nu. Formuläret är inte öppet.' });
     }
   }
@@ -217,8 +226,9 @@ app.post('/delete-event', deleteEventLimiter, (req, res) => {
     return res.status(400).json({ success: false, error: 'Aktivitets-ID saknas.' });
   }
 
-  // Verify ownership: event ID must have signed session ownership OR
-  // the request must carry a valid admin token (02-§7.3, §89.13).
+  // Verify ownership: event ID must have signed session ownership OR the
+  // request must carry an admin-role token — the early role does not bypass
+  // ownership (02-§7.3, §89.13, 02-§105.2).
   const ownedIds = parseVerifiedSessionIds(req.headers.cookie || '', sessionSecret);
   if (!ownedIds.includes(eventId) && !isAdmin) {
     return res.status(403).json({ success: false, error: 'Ej behörig att radera denna aktivitet.' });

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -24,7 +24,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
-| [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104 |
+| [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105 |
 | [`design-and-content.md`](./design-and-content.md) | Design and Content | §30, §31, §47, §55, §64, §94, §98 |
 | [`archive.md`](./archive.md) | Archived Requirements | (superseded sections) |
 

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -595,15 +595,15 @@ reuses the format, signing, and activation flow described here.
 - The roles `admin` and `superadmin` grant administrator privileges: they
   bypass per-event cookie ownership and pre-camp time-gating. `superadmin`
   additionally authorises minting new tokens. The role `early` is a
-  recognised role reserved for early-access contributors; its narrower
-  privileges are defined in their own requirement section. <!-- 02-§91.31 -->
+  recognised role for early-access contributors; its narrower privileges
+  are defined in §105. <!-- 02-§91.31 -->
 - `ADMIN_TOKEN_SECRET` is a high-entropy random value of at least 32 bytes.
   Both runtimes log a warning at startup when it is shorter. <!-- 02-§91.32 -->
 - The creation script `npm run admin:create` signs a token offline against
   `ADMIN_TOKEN_SECRET` for the chosen role — 60 days validity for `admin`,
-  180 days for `superadmin` — and prints the token to hand over. The
-  `superadmin` role is minted only by this script, never from the web
-  UI. <!-- 02-§91.30 -->
+  90 days for `early`, 180 days for `superadmin` — and prints the token to
+  hand over. The `superadmin` role is minted only by this script, never
+  from the web UI. <!-- 02-§91.30 -->
 - When `ADMIN_TOKEN_SECRET` is unset or empty, all admin functionality is
   disabled — no token validates and the site behaves as if no one is an
   administrator. <!-- 02-§91.3 -->
@@ -1283,3 +1283,70 @@ calls without weakening the rest.
   and `preload` are intentionally omitted until every `*.sbsommar.se` subdomain
   is confirmed HTTPS-only, because the directive is hard to reverse within the
   `max-age` window. <!-- 02-§104.19 -->
+
+---
+
+---
+
+## 105. Early Access Role (tidig åtkomst)
+
+### 105.1 Context
+
+Organisers want a skeleton schedule in place before the form opens for
+participants. The `admin` role can already do this, but it also grants the
+power to edit and delete every participant's activity — more than the need
+requires. The `early` role is a narrower credential: its holder works under
+the same rules as a regular participant, with one difference — the pre-camp
+time gate can be bypassed. The role reuses the token format, signing,
+activation page, and footer indicator defined in §91. Agreed in #380.
+
+### 105.2 Server authorisation (API requirements)
+
+- A request to add, edit, or delete an activity made before the active
+  camp's `opens_for_editing` date is admitted by the time gate when it
+  carries a valid token whose role is `admin`, `superadmin`, or
+  `early`. <!-- 02-§105.1 -->
+- Edit and delete authorisation for an `early` token holder is decided
+  solely by the session-cookie ownership model. The ownership bypass that
+  lets administrators act on any activity applies only to the roles
+  `admin` and `superadmin` — an `early` token holder edits and deletes
+  only activities owned by their browser's session cookie. <!-- 02-§105.2 -->
+- The post-camp lock applies to every role: when today is after
+  `end_date + 1 day` (§26), no token — `admin`, `superadmin`, or `early` —
+  admits add, edit, or delete requests. <!-- 02-§105.3 -->
+- `POST /verify-admin` answers `200 { "valid": true }` for a valid token of
+  any recognised role, including `early`, so an early-access token is
+  activated on `/token.html` exactly like an admin token. <!-- 02-§105.4 -->
+- Both runtimes (Node and PHP) expose two distinct role checks: the boolean
+  `verifyAdminToken` is true only for `admin` and `superadmin`, and a
+  separate pre-camp-bypass check is true for `admin`, `superadmin`, and
+  `early`. The time gate uses the pre-camp-bypass check; ownership uses
+  `verifyAdminToken`. <!-- 02-§105.5 -->
+
+### 105.3 Issuing (site requirements)
+
+- `npm run admin:create` mints `early` tokens with 90 days
+  validity. <!-- 02-§105.6 -->
+
+### 105.4 Client behaviour (user requirements)
+
+- Edit links on all schedule events are injected only when the stored
+  token's role is `admin` or `superadmin`. A stored `early` token injects
+  no all-event edit links; the holder's own activities receive edit links
+  through the session cookie, as for any participant. <!-- 02-§105.7 -->
+- Before `opens_for_editing`, the add form and the edit page show the
+  "open anyway" bypass button for a valid stored token of role `admin`,
+  `superadmin`, or `early`. The button label is "Öppna ändå (admin)" for
+  administrator roles and "Öppna ändå (tidig åtkomst)" for
+  `early`. <!-- 02-§105.8 -->
+- On the edit page, the client-side shortcut that skips the ownership
+  check applies only to the roles `admin` and `superadmin`. A visitor
+  whose stored token role is `early` passes the ownership check only for
+  activities in their session cookie. <!-- 02-§105.9 -->
+
+### 105.5 Constraints
+
+- All user-facing text is in Swedish. <!-- 02-§105.10 -->
+- The role is read from the token's second underscore-separated segment;
+  the client never needs to verify the signature — the server remains the
+  authority on every privileged action. <!-- 02-§105.11 -->

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -181,6 +181,37 @@ privileges. When the secret is unset or empty, no token validates and admin
 functionality is disabled. The runtimes log a warning when the secret is
 shorter than 32 bytes (same posture as `SESSION_SECRET`).
 
+### Role checks
+
+Two distinct role checks exist in both runtimes (02-§105.5), because the
+two privileges they guard have different blast radii:
+
+- `verifyAdminToken(candidate, secret)` — true only for `admin` and
+  `superadmin`. Used by the ownership OR-condition in `/edit-event` and
+  `/delete-event` (acting on **other people's** events).
+- `verifyPreCampBypassToken(candidate, secret)` — true for `admin`,
+  `superadmin`, and `early`. Used only by the pre-camp time gate in
+  `/add-event`, `/add-events`, `/edit-event`, and `/delete-event`
+  (acting **before `opens_for_editing`**).
+
+The post-camp lock (`isAfterEditingPeriod`, today > `end_date + 1`) is
+checked before either helper and no role bypasses it (02-§105.3).
+
+### Early access role (tidig åtkomst)
+
+The `early` role (02-§105) lets trusted organisers build a skeleton
+schedule before the form opens, without granting admin power over other
+people's events. An `early` token holder behaves exactly like a regular
+participant — cookie-based ownership of their own events — except that
+`verifyPreCampBypassToken` admits their add/edit/delete requests before
+`opens_for_editing`. Client-side, the stored token's role (second
+underscore-segment) decides what UI appears: the all-event edit links in
+`session.js` and the ownership shortcut in `redigera.js` require an
+admin-equivalent role, while the pre-camp "Öppna ändå" bypass button in
+`lagg-till.js` and `redigera.js` appears for any valid stored token,
+labelled "(admin)" or "(tidig åtkomst)" by role. The client role check is
+cosmetic — the server re-verifies the signature and role on every request.
+
 ### Verification endpoint
 
 `POST /verify-admin` accepts `{ "token": "<string>" }` and responds:
@@ -188,18 +219,22 @@ shorter than 32 bytes (same posture as `SESSION_SECRET`).
 - `200 { "valid": true }` — valid signature, recognised role, unexpired epoch
 - `403 { "valid": false }` — otherwise
 
-The supplied and recomputed signatures are compared in constant time over
-fixed-width digests (`tokenDigest()`, an HMAC keyed by a per-process random
-key, retained from #386), so neither validity nor token length leaks via
-timing.
+Any recognised role validates here — including `early` — so every token
+kind is activated through the same `/token.html` flow (02-§105.4). The
+endpoint verifies activation only; each privileged action applies its own
+role check. The supplied and recomputed signatures are compared in constant
+time over fixed-width digests (`tokenDigest()`, an HMAC keyed by a
+per-process random key, retained from #386), so neither validity nor token
+length leaks via timing.
 
 ### Provisioning and revocation
 
 `npm run admin:create` signs a token offline against `ADMIN_TOKEN_SECRET`
-for the chosen role and prints it to hand over — no environment edit and no
-redeploy per person, because the secret (not a list) is what the runtimes
-read. `superadmin` is minted only by this script (it grants the right to
-mint others), never from the web UI. Because tokens are stateless, an
+for the chosen role — 60 days validity for `admin`, 90 days for `early`,
+180 days for `superadmin` — and prints it to hand over: no environment edit
+and no redeploy per person, because the secret (not a list) is what the
+runtimes read. `superadmin` is minted only by this script (it grants the
+right to mint others), never from the web UI. Because tokens are stateless, an
 individual token cannot be revoked without rotating `ADMIN_TOKEN_SECRET`
 (which invalidates all tokens at once); short embedded expiries bound the
 exposure of a leaked token.

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -213,6 +213,18 @@ Tokens are signed, not listed: the runtimes validate a token by recomputing
 its HMAC signature against `ADMIN_TOKEN_SECRET`, so issuing or retiring a
 person never requires an environment edit or a redeploy.
 
+Three roles exist:
+
+| Role | Grants | Validity |
+| --- | --- | --- |
+| `admin` | Edit/delete any event; add/edit before the form opens | 60 days |
+| `early` | Add/edit/delete **own** events before the form opens (tidig åtkomst) | 90 days |
+| `superadmin` | As `admin`; reserved for minting tokens (only issued via CLI) | 180 days |
+
+`early` is handed to a small set of trusted organisers who need to build a
+skeleton schedule before `opens_for_editing`. It gives no access to other
+people's events, and the post-camp lock applies to it like everyone else.
+
 ### One-time setup of the signing secret
 
 Generate a high-entropy secret once and store it like any other server
@@ -229,12 +241,13 @@ Rotating this secret invalidates every existing token at once.
 
 1. Run `npm run admin:create` and follow the prompts (name + role). The
    script signs a token in the format `namn_roll_epoch_sig` against
-   `ADMIN_TOKEN_SECRET` — 60 days validity for `admin`, 180 days for
-   `superadmin`. The token is shown only once — save it immediately.
-2. Share the token privately with the admin (e.g. via SMS or in person).
+   `ADMIN_TOKEN_SECRET` — 60 days validity for `admin`, 90 days for
+   `early`, 180 days for `superadmin`. The token is shown only once —
+   save it immediately.
+2. Share the token privately with the holder (e.g. via SMS or in person).
    No environment edit and no redeploy are needed.
-3. The admin visits `/token.html`, enters the token, and gains admin
-   status until the token's embedded expiry.
+3. The holder visits `/token.html`, enters the token, and gains the role's
+   privileges until the token's embedded expiry.
 
 ### Revoking access
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1572,3 +1572,21 @@ Doc ref: `03-architecture/platform-and-security.md §34`.
 | `02-§104.17` | covered | SEC-384-01: `source/static/.htaccess` sets a CSP with `default-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, GoatCounter origins, `'unsafe-inline'` scripts/styles |
 | `02-§104.18` | covered | SEC-384-03: `injectHtaccessCsp()` injects the `API_URL` origin into `connect-src` (cross-origin added, same-origin/unset resolves clean, no placeholder left); `source/build/utils.js`, wired in `source/build/build.js` |
 | `02-§104.19` | covered | SEC-384-02: `.htaccess` sets `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, HSTS |
+
+### §105 — Early Access Role (tidig åtkomst)
+
+Doc ref: `03-architecture/platform-and-security.md §30`.
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§105.1` | gap | Pre-camp time gate admits valid `admin`/`superadmin`/`early` tokens |
+| `02-§105.2` | gap | Ownership bypass excludes `early` — cookie ownership only |
+| `02-§105.3` | gap | Post-camp lock applies to every role |
+| `02-§105.4` | gap | `/verify-admin` accepts any recognised role incl. `early` |
+| `02-§105.5` | gap | Two role checks: `verifyAdminToken` vs pre-camp-bypass check, both runtimes |
+| `02-§105.6` | gap | `npm run admin:create` mints `early` with 90 days validity |
+| `02-§105.7` | gap | All-event edit links only for `admin`/`superadmin` roles |
+| `02-§105.8` | gap | Bypass button for all roles; label "(admin)" / "(tidig åtkomst)" |
+| `02-§105.9` | gap | Edit-page ownership shortcut only for admin-equivalent roles |
+| `02-§105.10` | gap | All user-facing text in Swedish |
+| `02-§105.11` | gap | Client reads role from segment 2; server is the authority |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1248,7 +1248,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.2` | covered | TOK-01 fixed vector (Node + PHP `AdminTokenTest.php`); TOK-03/12 round-trips; `source/api/admin.js`, `api/src/Admin.php` |
 | `02-§91.3` | covered | TOK-10: `verifyToken` returns null when the secret is empty |
 | `02-§91.29` | covered | TOK-05..09: tampered field, unknown role, expired rejected (PHP parity in `AdminTokenTest.php`) |
-| `02-§91.30` | implemented | `npm run admin:create` signs offline for `admin`/`superadmin` (60/180 days); manual: minted token round-trips |
+| `02-§91.30` | implemented | `npm run admin:create` signs offline for `admin`/`early`/`superadmin` (60/90/180 days); manual: minted token round-trips |
 | `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
@@ -1579,14 +1579,14 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§105.1` | gap | Pre-camp time gate admits valid `admin`/`superadmin`/`early` tokens |
-| `02-§105.2` | gap | Ownership bypass excludes `early` — cookie ownership only |
-| `02-§105.3` | gap | Post-camp lock applies to every role |
-| `02-§105.4` | gap | `/verify-admin` accepts any recognised role incl. `early` |
-| `02-§105.5` | gap | Two role checks: `verifyAdminToken` vs pre-camp-bypass check, both runtimes |
-| `02-§105.6` | gap | `npm run admin:create` mints `early` with 90 days validity |
-| `02-§105.7` | gap | All-event edit links only for `admin`/`superadmin` roles |
-| `02-§105.8` | gap | Bypass button for all roles; label "(admin)" / "(tidig åtkomst)" |
-| `02-§105.9` | gap | Edit-page ownership shortcut only for admin-equivalent roles |
-| `02-§105.10` | gap | All user-facing text in Swedish |
-| `02-§105.11` | gap | Client reads role from segment 2; server is the authority |
+| `02-§105.1` | covered | EARLY-01..02, EARLY-07..10, EARLY-18 + PHPUnit `testVerifyPreCampBypassToken*`: pre-camp gate admits `admin`/`superadmin`/`early`; `source/api/admin.js` + `api/src/Admin.php` `verifyPreCampBypassToken()`, wired in `app.js` and `api/index.php` add/edit/delete |
+| `02-§105.2` | covered | EARLY-13..15, EARLY-19 + PHPUnit role gating: ownership OR-condition keeps `verifyAdminToken` (admin/superadmin only); early authorised only via cookie ownership |
+| `02-§105.3` | covered | EARLY-11..12: post-camp lock checked before any role bypass; no token admits after `end_date + 1` |
+| `02-§105.4` | covered | EARLY-17: `app.js` `/verify-admin` uses `verifyToken`, `api/index.php` `handleVerifyAdmin()` uses `Admin::verifyToken`; manual: activate an early token on `/token.html` |
+| `02-§105.5` | covered | EARLY-06, EARLY-19, EARLY-20: `verifyAdminToken` false for early while `verifyPreCampBypassToken` true, in both runtimes |
+| `02-§105.6` | covered | EARLY-16: `ROLE_DAYS` maps `early: 90` in `source/scripts/create-admin-token.js`; prompt offers admin/early/superadmin |
+| `02-§105.7` | implemented | EARLY-21 (structural: `session.js` `hasValidAdminToken()` requires role admin/superadmin); manual: activate an early token, open the schedule, confirm no edit links on others' events |
+| `02-§105.8` | implemented | EARLY-22, EARLY-23 (structural: role-aware label in `redigera.js` + `lagg-till.js`); manual: open `/lagg-till.html` before `opens_for_editing` with an early token and confirm "Öppna ändå (tidig åtkomst)" |
+| `02-§105.9` | implemented | EARLY-22 (structural: `redigera.js` ownership shortcut uses `hasAdminRole`); manual: open `redigera.html?id=<annans>` with an early token and confirm "inte rättighet" message |
+| `02-§105.10` | implemented | Swedish labels and error texts; manual/visual check (CLI prompts and bypass labels in Swedish) |
+| `02-§105.11` | covered | EARLY-21..23: clients read the role from segment 2 only for UI; every privileged action re-verified server-side (EARLY-18..19) |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -138,11 +138,17 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1320
-Covered (implemented + tested): 692
-Implemented, not tested:        628
+Total requirements:            1331
+Covered (implemented + tested): 699
+Implemented, not tested:        632
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
+
+Note: §105 (Early Access Role, tidig åtkomst) adds 11 requirements
+  (02-§105.1–105.11): 7 covered (EARLY-01..23, tests/early-access.test.js,
+  plus PHPUnit AdminTokenTest verifyPreCampBypassToken parity) and 4
+  implemented (browser/manual checkpoints for edit-link suppression,
+  role-aware bypass labels, ownership message, Swedish text).
 
 Note: §104 (Security Hardening 2026-06) adds 20 requirements
   (02-§104.1–104.20), all covered by SEC-369..387 (tests/security-hardening.test.js)

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -196,3 +196,7 @@ Part of [the traceability index](./index.md).
 | SEC-386-01..03 | `tests/security-hardening.test.js` | Constant-time admin-token comparison (02-§104.6, 02-§104.7) |
 | SEC-387-01..02 | `tests/security-hardening.test.js` | SESSION_SECRET / TRUSTED_PROXIES documented; weak-secret warning (02-§104.8, 02-§104.9) |
 | (PHPUnit) | `api/tests/SecurityHardeningTest.php` | PHP coverage of feedback sanitiser, constant-time token, rate-limit counter (02-§104) |
+| TOK-01..22 | `tests/admin-token.test.js` | HMAC token model: sign/verify/role gating, embedded expiry, cross-runtime vector (02-§91) |
+| ABYP-01..13 | `tests/admin-time-gate-bypass.test.js` | Admin bypass of the pre-camp schedule lock (02-§26.14–26.19) |
+| EARLY-01..23 | `tests/early-access.test.js` | Early access role: pre-camp bypass, ownership exclusion, CLI, role wiring (02-§105) |
+| (PHPUnit) | `api/tests/AdminTokenTest.php` | PHP mirror of the token model incl. `verifyPreCampBypassToken` (02-§91, 02-§105) |

--- a/source/api/admin.js
+++ b/source/api/admin.js
@@ -14,6 +14,7 @@ const crypto = require('crypto');
 
 const VALID_ROLES = new Set(['admin', 'early', 'superadmin']);
 const ADMIN_ROLES = new Set(['admin', 'superadmin']);
+const PRE_CAMP_BYPASS_ROLES = new Set(['admin', 'early', 'superadmin']);
 
 // ── Constant-time comparison helper (retained from #386) ─────────────────────
 
@@ -98,10 +99,20 @@ function verifyAdminToken(candidate, secret) {
   return !!token && ADMIN_ROLES.has(token.role);
 }
 
+// True for roles allowed to bypass the pre-camp time gate: administrators
+// plus early-access contributors (02-§105.1). Unlike verifyAdminToken,
+// passing this check grants no ownership bypass — an early holder still only
+// edits and deletes their own cookie-owned events (02-§105.2, §105.5).
+function verifyPreCampBypassToken(candidate, secret) {
+  const token = verifyToken(candidate, secret);
+  return !!token && PRE_CAMP_BYPASS_ROLES.has(token.role);
+}
+
 module.exports = {
   signToken,
   verifyToken,
   verifyAdminToken,
+  verifyPreCampBypassToken,
   isTokenExpired,
   extractTokenExpiry,
   VALID_ROLES,

--- a/source/assets/js/client/lagg-till.js
+++ b/source/assets/js/client/lagg-till.js
@@ -420,6 +420,14 @@
   var adminToken = getAdminToken();
   var adminBypassActive = false;
 
+  // The role is the second segment of the token (namn_roll_epoch_sig). Any
+  // valid role may open the form before opens_for_editing (02-§105.8); the
+  // server re-verifies the role on submit.
+  function tokenRole(token) {
+    if (!token) return null;
+    return token.split('_')[1] || null;
+  }
+
   // ── Time-gating (02-§26.3–26.8, §26.14–§26.19) ────────────────────────────
 
   var opensDate = form.dataset.opens;
@@ -445,7 +453,9 @@
         var bypassBtn = document.createElement('button');
         bypassBtn.type = 'button';
         bypassBtn.className = 'form-gate-bypass';
-        bypassBtn.textContent = 'Öppna ändå (admin)';
+        bypassBtn.textContent = tokenRole(adminToken) === 'early'
+          ? 'Öppna ändå (tidig åtkomst)'
+          : 'Öppna ändå (admin)';
         bypassBtn.addEventListener('click', function () {
           adminBypassActive = true;
           fieldset.disabled = false;

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -269,7 +269,17 @@
     }
   }
 
+  // The role is the second segment of the token (namn_roll_epoch_sig).
+  function tokenRole(token) {
+    if (!token) return null;
+    return token.split('_')[1] || null;
+  }
+
   var adminToken = getAdminToken();
+  // Only admin-equivalent roles skip the ownership check; an early-access
+  // token bypasses the pre-camp gate but never ownership (02-§105.9). The
+  // server re-verifies the role either way.
+  var hasAdminRole = tokenRole(adminToken) === 'admin' || tokenRole(adminToken) === 'superadmin';
 
   // ── Error display ────────────────────────────────────────────────────────────
 
@@ -333,12 +343,15 @@
         sectionEl.parentNode.insertBefore(gateMsg, sectionEl);
         gateBlocked = true;
 
-        // Admin bypass button — only before opens (02-§26.16)
+        // Pre-camp bypass button — only before opens, for any valid token
+        // role (02-§26.16, 02-§105.8)
         if (isBeforeOpens && adminToken) {
           var bypassBtn = document.createElement('button');
           bypassBtn.type = 'button';
           bypassBtn.className = 'form-gate-bypass';
-          bypassBtn.textContent = 'Öppna ändå (admin)';
+          bypassBtn.textContent = tokenRole(adminToken) === 'early'
+            ? 'Öppna ändå (tidig åtkomst)'
+            : 'Öppna ändå (admin)';
           bypassBtn.addEventListener('click', function () {
             gateMsg.hidden = true;
             bypassBtn.hidden = true;
@@ -428,8 +441,10 @@
     }
 
     // Specific event selected — existing edit behaviour (02-§48.17)
-    // Authorised if event ID is in session cookie OR user has admin token (02-§7.3).
-    if (ownedIds.indexOf(eventId) === -1 && !adminToken) {
+    // Authorised if event ID is in session cookie OR the stored token has an
+    // admin-equivalent role — early gives no ownership bypass (02-§7.3,
+    // 02-§105.9).
+    if (ownedIds.indexOf(eventId) === -1 && !hasAdminRole) {
       showError('Du har inte rättighet att redigera denna aktivitet.');
       fetch('/events.json')
         .then(function (r) { return r.json(); })

--- a/source/assets/js/client/session.js
+++ b/source/assets/js/client/session.js
@@ -102,7 +102,10 @@
 
   // ── Admin token helper ──────────────────────────────────────────────────────
 
-  // Check if a valid (non-expired) admin token exists in localStorage (02-§7.3).
+  // Check if a valid (non-expired) token with an admin-equivalent role exists
+  // in localStorage (02-§7.3). The role is the second segment of the token
+  // (namn_roll_epoch_sig). An early-access token must NOT light this up —
+  // its holder gets edit links only via cookie ownership (02-§105.7).
   function hasValidAdminToken() {
     try {
       var raw = localStorage.getItem('sb_admin');
@@ -113,6 +116,7 @@
       // (the base64url signature may contain underscores, so read by position).
       var parts = data.token.split('_');
       if (parts.length < 4) return false;
+      if (parts[1] !== 'admin' && parts[1] !== 'superadmin') return false;
       var epoch = Number(parts[2]);
       if (!isFinite(epoch) || epoch <= 0) return false;
       return Math.floor(Date.now() / 1000) <= epoch;

--- a/source/scripts/create-admin-token.js
+++ b/source/scripts/create-admin-token.js
@@ -3,8 +3,8 @@
 const readline = require('readline');
 const { signToken } = require('../api/admin');
 
-// Validity per role, in days (02-§91.30).
-const ROLE_DAYS = { admin: 60, superadmin: 180 };
+// Validity per role, in days (02-§91.30, 02-§105.6).
+const ROLE_DAYS = { admin: 60, early: 90, superadmin: 180 };
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -52,12 +52,12 @@ async function main() {
     process.exit(1);
   }
 
-  const rawRole = (await ask('Roll [admin/superadmin] (admin): ')).trim().toLowerCase();
+  const rawRole = (await ask('Roll [admin/early/superadmin] (admin): ')).trim().toLowerCase();
   rl.close();
   const role = rawRole || 'admin';
   if (!Object.prototype.hasOwnProperty.call(ROLE_DAYS, role)) {
-    console.error(`\nFel: okänd roll "${role}". Välj admin eller superadmin.`);
-    console.error('(Rollen "early" delas ut separat; superadmin skapas bara här, aldrig i webb-UI.)');
+    console.error(`\nFel: okänd roll "${role}". Välj admin, early eller superadmin.`);
+    console.error('(early = tidig åtkomst: egna inlägg före öppning; superadmin skapas bara här, aldrig i webb-UI.)');
     process.exit(1);
   }
 

--- a/source/scripts/create-admin-token.js
+++ b/source/scripts/create-admin-token.js
@@ -21,8 +21,8 @@ async function main() {
   const secret = process.env.ADMIN_TOKEN_SECRET || '';
 
   console.log('');
-  console.log('Skapa admin-token');
-  console.log('─────────────────');
+  console.log('Skapa token (admin / tidig åtkomst / superadmin)');
+  console.log('────────────────────────────────────────────────');
   console.log('');
 
   if (!secret) {
@@ -42,7 +42,7 @@ async function main() {
     console.warn('');
   }
 
-  const rawName = await ask('Namn på admin: ');
+  const rawName = await ask('Namn på mottagaren: ');
   // Hyphen-separated identifier, no underscores (underscore is the token
   // field delimiter, so the name must never contain one).
   const name = rawName.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-zåäö0-9-]/g, '');

--- a/tests/early-access.test.js
+++ b/tests/early-access.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+// Tests for the early access role (tidig åtkomst) — 02-§105.
+//
+// Testable in Node.js:
+//   - verifyPreCampBypassToken role gating (EARLY-01..06)
+//   - time-gate admission with early tokens (EARLY-07..12)
+//   - ownership OR-condition excludes early (EARLY-13..15)
+//   - CLI mints early with 90 days validity (EARLY-16)
+//   - structural role wiring in app.js / api/index.php / client files
+//     (EARLY-17..22); PHP behavioural parity lives in
+//     api/tests/AdminTokenTest.php against the same fixed vector
+//
+// Browser-only (manual checkpoints documented in traceability):
+//   - 02-§105.7: a stored early token injects no all-event edit links
+//   - 02-§105.8: bypass button label "(tidig åtkomst)" for early
+//   - 02-§105.9: edit page ownership shortcut not applied for early
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+
+const {
+  signToken,
+  verifyAdminToken,
+  verifyPreCampBypassToken,
+} = require('../source/api/admin');
+const {
+  isBeforeEditingPeriod,
+  isAfterEditingPeriod,
+} = require('../source/api/time-gate');
+const { createOwnershipEntry, parseVerifiedSessionIds } = require('../source/api/session');
+
+const SECRET = 'early-access-test-secret-value!!';
+const future = () => Math.floor(Date.now() / 1000) + 86400;
+const past = () => Math.floor(Date.now() / 1000) - 86400;
+
+const EARLY_TOKEN = signToken('anna', 'early', future(), SECRET);
+const ADMIN_TOKEN = signToken('erik', 'admin', future(), SECRET);
+const SUPER_TOKEN = signToken('sigge', 'superadmin', future(), SECRET);
+
+// ── verifyPreCampBypassToken (02-§105.1, §105.5) ─────────────────────────────
+
+describe('verifyPreCampBypassToken (02-§105.1, §105.5)', () => {
+  it('EARLY-01: true for early', () => {
+    assert.strictEqual(verifyPreCampBypassToken(EARLY_TOKEN, SECRET), true);
+  });
+
+  it('EARLY-02: true for admin and superadmin', () => {
+    assert.strictEqual(verifyPreCampBypassToken(ADMIN_TOKEN, SECRET), true);
+    assert.strictEqual(verifyPreCampBypassToken(SUPER_TOKEN, SECRET), true);
+  });
+
+  it('EARLY-03: false for an unknown role even with a valid signature', () => {
+    assert.strictEqual(
+      verifyPreCampBypassToken(signToken('x', 'root', future(), SECRET), SECRET),
+      false,
+    );
+  });
+
+  it('EARLY-04: false for a tampered or wrong-secret token', () => {
+    assert.strictEqual(verifyPreCampBypassToken(EARLY_TOKEN.replace('_early_', '_admin_'), SECRET), false);
+    assert.strictEqual(verifyPreCampBypassToken(signToken('anna', 'early', future(), 'other-secret'), SECRET), false);
+  });
+
+  it('EARLY-05: false for an expired token or empty secret', () => {
+    assert.strictEqual(verifyPreCampBypassToken(signToken('anna', 'early', past(), SECRET), SECRET), false);
+    assert.strictEqual(verifyPreCampBypassToken(EARLY_TOKEN, ''), false);
+  });
+
+  it('EARLY-06: verifyAdminToken remains false for early (02-§105.5)', () => {
+    assert.strictEqual(verifyAdminToken(EARLY_TOKEN, SECRET), false);
+    assert.strictEqual(verifyPreCampBypassToken(EARLY_TOKEN, SECRET), true);
+  });
+});
+
+// ── Time-gate admission (02-§105.1, §105.3) ──────────────────────────────────
+
+const OPENS = '2026-06-14';
+const END_DATE = '2026-06-27';
+// end_date + 1 = 2026-06-28 = last allowed day
+
+// Mirrors the time-gate admission logic the endpoints use.
+function isTimeGateAccepted(today, opens, endDate, token, secret) {
+  if (isAfterEditingPeriod(today, endDate)) return false;
+  if (!isBeforeEditingPeriod(today, opens)) return true;
+  return verifyPreCampBypassToken(token, secret);
+}
+
+describe('early bypasses the pre-camp lock (02-§105.1)', () => {
+  it('EARLY-07: early accepted before opens_for_editing', () => {
+    assert.strictEqual(isTimeGateAccepted('2026-06-13', OPENS, END_DATE, EARLY_TOKEN, SECRET), true);
+  });
+
+  it('EARLY-08: early accepted well before opens_for_editing', () => {
+    assert.strictEqual(isTimeGateAccepted('2026-01-01', OPENS, END_DATE, EARLY_TOKEN, SECRET), true);
+  });
+
+  it('EARLY-09: no token still rejected before opens_for_editing', () => {
+    assert.strictEqual(isTimeGateAccepted('2026-06-13', OPENS, END_DATE, undefined, SECRET), false);
+  });
+
+  it('EARLY-10: expired early token rejected before opens_for_editing', () => {
+    const expired = signToken('anna', 'early', past(), SECRET);
+    assert.strictEqual(isTimeGateAccepted('2026-06-13', OPENS, END_DATE, expired, SECRET), false);
+  });
+});
+
+describe('early does NOT bypass the post-camp lock (02-§105.3)', () => {
+  it('EARLY-11: early rejected after end_date + 1', () => {
+    assert.strictEqual(isTimeGateAccepted('2026-06-29', OPENS, END_DATE, EARLY_TOKEN, SECRET), false);
+    assert.strictEqual(isTimeGateAccepted('2027-01-01', OPENS, END_DATE, EARLY_TOKEN, SECRET), false);
+  });
+
+  it('EARLY-12: early accepted inside the open window and on end_date + 1', () => {
+    assert.strictEqual(isTimeGateAccepted('2026-06-21', OPENS, END_DATE, EARLY_TOKEN, SECRET), true);
+    assert.strictEqual(isTimeGateAccepted('2026-06-28', OPENS, END_DATE, EARLY_TOKEN, SECRET), true);
+  });
+});
+
+// ── Ownership OR-condition excludes early (02-§105.2) ────────────────────────
+
+const SESSION_SECRET = 'early-session-secret';
+
+// Simulates the OR condition app.js uses for edit/delete: authorised if the
+// event ID has valid signed ownership OR the request carries a token whose
+// role is admin-equivalent (verifyAdminToken — NOT the pre-camp check).
+function isAuthorised(cookieHeader, eventId, token, secret) {
+  const ownedIds = parseVerifiedSessionIds(cookieHeader, SESSION_SECRET);
+  if (ownedIds.includes(eventId)) return true;
+  if (token && verifyAdminToken(token, secret)) return true;
+  return false;
+}
+
+describe('ownership is not bypassed by early (02-§105.2)', () => {
+  const eventId = 'bada-2099-06-01-1000';
+  const ownCookie = `sb_session=${encodeURIComponent(JSON.stringify([createOwnershipEntry(eventId, SESSION_SECRET)]))}`;
+  const otherCookie = `sb_session=${encodeURIComponent(JSON.stringify([createOwnershipEntry('annans-event', SESSION_SECRET)]))}`;
+
+  it('EARLY-13: early token alone does NOT authorise editing someone else\'s event', () => {
+    assert.strictEqual(isAuthorised(otherCookie, eventId, EARLY_TOKEN, SECRET), false);
+    assert.strictEqual(isAuthorised('', eventId, EARLY_TOKEN, SECRET), false);
+  });
+
+  it('EARLY-14: early token holder IS authorised for their own (cookie-owned) event', () => {
+    assert.strictEqual(isAuthorised(ownCookie, eventId, EARLY_TOKEN, SECRET), true);
+  });
+
+  it('EARLY-15: admin token still authorises without ownership (unchanged)', () => {
+    assert.strictEqual(isAuthorised(otherCookie, eventId, ADMIN_TOKEN, SECRET), true);
+  });
+});
+
+// ── CLI validity (02-§105.6) ─────────────────────────────────────────────────
+
+describe('admin:create mints early with 90 days validity (02-§105.6)', () => {
+  const cli = read('source/scripts/create-admin-token.js');
+
+  it('EARLY-16: ROLE_DAYS maps early to 90 and the prompt offers early', () => {
+    assert.match(cli, /early:\s*90/);
+    assert.match(cli, /admin\/early\/superadmin/);
+  });
+});
+
+// ── Structural wiring: server (02-§105.1, §105.2, §105.4, §105.5) ────────────
+
+describe('server role wiring (02-§105.1, §105.2, §105.4, §105.5)', () => {
+  const node = read('app.js');
+  const php = read('api/index.php');
+  const phpAdmin = read('api/src/Admin.php');
+
+  it('EARLY-17: /verify-admin accepts any recognised role in both runtimes', () => {
+    // Node route uses verifyToken (any recognised role), not verifyAdminToken.
+    const nodeRoute = node.slice(node.indexOf("app.post('/verify-admin'"));
+    assert.match(nodeRoute.slice(0, 500), /(?<!Admin)verifyToken\(token/);
+    // PHP handler likewise.
+    const phpRoute = php.slice(php.indexOf('function handleVerifyAdmin'));
+    assert.match(phpRoute.slice(0, 600), /Admin::verifyToken\(/);
+  });
+
+  it('EARLY-18: pre-camp time gates use the pre-camp-bypass check in both runtimes', () => {
+    assert.match(node, /isBeforeEditingPeriod\([\s\S]{0,120}verifyPreCampBypassToken|verifyPreCampBypassToken[\s\S]{0,200}isBeforeEditingPeriod/);
+    assert.match(php, /Admin::verifyPreCampBypassToken\(/);
+  });
+
+  it('EARLY-19: ownership OR-condition still uses verifyAdminToken in both runtimes', () => {
+    // The isAdmin flag consumed by the ownership checks must come from
+    // verifyAdminToken (admin/superadmin only).
+    assert.match(node, /const isAdmin = verifyAdminToken\(/);
+    assert.match(php, /\$isAdmin\s*=\s*Admin::verifyAdminToken\(/);
+  });
+
+  it('EARLY-20: Admin.php exposes verifyPreCampBypassToken (PHP parity)', () => {
+    assert.match(phpAdmin, /function\s+verifyPreCampBypassToken\b/);
+    assert.match(phpAdmin, /PRE_CAMP_BYPASS_ROLES/);
+  });
+});
+
+// ── Structural wiring: client (02-§105.7, §105.8, §105.9) ────────────────────
+
+describe('client role wiring (02-§105.7, §105.8, §105.9)', () => {
+  it('EARLY-21: session.js injects all-event edit links only for admin roles', () => {
+    const src = read('source/assets/js/client/session.js');
+    // The role (second segment) must be checked, not just token presence.
+    assert.match(src, /parts\[1\]/);
+    assert.match(src, /'admin'/);
+    assert.match(src, /'superadmin'/);
+  });
+
+  it('EARLY-22: redigera.js gates the ownership shortcut on an admin role and labels the bypass per role', () => {
+    const src = read('source/assets/js/client/redigera.js');
+    assert.match(src, /parts\[1\]/);
+    assert.match(src, /hasAdminRole/);
+    assert.match(src, /Öppna ändå \(tidig åtkomst\)/);
+  });
+
+  it('EARLY-23: lagg-till.js labels the bypass button per role', () => {
+    const src = read('source/assets/js/client/lagg-till.js');
+    assert.match(src, /Öppna ändå \(tidig åtkomst\)/);
+    assert.match(src, /Öppna ändå \(admin\)/);
+  });
+});


### PR DESCRIPTION
## Sammanfattning

- Ny roll **`early` (tidig åtkomst)**: kringgår pre-läger-tidsspärren (`opens_for_editing`) för att lägga till/ändra/radera **egna** inlägg — ingen åtkomst till andras aktiviteter (WP2 av token-arbetet, se #390)
- Ny hjälpare `verifyPreCampBypassToken` i Node (`source/api/admin.js`) och PHP (`api/src/Admin.php`); tidsspärren i add/add-events/edit/delete använder den, medan ägarskapskontrollen behåller `verifyAdminToken` (admin/superadmin)
- Efter-läger-spärren (`end_date + 1`) gäller alla roller — ingen kringgår den
- `/verify-admin` accepterar alla erkända roller så early-tokens aktiveras på `/token.html`
- Klient: alla-events-redigeringslänkar bara för admin-roller (`session.js`); ägarskaps-genvägen i `redigera.js` rollgrindad; bypass-knappen rollmedveten — "Öppna ändå (tidig åtkomst)" för early
- CLI `npm run admin:create` myntar `early` med 90 dagars giltighet
- Docs: kravsektion 02-§105, arkitektur §30, OPERATIONS, traceability + test-id-legend

## Testplan

- [x] 23 nya tester i `tests/early-access.test.js` (EARLY-01..23): pre-läger-bypass, ägarskaps-exkludering, efter-läger-spärr, CLI, rollkoppling i båda runtimes
- [x] PHPUnit-paritet i `api/tests/AdminTokenTest.php` (`verifyPreCampBypassToken`, korsruntime-vektor)
- [x] Hela sviten grön: 1864 Node-tester, 61 PHP-tester; eslint/markdownlint/html-validate/stylelint/build gröna
- [x] HTTP-verifierat lokalt: early ger `valid:true` på `/verify-admin`, nekas på andras event; admin kringgår fortsatt ägarskapet
- [ ] Manuella browser-checkpoints (dokumenterade i traceability §105): inga redigeringslänkar på andras event med early-token; knappetikett "Öppna ändå (tidig åtkomst)" före öppning

Closes #380

https://claude.ai/code/session_01P9hDRrudY6qi1XpJtpEGmx

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9hDRrudY6qi1XpJtpEGmx)_