### PR TITLE
feat: self-service mint-UI för tokens (superadmin)

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -50,6 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 const HOUR_SECONDS              = 3600;
 const RATE_LIMIT_MSG            = 'För många förfrågningar. Försök igen senare.';
 const RATE_LIMIT_VERIFY_ADMIN   = 5;
+const RATE_LIMIT_MINT_TOKEN     = 5;
 const RATE_LIMIT_ADD_EVENT      = 30;
 const RATE_LIMIT_EDIT_EVENT     = 30;
 const RATE_LIMIT_DELETE_EVENT   = 30;
@@ -177,6 +178,9 @@ try {
 
         $method === 'POST' && $route === '/verify-admin'
             => handleVerifyAdmin($adminTokenSecret),
+
+        $method === 'POST' && $route === '/mint-token'
+            => handleMintToken($adminTokenSecret),
 
         default
             => jsonResponse(['error' => 'Not found'], 404),
@@ -614,6 +618,38 @@ function handleVerifyAdmin(string $adminTokenSecret): void
     } else {
         jsonResponse(['valid' => false], 403);
     }
+}
+
+function handleMintToken(string $adminTokenSecret): void
+{
+    if (RateLimit::isLimited(clientIp(), 'mint-token', RATE_LIMIT_MINT_TOKEN, HOUR_SECONDS)) {
+        jsonResponse(['success' => false, 'error' => RATE_LIMIT_MSG], 429);
+
+        return;
+    }
+
+    $body = getJsonBody();
+
+    // Privilege boundary: only a valid superadmin token may mint, and only
+    // admin/early can be minted — superadmin is CLI-only (02-§106.2,
+    // §106.3). With an unset secret nothing verifies, so the gate fails
+    // closed (§106.8).
+    $requester = Admin::verifyToken((string) ($body['token'] ?? ''), $adminTokenSecret);
+    if ($requester === null || $requester['role'] !== 'superadmin') {
+        jsonResponse(['success' => false, 'error' => 'Endast superadmin kan skapa tokens.'], 403);
+
+        return;
+    }
+
+    $result = Admin::mintRequest($body, $adminTokenSecret);
+    if (!$result['ok']) {
+        jsonResponse(['success' => false, 'error' => $result['error']], 400);
+
+        return;
+    }
+
+    // Stateless: the token is returned, never stored (02-§106.6).
+    jsonResponse(['success' => true, 'token' => $result['token']]);
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────

--- a/api/src/Admin.php
+++ b/api/src/Admin.php
@@ -160,4 +160,65 @@ final class Admin
 
         return $token !== null && in_array($token['role'], self::PRE_CAMP_BYPASS_ROLES, true);
     }
+
+    /**
+     * Roles a superadmin may mint from the web, with their maximum (and
+     * default) validity in days (02-§106.3, §106.5). superadmin is CLI-only
+     * (02-§91.30).
+     *
+     * @var array<string,int>
+     */
+    private const MINTABLE_ROLE_DAYS = ['admin' => 60, 'early' => 90];
+
+    /**
+     * Hyphen-separated identifier: lowercase a–ö, digits, hyphens. Never an
+     * underscore — that is the token field delimiter (02-§106.4). Mirrors
+     * sanitizeTokenName in source/api/admin.js.
+     */
+    public static function sanitizeTokenName(mixed $raw): string
+    {
+        $name = mb_strtolower(trim((string) ($raw ?? '')), 'UTF-8');
+        $name = (string) preg_replace('/\s+/u', '-', $name);
+
+        return (string) preg_replace('/[^a-zåäö0-9-]/u', '', $name);
+    }
+
+    /**
+     * Validate a mint request and sign the token (02-§106.3–106.6). The
+     * caller is responsible for the superadmin gate (02-§106.2); this method
+     * only shapes the minted token. Mirrors mintRequest in
+     * source/api/admin.js.
+     *
+     * @param array<string,mixed> $body
+     * @return array{ok: bool, token?: string, error?: string}
+     */
+    public static function mintRequest(array $body, string $secret, ?int $nowSeconds = null): array
+    {
+        $now  = $nowSeconds ?? time();
+        $name = self::sanitizeTokenName($body['name'] ?? '');
+        if ($name === '') {
+            return ['ok' => false, 'error' => 'Namn krävs (a–ö, siffror, bindestreck).'];
+        }
+        $role = (string) ($body['role'] ?? '');
+        if (!array_key_exists($role, self::MINTABLE_ROLE_DAYS)) {
+            return ['ok' => false, 'error' => 'Ogiltig roll. Välj admin eller early.'];
+        }
+        $cap     = self::MINTABLE_ROLE_DAYS[$role];
+        $rawDays = $body['days'] ?? null;
+        if ($rawDays === null || $rawDays === '') {
+            $days = $cap;
+        } elseif (is_int($rawDays)) {
+            $days = $rawDays;
+        } elseif (is_numeric($rawDays) && (float) $rawDays === floor((float) $rawDays)) {
+            $days = (int) $rawDays;
+        } else {
+            $days = 0; // non-integer → rejected below
+        }
+        if ($days < 1 || $days > $cap) {
+            return ['ok' => false, 'error' => "Giltighetstiden måste vara 1–{$cap} dagar."];
+        }
+        $epoch = $now + $days * 86400;
+
+        return ['ok' => true, 'token' => self::signToken($name, $role, $epoch, $secret)];
+    }
 }

--- a/api/tests/MintTokenTest.php
+++ b/api/tests/MintTokenTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBSommar\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SBSommar\Admin;
+
+/**
+ * PHP behavioural coverage for web token minting — parity with
+ * tests/mint-token.test.js (02-§106).
+ *
+ * The fixed inputs (secret, now) match the Node suite, so a mint performed
+ * by one runtime is byte-identical to the other (cross-runtime proof via
+ * signToken over the same sanitised claims).
+ */
+final class MintTokenTest extends TestCase
+{
+    private const SECRET = 'mint-token-test-secret-32-bytes!';
+    private const NOW    = 2000000000;
+    private const DAY    = 86400;
+
+    public function testMintsAdminWithDefaultValidity(): void
+    {
+        $r = Admin::mintRequest(['name' => 'Anna Söder', 'role' => 'admin'], self::SECRET, self::NOW);
+        self::assertTrue($r['ok']);
+        self::assertSame(
+            ['name' => 'anna-söder', 'role' => 'admin', 'epoch' => self::NOW + 60 * self::DAY],
+            Admin::verifyToken($r['token'], self::SECRET),
+        );
+        self::assertSame(
+            Admin::signToken('anna-söder', 'admin', self::NOW + 60 * self::DAY, self::SECRET),
+            $r['token'],
+        );
+    }
+
+    public function testMintsEarlyWithDefaultValidity(): void
+    {
+        $r = Admin::mintRequest(['name' => 'erik', 'role' => 'early'], self::SECRET, self::NOW);
+        self::assertTrue($r['ok']);
+        self::assertSame(self::NOW + 90 * self::DAY, Admin::verifyToken($r['token'], self::SECRET)['epoch']);
+    }
+
+    public function testHonoursExplicitDaysWithinRange(): void
+    {
+        $r = Admin::mintRequest(['name' => 'erik', 'role' => 'admin', 'days' => 7], self::SECRET, self::NOW);
+        self::assertSame(self::NOW + 7 * self::DAY, Admin::verifyToken($r['token'], self::SECRET)['epoch']);
+    }
+
+    public function testRejectsDaysOutsideRange(): void
+    {
+        foreach ([['admin', 0], ['admin', 61], ['early', 91], ['admin', -5], ['admin', 2.5], ['admin', 'nan']] as [$role, $days]) {
+            $r = Admin::mintRequest(['name' => 'erik', 'role' => $role, 'days' => $days], self::SECRET, self::NOW);
+            self::assertFalse($r['ok'], "{$role}/{$days} should be rejected");
+            self::assertNotSame('', $r['error']);
+        }
+    }
+
+    public function testRejectsNonWhitelistedRoles(): void
+    {
+        self::assertFalse(Admin::mintRequest(['name' => 'x', 'role' => 'superadmin'], self::SECRET, self::NOW)['ok']);
+        self::assertFalse(Admin::mintRequest(['name' => 'x', 'role' => 'root'], self::SECRET, self::NOW)['ok']);
+        self::assertFalse(Admin::mintRequest(['name' => 'x', 'role' => ''], self::SECRET, self::NOW)['ok']);
+    }
+
+    public function testRejectsEmptyNameAfterSanitisation(): void
+    {
+        self::assertFalse(Admin::mintRequest(['name' => '!!!', 'role' => 'admin'], self::SECRET, self::NOW)['ok']);
+        self::assertFalse(Admin::mintRequest(['role' => 'admin'], self::SECRET, self::NOW)['ok']);
+    }
+
+    public function testSanitisesNameLikeTheCli(): void
+    {
+        $r = Admin::mintRequest(['name' => '  Erik  Ek_! ', 'role' => 'early'], self::SECRET, self::NOW);
+        self::assertTrue($r['ok']);
+        self::assertSame('erik-ek', Admin::verifyToken($r['token'], self::SECRET)['name']);
+    }
+}

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const {
 } = require('./source/api/session');
 const { isBeforeEditingPeriod, isAfterEditingPeriod }            = require('./source/api/time-gate');
 const { validateFeedbackRequest, createFeedbackIssue }           = require('./source/api/feedback');
-const { verifyToken, verifyAdminToken, verifyPreCampBypassToken } = require('./source/api/admin');
+const { verifyToken, verifyAdminToken, verifyPreCampBypassToken, mintRequest } = require('./source/api/admin');
 const { resolveActiveCamp }                                      = require('./source/scripts/resolve-active-camp');
 
 const app = express();
@@ -72,6 +72,7 @@ function makeLimiter({ limit, windowMs, includeSuccess = true }) {
 }
 
 const verifyAdminLimiter = makeLimiter({ limit: 5,  windowMs: HOUR_MS, includeSuccess: false });
+const mintTokenLimiter   = makeLimiter({ limit: 5,  windowMs: HOUR_MS });
 const addEventLimiter    = makeLimiter({ limit: 30, windowMs: HOUR_MS });
 const editEventLimiter   = makeLimiter({ limit: 30, windowMs: HOUR_MS });
 const deleteEventLimiter = makeLimiter({ limit: 30, windowMs: HOUR_MS });
@@ -111,6 +112,25 @@ app.post('/verify-admin', verifyAdminLimiter, (req, res) => {
     return res.json({ valid: true });
   }
   return res.status(403).json({ valid: false });
+});
+
+// ── Token minting (02-§106) ─────────────────────────────────────────────────
+
+app.post('/mint-token', mintTokenLimiter, (req, res) => {
+  const body = req.body || {};
+  // Privilege boundary: only a valid superadmin token may mint, and only
+  // admin/early can be minted — superadmin is CLI-only (02-§106.2, §106.3).
+  // With an unset secret nothing verifies, so the gate fails closed (§106.8).
+  const requester = verifyToken(body.token, adminTokenSecret);
+  if (!requester || requester.role !== 'superadmin') {
+    return res.status(403).json({ success: false, error: 'Endast superadmin kan skapa tokens.' });
+  }
+  const result = mintRequest(body, adminTokenSecret, Math.floor(Date.now() / 1000));
+  if (!result.ok) {
+    return res.status(400).json({ success: false, error: result.error });
+  }
+  // Stateless: the token is returned, never stored (02-§106.6).
+  res.json({ success: true, token: result.token });
 });
 
 app.post('/add-event', addEventLimiter, (req, res) => {

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -24,7 +24,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
-| [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105 |
+| [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105, §106 |
 | [`design-and-content.md`](./design-and-content.md) | Design and Content | §30, §31, §47, §55, §64, §94, §98 |
 | [`archive.md`](./archive.md) | Archived Requirements | (superseded sections) |
 

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -1350,3 +1350,91 @@ activation page, and footer indicator defined in §91. Agreed in #380.
 - The role is read from the token's second underscore-separated segment;
   the client never needs to verify the signature — the server remains the
   authority on every privileged action. <!-- 02-§105.11 -->
+
+---
+
+---
+
+## 106. Token Minting from the Web (superadmin)
+
+### 106.1 Context
+
+Issuing a token (§91, §105) is also possible without a terminal: a
+superadmin mints `admin` and `early` tokens directly from the web —
+mobile-friendly, no environment edit, no redeploy — and shares an
+activation link. The server signs the token on demand with
+`ADMIN_TOKEN_SECRET` and stores nothing, preserving the stateless model
+of §91. The `superadmin` role itself is minted only via the CLI
+(02-§91.30), so the web path can never escalate to a new superadmin.
+Agreed in #391.
+
+### 106.2 Mint endpoint (API requirements)
+
+- Both runtimes expose `POST /mint-token` (Node `app.js`, PHP
+  `api/index.php`). <!-- 02-§106.1 -->
+- The request body is `{ "token", "name", "role", "days" }`. The request
+  is authorised only when `token` is a valid token (§91) whose role is
+  `superadmin`; otherwise the response is
+  `403 { "success": false, "error" }`. <!-- 02-§106.2 -->
+- The mintable roles are exactly `admin` and `early`. Any other requested
+  role — including `superadmin` — is rejected with
+  `400 { "success": false, "error" }`. <!-- 02-§106.3 -->
+- The name is sanitised the same way as in the CLI: trimmed, lowercased,
+  whitespace replaced by hyphens, and restricted to `a–ö`, digits, and
+  hyphens — it never contains an underscore (the token field delimiter).
+  A name that is empty after sanitisation is rejected with
+  `400`. <!-- 02-§106.4 -->
+- `days` is an integer between 1 and the role's standard validity —
+  60 for `admin`, 90 for `early` (02-§91.30, 02-§105.6). A request
+  without `days` uses the role's standard validity; a value outside the
+  range is rejected with `400`. <!-- 02-§106.5 -->
+- On success the response is `200 { "success": true, "token" }` where the
+  token is signed for the sanitised name, the requested role, and an
+  expiry of now plus the validity. Nothing is stored
+  server-side. <!-- 02-§106.6 -->
+- The endpoint is rate-limited to 5 requests per hour per IP, the same
+  budget as `/verify-admin` (§93). <!-- 02-§106.7 -->
+- When `ADMIN_TOKEN_SECRET` is unset or empty, no requester token
+  validates and every mint request is rejected with `403`
+  (fail-closed, 02-§91.3). <!-- 02-§106.8 -->
+
+### 106.3 Mint UI (user requirements)
+
+- `/token.html` contains a mint section that is displayed only when the
+  stored token in `localStorage` is unexpired and its role (second
+  underscore-segment) is `superadmin`. The client-side role check decides
+  visibility only — the server authorises every mint request
+  (02-§105.11). <!-- 02-§106.9 -->
+- The mint form has three fields: name, role (`admin` /
+  `early`, labelled "Admin" and "Tidig åtkomst" with their validity), and
+  validity in days. Changing the role updates the day field's default and
+  maximum to the role's standard validity. <!-- 02-§106.10 -->
+- Submitting the form sends `POST /mint-token` with the stored superadmin
+  token. On success the UI shows an activation link of the form
+  `<site-origin>/token.html#token=<token>`. <!-- 02-§106.11 -->
+- The result row has a copy button, and a share button (`navigator.share`)
+  that is displayed only when the browser supports sharing. <!-- 02-§106.12 -->
+- Error responses are displayed in Swedish in the mint section's message
+  area. <!-- 02-§106.13 -->
+
+### 106.4 Redemption via link (user requirements)
+
+- On load, `/token.html` reads `location.hash`. When the fragment contains
+  `token=<value>`, the page calls `POST /verify-admin` with the value and,
+  on `valid: true`, stores it in `localStorage` exactly like a manual
+  activation (02-§91.12) and shows the activation success
+  message. <!-- 02-§106.14 -->
+- The fragment is removed from the address bar via
+  `history.replaceState` whether or not the activation succeeds, so the
+  token does not linger in the visible URL. <!-- 02-§106.15 -->
+- The link carries the token in the `#fragment` — never in a `?query`
+  parameter — because fragments are not sent to the server and do not
+  leak through `Referer` headers or server logs. <!-- 02-§106.16 -->
+
+### 106.5 Constraints
+
+- `ADMIN_TOKEN_SECRET` exists only server-side; the client never signs
+  or sees the secret (02-§91.1). <!-- 02-§106.17 -->
+- All user-facing text is in Swedish; styling uses the custom properties
+  from `docs/07-design/css-strategy.md §7` and the token page's existing
+  form components. <!-- 02-§106.18 -->

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -234,7 +234,39 @@ for the chosen role — 60 days validity for `admin`, 90 days for `early`,
 180 days for `superadmin` — and prints it to hand over: no environment edit
 and no redeploy per person, because the secret (not a list) is what the
 runtimes read. `superadmin` is minted only by this script (it grants the
-right to mint others), never from the web UI. Because tokens are stateless, an
+right to mint others), never from the web UI.
+
+### Self-service minting (`/mint-token`)
+
+`POST /mint-token` (02-§106) lets a superadmin mint `admin` and `early`
+tokens from the web. The route is a privilege boundary and is deliberately
+narrow:
+
+- **Gate**: the request body's `token` must verify with role `superadmin`
+  (`verifyToken(...).role === 'superadmin'`); anything else is 403. With an
+  unset secret nothing verifies, so the endpoint fails closed.
+- **Whitelist**: only `admin` and `early` can be minted (`superadmin` is
+  CLI-only, Linje A), with `days` capped at the role's standard validity
+  (60/90).
+- **Stateless**: the response is the signed token and nothing else — no
+  storage, no log of issued tokens, same model as §91.
+- **Rate-limited**: 5 requests/hour per IP, like `/verify-admin`.
+
+The shared mint logic lives in `mintRequest()` (`source/api/admin.js` and
+`api/src/Admin.php`) — name sanitisation (identical to the CLI: lowercase,
+hyphens, `a–ö`/digits only, never underscore), role whitelist, day cap, and
+signing — so the Node and PHP routes stay thin and behave identically. The
+CLI reuses the same sanitiser.
+
+The mint UI is a section on `/token.html` (rendered hidden by
+`render-admin.js`, revealed by `admin.js` when the stored token's role is
+`superadmin`). It builds an activation link
+`<site-origin>/token.html#token=<token>` with copy and `navigator.share`
+buttons. On load the same page redeems incoming links: it reads
+`location.hash`, posts the value to `/verify-admin`, stores it like a
+manual activation, and clears the fragment with `history.replaceState`.
+The token travels in the fragment — never a query parameter — so it stays
+out of server logs and `Referer` headers. Because tokens are stateless, an
 individual token cannot be revoked without rotating `ADMIN_TOKEN_SECRET`
 (which invalidates all tokens at once); short embedded expiries bound the
 exposure of a leaked token.

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -239,6 +239,8 @@ Rotating this secret invalidates every existing token at once.
 
 ### Issuing a token
 
+Via the CLI:
+
 1. Run `npm run admin:create` and follow the prompts (name + role). The
    script signs a token in the format `namn_roll_epoch_sig` against
    `ADMIN_TOKEN_SECRET` — 60 days validity for `admin`, 90 days for
@@ -248,6 +250,15 @@ Rotating this secret invalidates every existing token at once.
    No environment edit and no redeploy are needed.
 3. The holder visits `/token.html`, enters the token, and gains the role's
    privileges until the token's embedded expiry.
+
+Or from the web (superadmin only):
+
+1. Open `/token.html` with an active superadmin token — a "Skapa
+   token-länk" section appears.
+2. Fill in name, role (`admin` or `early` — superadmin can never be minted
+   here), and validity, then press "Skapa länk".
+3. Share the activation link (`/token.html#token=…`) privately. The
+   recipient opens it and the token activates automatically.
 
 ### Revoking access
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1590,3 +1590,28 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 | `02-§105.9` | implemented | EARLY-22 (structural: `redigera.js` ownership shortcut uses `hasAdminRole`); manual: open `redigera.html?id=<annans>` with an early token and confirm "inte rättighet" message |
 | `02-§105.10` | implemented | Swedish labels and error texts; manual/visual check (CLI prompts and bypass labels in Swedish) |
 | `02-§105.11` | covered | EARLY-21..23: clients read the role from segment 2 only for UI; every privileged action re-verified server-side (EARLY-18..19) |
+
+### §106 — Token Minting from the Web (superadmin)
+
+Doc ref: `03-architecture/platform-and-security.md §30`.
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§106.1` | gap | `POST /mint-token` in `app.js` and `api/index.php` |
+| `02-§106.2` | gap | Requires valid superadmin token, else 403 |
+| `02-§106.3` | gap | Mintable roles exactly admin/early; superadmin rejected 400 |
+| `02-§106.4` | gap | Name sanitised like the CLI; empty → 400; never underscore |
+| `02-§106.5` | gap | `days` 1..role cap (60/90); default = cap; outside → 400 |
+| `02-§106.6` | gap | 200 `{success, token}`; nothing stored |
+| `02-§106.7` | gap | Rate limit 5/h per IP |
+| `02-§106.8` | gap | Unset secret → no requester validates → 403 (fail-closed) |
+| `02-§106.9` | gap | Mint section on /token.html visible only for superadmin role |
+| `02-§106.10` | gap | Form: name, role, days; role change updates day default/max |
+| `02-§106.11` | gap | POST with stored token; link `<origin>/token.html#token=…` |
+| `02-§106.12` | gap | Copy button; share button only when navigator.share exists |
+| `02-§106.13` | gap | Errors in Swedish in mint message area |
+| `02-§106.14` | gap | Hash redemption → /verify-admin → store like manual activation |
+| `02-§106.15` | gap | history.replaceState clears the fragment either way |
+| `02-§106.16` | gap | Token in #fragment, never ?query |
+| `02-§106.17` | gap | Secret never client-side; minting server-side only |
+| `02-§106.18` | gap | Swedish text; existing form components and CSS tokens |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1597,21 +1597,21 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§106.1` | gap | `POST /mint-token` in `app.js` and `api/index.php` |
-| `02-§106.2` | gap | Requires valid superadmin token, else 403 |
-| `02-§106.3` | gap | Mintable roles exactly admin/early; superadmin rejected 400 |
-| `02-§106.4` | gap | Name sanitised like the CLI; empty → 400; never underscore |
-| `02-§106.5` | gap | `days` 1..role cap (60/90); default = cap; outside → 400 |
-| `02-§106.6` | gap | 200 `{success, token}`; nothing stored |
-| `02-§106.7` | gap | Rate limit 5/h per IP |
-| `02-§106.8` | gap | Unset secret → no requester validates → 403 (fail-closed) |
-| `02-§106.9` | gap | Mint section on /token.html visible only for superadmin role |
-| `02-§106.10` | gap | Form: name, role, days; role change updates day default/max |
-| `02-§106.11` | gap | POST with stored token; link `<origin>/token.html#token=…` |
-| `02-§106.12` | gap | Copy button; share button only when navigator.share exists |
-| `02-§106.13` | gap | Errors in Swedish in mint message area |
-| `02-§106.14` | gap | Hash redemption → /verify-admin → store like manual activation |
-| `02-§106.15` | gap | history.replaceState clears the fragment either way |
-| `02-§106.16` | gap | Token in #fragment, never ?query |
-| `02-§106.17` | gap | Secret never client-side; minting server-side only |
-| `02-§106.18` | gap | Swedish text; existing form components and CSS tokens |
+| `02-§106.1` | covered | MINT-11, MINT-12: `POST /mint-token` wired in `app.js` and `api/index.php` |
+| `02-§106.2` | covered | MINT-09, MINT-10 (gate predicate) + MINT-11/12 (structural); HTTP-verified: admin/early/garbage → 403 |
+| `02-§106.3` | covered | MINT-06 + PHPUnit `testRejectsNonWhitelistedRoles`: superadmin/unknown roles rejected 400 |
+| `02-§106.4` | covered | MINT-01, MINT-07 + PHPUnit `testSanitisesNameLikeTheCli`: shared `sanitizeTokenName()`; empty → 400 |
+| `02-§106.5` | covered | MINT-02..05 + PHPUnit: default = cap (60/90); outside 1..cap or non-integer → 400 |
+| `02-§106.6` | covered | MINT-02, MINT-08 + PHPUnit parity vector: token = `signToken(sanitised, role, now+days·86400)`; handlers return it without storing |
+| `02-§106.7` | covered | MINT-11, MINT-12: `mintTokenLimiter` (5/h) in `app.js`; `RateLimit::isLimited(.., 'mint-token', 5, 3600)` in PHP |
+| `02-§106.8` | covered | MINT-10: empty secret → no requester verifies → gate false (403) |
+| `02-§106.9` | implemented | MINT-15 (structural: role gate in `admin.js`); manual: open /token.html with superadmin vs admin token and confirm section visibility |
+| `02-§106.10` | implemented | MINT-14 (markup: name/role/days with data-days); manual: switch role and confirm day default/max follows (60↔90) |
+| `02-§106.11` | implemented | MINT-15 (structural: `#token=` link build); manual: mint and confirm the link format |
+| `02-§106.12` | implemented | MINT-14 (markup: copy button, share hidden by default); manual: share button appears only when navigator.share exists |
+| `02-§106.13` | implemented | Swedish error strings in `admin.js`/server handlers; manual/visual check |
+| `02-§106.14` | implemented | MINT-15 (structural: hash parse + /verify-admin reuse via activateToken); manual: open an activation link and confirm activation |
+| `02-§106.15` | implemented | MINT-15 (structural: history.replaceState); manual: confirm the fragment leaves the address bar on success and failure |
+| `02-§106.16` | covered | MINT-15: `admin.js` matches `#token=` and contains no `?token=`; link built with `#token=` |
+| `02-§106.17` | implemented | Architectural: signing only in `app.js`/`api/index.php` via the shared helpers; no secret reference in any client file |
+| `02-§106.18` | implemented | Swedish text; reuses `.admin-form` components; new CSS uses only `--space-*`/`--color-*`/`--font-*`/`--radius-*` tokens; manual/visual |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -138,11 +138,17 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1331
-Covered (implemented + tested): 699
-Implemented, not tested:        632
+Total requirements:            1349
+Covered (implemented + tested): 708
+Implemented, not tested:        641
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
+
+Note: §106 (Token Minting from the Web) adds 18 requirements
+  (02-§106.1–106.18): 9 covered (MINT-01..15, tests/mint-token.test.js,
+  plus PHPUnit MintTokenTest cross-runtime parity) and 9 implemented
+  (browser/manual checkpoints for mint-UI visibility, role-driven day
+  field, copy/share buttons, and fragment redemption).
 
 Note: §105 (Early Access Role, tidig åtkomst) adds 11 requirements
   (02-§105.1–105.11): 7 covered (EARLY-01..23, tests/early-access.test.js,

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -200,3 +200,5 @@ Part of [the traceability index](./index.md).
 | ABYP-01..13 | `tests/admin-time-gate-bypass.test.js` | Admin bypass of the pre-camp schedule lock (02-§26.14–26.19) |
 | EARLY-01..23 | `tests/early-access.test.js` | Early access role: pre-camp bypass, ownership exclusion, CLI, role wiring (02-§105) |
 | (PHPUnit) | `api/tests/AdminTokenTest.php` | PHP mirror of the token model incl. `verifyPreCampBypassToken` (02-§91, 02-§105) |
+| MINT-01..15 | `tests/mint-token.test.js` | Web token minting: sanitiser, mintRequest, superadmin gate, route/UI wiring (02-§106) |
+| (PHPUnit) | `api/tests/MintTokenTest.php` | PHP mirror of `mintRequest` with the same fixed inputs (02-§106) |

--- a/source/api/admin.js
+++ b/source/api/admin.js
@@ -108,11 +108,55 @@ function verifyPreCampBypassToken(candidate, secret) {
   return !!token && PRE_CAMP_BYPASS_ROLES.has(token.role);
 }
 
+// ── Minting (02-§106) ────────────────────────────────────────────────────────
+
+// Roles a superadmin may mint from the web, with their maximum (and default)
+// validity in days (02-§106.3, §106.5). superadmin is CLI-only (02-§91.30).
+const MINTABLE_ROLE_DAYS = { admin: 60, early: 90 };
+
+// Hyphen-separated identifier: lowercase a–ö, digits, hyphens. Never an
+// underscore — that is the token field delimiter (02-§106.4). Shared by the
+// CLI and the /mint-token endpoint so both produce identical names.
+function sanitizeTokenName(raw) {
+  return String(raw == null ? '' : raw)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zåäö0-9-]/g, '');
+}
+
+// Validate a mint request and sign the token (02-§106.3–106.6). The caller
+// is responsible for the superadmin gate (02-§106.2); this function only
+// shapes the minted token. Returns { ok: true, token } or
+// { ok: false, error } with a Swedish message.
+function mintRequest(body, secret, nowSeconds) {
+  const name = sanitizeTokenName(body && body.name);
+  if (!name) {
+    return { ok: false, error: 'Namn krävs (a–ö, siffror, bindestreck).' };
+  }
+  const role = String((body && body.role) || '');
+  if (!Object.prototype.hasOwnProperty.call(MINTABLE_ROLE_DAYS, role)) {
+    return { ok: false, error: 'Ogiltig roll. Välj admin eller early.' };
+  }
+  const cap = MINTABLE_ROLE_DAYS[role];
+  const rawDays = body.days;
+  const days = (rawDays === undefined || rawDays === null || rawDays === '')
+    ? cap
+    : Number(rawDays);
+  if (!Number.isInteger(days) || days < 1 || days > cap) {
+    return { ok: false, error: `Giltighetstiden måste vara 1–${cap} dagar.` };
+  }
+  const epoch = nowSeconds + days * 86400;
+  return { ok: true, token: signToken(name, role, epoch, secret) };
+}
+
 module.exports = {
   signToken,
   verifyToken,
   verifyAdminToken,
   verifyPreCampBypassToken,
+  mintRequest,
+  sanitizeTokenName,
   isTokenExpired,
   extractTokenExpiry,
   VALID_ROLES,

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2858,7 +2858,9 @@ body.modal-open {
   color: var(--color-navy);
 }
 
-.admin-form input[type="text"] {
+.admin-form input[type="text"],
+.admin-form input[type="number"],
+.admin-form select {
   width: 100%;
   padding: var(--space-xs) var(--space-sm);
   font-family: var(--font-sans);
@@ -2867,9 +2869,23 @@ body.modal-open {
   border-radius: var(--radius-sm);
 }
 
-.admin-form input[type="text"]:focus-visible {
+.admin-form input[type="text"]:focus-visible,
+.admin-form input[type="number"]:focus-visible,
+.admin-form select:focus-visible {
   outline: 2px solid var(--color-terracotta);
   outline-offset: 2px;
+}
+
+.mint-result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.mint-actions {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
 }
 
 .admin-message {

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -64,7 +64,19 @@
     }
   }
 
-  // ── Activation form (only on /admin.html) ──────────────────────────────────
+  // The role is the second segment of the token (namn_roll_epoch_sig).
+  function tokenRole(token) {
+    if (!token || typeof token !== 'string') return null;
+    return token.split('_')[1] || null;
+  }
+
+  // Derive the API base URL from the page's API configuration.
+  function apiBase() {
+    var feedbackBtn = document.querySelector('.feedback-btn[data-api-url]');
+    return feedbackBtn ? feedbackBtn.dataset.apiUrl.replace(/\/feedback$/, '') : '';
+  }
+
+  // ── Activation form (only on /token.html) ──────────────────────────────────
 
   var wrapper = document.getElementById('admin-form');
   var form = document.getElementById('admin-activate');
@@ -107,21 +119,14 @@
       });
     }
 
-    form.addEventListener('submit', function (e) {
-      e.preventDefault();
-      var token = (input.value || '').trim();
-      if (!token) return;
-
+    // Verify a token against the server and store it on success. Used by the
+    // manual form and by activation links (02-§91.11–91.13, 02-§106.14).
+    var activateToken = function (token) {
       message.hidden = true;
       message.classList.remove('admin-message--success', 'admin-message--error');
 
-      // Derive API URL from the page's API configuration
-      var apiBase = '';
-      var feedbackBtn = document.querySelector('.feedback-btn[data-api-url]');
-      if (feedbackBtn) {
-        apiBase = feedbackBtn.dataset.apiUrl.replace(/\/feedback$/, '');
-      }
-      var verifyUrl = apiBase ? apiBase + '/verify-admin' : '/verify-admin';
+      var base = apiBase();
+      var verifyUrl = base ? base + '/verify-admin' : '/verify-admin';
 
       fetch(verifyUrl, {
         method: 'POST',
@@ -151,6 +156,109 @@
           message.classList.add('admin-message--error');
           message.hidden = false;
         });
+    };
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var token = (input.value || '').trim();
+      if (!token) return;
+      activateToken(token);
+    });
+
+    // ── Activation links (02-§106.14–106.16) ────────────────────────────────
+    // The token arrives in the #fragment — never a ?query — so it is not
+    // sent to the server or leaked via Referer. The fragment is cleared from
+    // the address bar whether or not activation succeeds.
+    var hashMatch = location.hash.match(/[#&]token=([^&]+)/);
+    if (hashMatch) {
+      var incoming = decodeURIComponent(hashMatch[1]);
+      history.replaceState(null, '', location.pathname + location.search);
+      input.value = incoming;
+      activateToken(incoming);
+    }
+  }
+
+  // ── Mint UI (only on /token.html, superadmin only — 02-§106.9–106.13) ──────
+  // The role check decides visibility only; the server authorises every mint.
+
+  var mintSection = document.getElementById('mint-section');
+  var mintData = getAdminData();
+  if (mintSection && mintData && !isExpired(mintData) && tokenRole(mintData.token) === 'superadmin') {
+    mintSection.hidden = false;
+
+    var mintForm = document.getElementById('mint-form');
+    var mintMessage = document.getElementById('mint-message');
+    var mintRoleSel = document.getElementById('mint-role');
+    var mintDays = document.getElementById('mint-days');
+    var mintResult = document.getElementById('mint-result');
+    var mintLink = document.getElementById('mint-link');
+    var mintCopy = document.getElementById('mint-copy');
+    var mintShare = document.getElementById('mint-share');
+
+    var showMintMessage = function (text, ok) {
+      mintMessage.textContent = text;
+      mintMessage.className = 'admin-message ' + (ok ? 'admin-message--success' : 'admin-message--error');
+      mintMessage.hidden = false;
+    };
+
+    // Role change updates the day field's default and maximum (02-§106.10).
+    mintRoleSel.addEventListener('change', function () {
+      var opt = mintRoleSel.options[mintRoleSel.selectedIndex];
+      var days = (opt && opt.dataset.days) || '60';
+      mintDays.max = days;
+      mintDays.value = days;
+    });
+
+    mintForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+      mintMessage.hidden = true;
+      mintResult.hidden = true;
+
+      var base = apiBase();
+      fetch(base ? base + '/mint-token' : '/mint-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token: mintData.token,
+          name: document.getElementById('mint-name').value,
+          role: mintRoleSel.value,
+          days: parseInt(mintDays.value, 10),
+        }),
+      })
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+          if (!data.success || !data.token) {
+            showMintMessage(data.error || 'Kunde inte skapa token. Försök igen.', false);
+            return;
+          }
+          // Activation link with the token in the fragment (02-§106.11, §106.16).
+          mintLink.value = location.origin + '/token.html#token=' + encodeURIComponent(data.token);
+          mintResult.hidden = false;
+          if (navigator.share) mintShare.hidden = false;
+          showMintMessage('Länk skapad. Dela den privat med mottagaren.', true);
+        })
+        .catch(function () {
+          showMintMessage('Kunde inte skapa token. Kontrollera din anslutning.', false);
+        });
+    });
+
+    mintCopy.addEventListener('click', function () {
+      var fallbackCopy = function () {
+        mintLink.select();
+        try { document.execCommand('copy'); showMintMessage('Länken är kopierad.', true); } catch { /* ignore */ }
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(mintLink.value).then(function () {
+          showMintMessage('Länken är kopierad.', true);
+        }, fallbackCopy);
+      } else {
+        fallbackCopy();
+      }
+    });
+
+    mintShare.addEventListener('click', function () {
+      navigator.share({ title: 'SB Sommar – aktivera din token', url: mintLink.value })
+        .catch(function () { /* user cancelled the share sheet */ });
     });
   }
 

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -145,6 +145,7 @@
             message.hidden = false;
             if (removeBtn) removeBtn.hidden = false;
             renderFooterIcon();
+            initMintSection();
           } else {
             message.textContent = data.error || 'Ogiltig token. Försök igen.';
             message.classList.add('admin-message--error');
@@ -180,10 +181,14 @@
 
   // ── Mint UI (only on /token.html, superadmin only — 02-§106.9–106.13) ──────
   // The role check decides visibility only; the server authorises every mint.
+  // Runs at load and again after a successful activation, so a superadmin who
+  // just activated sees the section without reloading.
 
-  var mintSection = document.getElementById('mint-section');
-  var mintData = getAdminData();
-  if (mintSection && mintData && !isExpired(mintData) && tokenRole(mintData.token) === 'superadmin') {
+  function initMintSection() {
+    var mintSection = document.getElementById('mint-section');
+    if (!mintSection || !mintSection.hidden) return;
+    var mintData = getAdminData();
+    if (!mintData || isExpired(mintData) || tokenRole(mintData.token) !== 'superadmin') return;
     mintSection.hidden = false;
 
     var mintForm = document.getElementById('mint-form');
@@ -261,6 +266,8 @@
         .catch(function () { /* user cancelled the share sheet */ });
     });
   }
+
+  initMintSection();
 
   // Run footer icon on page load
   renderFooterIcon();

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -219,12 +219,16 @@
       mintMessage.hidden = true;
       mintResult.hidden = true;
 
+      // Read the stored token fresh on every mint, in case it was replaced
+      // since the section was revealed. The server is the real gate.
+      var stored = getAdminData() || {};
+
       var base = apiBase();
       fetch(base ? base + '/mint-token' : '/mint-token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          token: mintData.token,
+          token: stored.token,
           name: document.getElementById('mint-name').value,
           role: mintRoleSel.value,
           days: parseInt(mintDays.value, 10),

--- a/source/build/render-admin.js
+++ b/source/build/render-admin.js
@@ -34,6 +34,31 @@ ${nav}
       </form>
       <button type="button" id="admin-remove" class="btn btn--secondary admin-remove" hidden>Ta bort min token</button>
     </div>
+    <div id="mint-section" class="admin-form" hidden>
+      <h2>Skapa token-länk</h2>
+      <p class="admin-intro">Skapa en aktiveringslänk för en ny token och dela den med mottagaren. Superadmin kan inte skapas här.</p>
+      <p id="mint-message" class="admin-message" aria-live="polite" hidden></p>
+      <form id="mint-form">
+        <label for="mint-name">Namn på mottagaren</label>
+        <input type="text" id="mint-name" name="name" required autocomplete="off">
+        <label for="mint-role">Roll</label>
+        <select id="mint-role" name="role">
+          <option value="admin" data-days="60">Admin (max 60 dagar)</option>
+          <option value="early" data-days="90">Tidig åtkomst (max 90 dagar)</option>
+        </select>
+        <label for="mint-days">Giltighetstid (dagar)</label>
+        <input type="number" id="mint-days" name="days" min="1" max="60" value="60" required>
+        <button type="submit" class="btn btn--primary">Skapa länk</button>
+      </form>
+      <div id="mint-result" class="mint-result" hidden>
+        <label for="mint-link">Aktiveringslänk – dela privat med mottagaren</label>
+        <input type="text" id="mint-link" readonly>
+        <div class="mint-actions">
+          <button type="button" id="mint-copy" class="btn btn--secondary">Kopiera länken</button>
+          <button type="button" id="mint-share" class="btn btn--secondary" hidden>Dela …</button>
+        </div>
+      </div>
+    </div>
   </main>
 ${footer}
   <script src="admin.js"></script>

--- a/source/scripts/create-admin-token.js
+++ b/source/scripts/create-admin-token.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const readline = require('readline');
-const { signToken } = require('../api/admin');
+const { signToken, sanitizeTokenName } = require('../api/admin');
 
 // Validity per role, in days (02-§91.30, 02-§105.6).
 const ROLE_DAYS = { admin: 60, early: 90, superadmin: 180 };
@@ -44,8 +44,8 @@ async function main() {
 
   const rawName = await ask('Namn på mottagaren: ');
   // Hyphen-separated identifier, no underscores (underscore is the token
-  // field delimiter, so the name must never contain one).
-  const name = rawName.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-zåäö0-9-]/g, '');
+  // field delimiter). Same sanitiser as the /mint-token endpoint (02-§106.4).
+  const name = sanitizeTokenName(rawName);
   if (!name) {
     console.error('\nFel: namn krävs (a-ö, siffror, bindestreck).');
     rl.close();

--- a/tests/mint-token.test.js
+++ b/tests/mint-token.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// Tests for web token minting (superadmin) — 02-§106.
+//
+// Testable in Node.js:
+//   - sanitizeTokenName (MINT-01)
+//   - mintRequest: happy path, defaults, caps, whitelist, signing
+//     (MINT-02..08); PHP behavioural parity lives in
+//     api/tests/MintTokenTest.php with the same fixed inputs
+//   - superadmin gate predicate (MINT-09..10)
+//   - structural route/UI wiring (MINT-11..15)
+//
+// Browser-only (manual checkpoints documented in traceability):
+//   - 02-§106.9: mint section visible only with a superadmin token
+//   - 02-§106.12: copy button; share button only when navigator.share exists
+//   - 02-§106.14..15: hash redemption activates and clears the fragment
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+
+const {
+  signToken,
+  verifyToken,
+  mintRequest,
+  sanitizeTokenName,
+} = require('../source/api/admin');
+
+const SECRET = 'mint-token-test-secret-32-bytes!';
+const NOW = 2000000000; // fixed, mirrored in api/tests/MintTokenTest.php
+const DAY = 86400;
+
+// ── Name sanitisation (02-§106.4) ────────────────────────────────────────────
+
+describe('sanitizeTokenName (02-§106.4)', () => {
+  it('MINT-01: lowercases, hyphenates whitespace, strips invalid chars incl. underscore', () => {
+    assert.strictEqual(sanitizeTokenName('Anna Söder'), 'anna-söder');
+    assert.strictEqual(sanitizeTokenName('  Erik  Ek  '), 'erik-ek');
+    assert.strictEqual(sanitizeTokenName('a_b!c?d'), 'abcd');
+    assert.strictEqual(sanitizeTokenName('ÅSA'), 'åsa');
+    assert.strictEqual(sanitizeTokenName('___'), '');
+    assert.strictEqual(sanitizeTokenName(''), '');
+    assert.strictEqual(sanitizeTokenName(null), '');
+  });
+});
+
+// ── mintRequest (02-§106.3–106.6) ────────────────────────────────────────────
+
+describe('mintRequest (02-§106.3–106.6)', () => {
+  it('MINT-02: mints admin with the 60-day default and a verifiable token', () => {
+    const r = mintRequest({ name: 'Anna Söder', role: 'admin' }, SECRET, NOW);
+    assert.strictEqual(r.ok, true);
+    assert.deepStrictEqual(verifyToken(r.token, SECRET),
+      { name: 'anna-söder', role: 'admin', epoch: NOW + 60 * DAY });
+  });
+
+  it('MINT-03: mints early with the 90-day default', () => {
+    const r = mintRequest({ name: 'erik', role: 'early' }, SECRET, NOW);
+    assert.strictEqual(r.ok, true);
+    assert.deepStrictEqual(verifyToken(r.token, SECRET),
+      { name: 'erik', role: 'early', epoch: NOW + 90 * DAY });
+  });
+
+  it('MINT-04: honours an explicit days value within range', () => {
+    const r = mintRequest({ name: 'erik', role: 'admin', days: 7 }, SECRET, NOW);
+    assert.strictEqual(verifyToken(r.token, SECRET).epoch, NOW + 7 * DAY);
+  });
+
+  it('MINT-05: rejects days outside 1..cap (60 admin / 90 early) or non-integer', () => {
+    for (const [role, days] of [['admin', 0], ['admin', 61], ['early', 91], ['admin', -5], ['admin', 2.5], ['admin', 'nan']]) {
+      const r = mintRequest({ name: 'erik', role, days }, SECRET, NOW);
+      assert.strictEqual(r.ok, false, `${role}/${days} should be rejected`);
+      assert.ok(r.error, 'expected an error message');
+    }
+  });
+
+  it('MINT-06: whitelist — superadmin and unknown roles are rejected (02-§106.3)', () => {
+    assert.strictEqual(mintRequest({ name: 'x', role: 'superadmin' }, SECRET, NOW).ok, false);
+    assert.strictEqual(mintRequest({ name: 'x', role: 'root' }, SECRET, NOW).ok, false);
+    assert.strictEqual(mintRequest({ name: 'x', role: '' }, SECRET, NOW).ok, false);
+  });
+
+  it('MINT-07: rejects a name that is empty after sanitisation', () => {
+    assert.strictEqual(mintRequest({ name: '!!!', role: 'admin' }, SECRET, NOW).ok, false);
+    assert.strictEqual(mintRequest({ role: 'admin' }, SECRET, NOW).ok, false);
+  });
+
+  it('MINT-08: minted token is byte-identical to signToken over the sanitised claims (cross-runtime vector)', () => {
+    const r = mintRequest({ name: 'Anna Söder', role: 'admin' }, SECRET, NOW);
+    assert.strictEqual(r.token, signToken('anna-söder', 'admin', NOW + 60 * DAY, SECRET));
+  });
+});
+
+// ── Superadmin gate (02-§106.2, §106.8) ──────────────────────────────────────
+
+// Mirrors the gate predicate the /mint-token routes use.
+function isMintAuthorised(candidate, secret) {
+  const requester = verifyToken(candidate, secret);
+  return !!requester && requester.role === 'superadmin';
+}
+
+describe('mint gate requires superadmin (02-§106.2, §106.8)', () => {
+  const future = Math.floor(Date.now() / 1000) + DAY;
+
+  it('MINT-09: superadmin authorised; admin/early/garbage are not', () => {
+    assert.strictEqual(isMintAuthorised(signToken('s', 'superadmin', future, SECRET), SECRET), true);
+    assert.strictEqual(isMintAuthorised(signToken('a', 'admin', future, SECRET), SECRET), false);
+    assert.strictEqual(isMintAuthorised(signToken('e', 'early', future, SECRET), SECRET), false);
+    assert.strictEqual(isMintAuthorised('garbage', SECRET), false);
+    assert.strictEqual(isMintAuthorised(undefined, SECRET), false);
+  });
+
+  it('MINT-10: unset secret fails closed', () => {
+    assert.strictEqual(isMintAuthorised(signToken('s', 'superadmin', future, SECRET), ''), false);
+  });
+});
+
+// ── Structural wiring ────────────────────────────────────────────────────────
+
+describe('mint route wiring (02-§106.1, §106.2, §106.7)', () => {
+  it('MINT-11: app.js exposes a rate-limited /mint-token requiring superadmin', () => {
+    const node = read('app.js');
+    assert.match(node, /app\.post\('\/mint-token', mintTokenLimiter/);
+    const route = node.slice(node.indexOf("app.post('/mint-token'"));
+    assert.match(route.slice(0, 700), /'superadmin'/);
+    assert.match(route.slice(0, 700), /mintRequest\(/);
+  });
+
+  it('MINT-12: api/index.php exposes a rate-limited /mint-token requiring superadmin', () => {
+    const php = read('api/index.php');
+    assert.match(php, /\$route === '\/mint-token'/);
+    const handler = php.slice(php.indexOf('function handleMintToken'));
+    assert.match(handler.slice(0, 900), /RateLimit::isLimited\(clientIp\(\), 'mint-token'/);
+    assert.match(handler.slice(0, 1200), /'superadmin'/);
+    assert.match(handler.slice(0, 1500), /Admin::mintRequest\(/);
+  });
+
+  it('MINT-13: Admin.php exposes mintRequest and the CLI reuses the shared sanitiser', () => {
+    assert.match(read('api/src/Admin.php'), /function\s+mintRequest\b/);
+    assert.match(read('source/scripts/create-admin-token.js'), /sanitizeTokenName/);
+  });
+});
+
+describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
+  it('MINT-14: token page markup contains the hidden mint section and result row', () => {
+    const { renderAdminPage } = require('../source/build/render-admin');
+    const html = renderAdminPage({ name: 'SB Sommar 2026' }, '<p>f</p>');
+    assert.match(html, /id="mint-section"[^>]*hidden/);
+    assert.match(html, /id="mint-name"/);
+    assert.match(html, /id="mint-role"/);
+    assert.match(html, /id="mint-days"/);
+    assert.match(html, /id="mint-link"/);
+    assert.match(html, /id="mint-copy"/);
+    assert.match(html, /id="mint-share"[^>]*hidden/);
+    assert.match(html, /Tidig åtkomst/);
+  });
+
+  it('MINT-15: admin.js gates the mint UI on the superadmin role and redeems hash tokens', () => {
+    const src = read('source/assets/js/client/admin.js');
+    assert.match(src, /'superadmin'/);
+    assert.match(src, /location\.hash/);
+    assert.match(src, /history\.replaceState/);
+    assert.match(src, /#token=/);
+    assert.match(src, /navigator\.share/);
+    assert.doesNotMatch(src, /\?token=/, 'redemption must use the fragment, not a query parameter');
+  });
+});


### PR DESCRIPTION
## Sammanfattning

- **Self-service mint-UI för tokens** (WP3 av token-arbetet, se #391): en superadmin skapar `admin`/`early`-tokens direkt från webben och delar en aktiveringslänk — utan terminal, miljöändring eller omdeploy
- `POST /mint-token` i Node (`app.js`) och PHP (`api/index.php`): kräver giltig **superadmin**-token (annars 403), myntar **endast** `admin`/`early` (superadmin förblir CLI-only), giltighetstid begränsad till rollens standardtid (60/90 dagar), hastighetsbegränsad 5/h per IP, statslös — inget lagras
- Delad logik `mintRequest`/`sanitizeTokenName` i `source/api/admin.js` + `api/src/Admin.php`; CLI:t återanvänder samma namnsanerare
- `/token.html`: "Skapa token-länk"-sektion synlig endast med aktiv superadmin-token (klientkollen styr bara synlighet — servern är grinden); formulär namn/roll/dagar, kopiera-knapp och dela-knapp (`navigator.share`)
- Inlösen: `/token.html` läser `#token=`-fragmentet, verifierar via `/verify-admin`, lagrar som vid manuell aktivering och rensar fragmentet med `history.replaceState`; fragment — aldrig query — så token når varken serverloggar eller Referer
- Docs: kravsektion 02-§106, arkitektur §30 (Self-service minting), OPERATIONS (utfärdande via webben), traceability + test-id-legend

## Testplan

- [x] 15 nya tester i `tests/mint-token.test.js` (MINT-01..15): sanering, dagtak/whitelist, superadmin-grind, route/UI-koppling
- [x] PHPUnit-paritet i `api/tests/MintTokenTest.php` (samma fasta indata → byte-identiska tokens i båda runtimes)
- [x] Hela sviten grön: 1879 Node-tester, 68 PHP-tester; eslint/stylelint/markdownlint/html-validate/bygge gröna
- [x] HTTP-verifierat lokalt: superadmin myntar → mottagartoken validerar; admin-token 403; superadmin-roll 400; >tak dagar 400
- [ ] Manuella browser-checkpoints (traceability §106): sektionens synlighet per roll, rollstyrt dagfält, kopiera/dela, fragmentinlösen + rensad adressrad

Closes #391

https://claude.ai/code/session_01P9hDRrudY6qi1XpJtpEGmx

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9hDRrudY6qi1XpJtpEGmx)_