### PR TITLE
fix: hide mint section from non-superadmins, show token role/rights

### DIFF
--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -637,12 +637,13 @@ reuses the format, signing, and activation flow described here.
   - Do not store anything.
   - Show an error message (in Swedish).
 - When a valid (unexpired) token is stored, the activation page's status
-  message names the token's recipient and role and states, in Swedish, what
-  that role allows. The recipient is the token's first underscore-segment and
-  the role is its second segment (`namn_roll_epoch_sig`), both read
-  client-side. The message also retains the token's expiry date, its
-  activation time, and the note that a new token can be entered below to
-  replace it. The rights phrasing per role is: <!-- 02-§91.33 -->
+  message leads with the role as a bold title on its own line, formatted
+  `Roll: <label>` (`Superadmin`, `Admin`, or `Tidig åtkomst`), and states
+  below it, in Swedish, what that role allows. The role is the token's second
+  underscore-segment (`namn_roll_epoch_sig`), read client-side. The body
+  below the title retains the token's expiry date, its activation time, and
+  the note that a new token can be entered below to replace it. The recipient
+  name in the token is not shown. The rights phrasing per role is: <!-- 02-§91.33 -->
   - `superadmin`: may edit all activities, open the form before the camp
     opens, and create new token links.
   - `admin`: may edit all activities and open the form before it opens for

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -636,6 +636,19 @@ reuses the format, signing, and activation flow described here.
 - If the server responds with `valid: false`: <!-- 02-§91.13 -->
   - Do not store anything.
   - Show an error message (in Swedish).
+- When a valid (unexpired) token is stored, the activation page's status
+  message names the token's recipient and role and states, in Swedish, what
+  that role allows. The recipient is the token's first underscore-segment and
+  the role is its second segment (`namn_roll_epoch_sig`), both read
+  client-side. The message also retains the token's expiry date, its
+  activation time, and the note that a new token can be entered below to
+  replace it. The rights phrasing per role is: <!-- 02-§91.33 -->
+  - `superadmin`: may edit all activities, open the form before the camp
+    opens, and create new token links.
+  - `admin`: may edit all activities and open the form before it opens for
+    everyone.
+  - `early`: may add and edit their own activities before the form opens for
+    everyone.
 - The page must use the same layout (header, navigation, footer) as
   other site pages. <!-- 02-§91.14 -->
 - The page must not be listed in the site navigation. <!-- 02-§91.15 -->

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -302,16 +302,19 @@ On submit, it calls `POST /verify-admin`. If valid, the token and
 timestamp are stored in `localStorage`. The page shares the site layout
 (header, navigation, footer) but is **not listed in the navigation**.
 
-When a valid token is already stored, the status message names the
-recipient and role — read client-side from the token's first two
-underscore-segments — and states in Swedish what the role allows:
+When a valid token is already stored, the status message leads with the
+role as a bold title (`Roll: <label>`, a `.admin-message-title` `<strong>`
+on its own line) — read client-side from the token's second
+underscore-segment — and states below it in Swedish what the role allows:
 `superadmin` may edit all activities, open the form before the camp opens,
 and mint token links; `admin` may edit all activities and open the form
 early; `early` may add and edit their own activities before the form opens
-(02-§91.33). A `roleDescription(role)` helper in `admin.js` maps the role
-to its Swedish rights sentence; the message retains the token's expiry
-date, its activation time, and the note that a new token can be entered
-below to replace it.
+(02-§91.33). A `roleDescription(role)` helper in `admin.js` maps the role to
+its Swedish rights sentence, and `setStatusWithRole()` builds the message
+with DOM nodes (no `innerHTML` on this token-bearing page); the body retains
+the token's expiry date, its activation time, and the note that a new token
+can be entered below to replace it. The recipient name in the token is not
+displayed.
 
 ### Footer status indicator
 

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -259,8 +259,15 @@ signing — so the Node and PHP routes stay thin and behave identically. The
 CLI reuses the same sanitiser.
 
 The mint UI is a section on `/token.html` (rendered hidden by
-`render-admin.js`, revealed by `admin.js` when the stored token's role is
-`superadmin`). It builds an activation link
+`render-admin.js`, revealed by `admin.js` only when the stored token's role
+is `superadmin`). The section carries the `.admin-form` class, which sets
+`display: flex`; because an author `display` rule overrides the user-agent
+`[hidden] { display: none }`, an explicit `.admin-form[hidden] { display:
+none }` rule in `style.css` keeps the `hidden` attribute authoritative, so
+the section stays invisible to every non-superadmin (02-§106.9). Visibility
+is cosmetic regardless — the server gates each mint — but without the
+override the form would render for all visitors. It builds an activation
+link
 `<site-origin>/token.html#token=<token>` with copy and `navigator.share`
 buttons. On load the same page redeems incoming links: it reads
 `location.hash`, posts the value to `/verify-admin`, stores it like a
@@ -294,6 +301,17 @@ client-side. An expired token behaves as if no token exists.
 On submit, it calls `POST /verify-admin`. If valid, the token and
 timestamp are stored in `localStorage`. The page shares the site layout
 (header, navigation, footer) but is **not listed in the navigation**.
+
+When a valid token is already stored, the status message names the
+recipient and role — read client-side from the token's first two
+underscore-segments — and states in Swedish what the role allows:
+`superadmin` may edit all activities, open the form before the camp opens,
+and mint token links; `admin` may edit all activities and open the form
+early; `early` may add and edit their own activities before the form opens
+(02-§91.33). A `roleDescription(role)` helper in `admin.js` maps the role
+to its Swedish rights sentence; the message retains the token's expiry
+date, its activation time, and the note that a new token can be entered
+below to replace it.
 
 ### Footer status indicator
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1251,7 +1251,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.30` | implemented | `npm run admin:create` signs offline for `admin`/`early`/`superadmin` (60/90/180 days); manual: minted token round-trips |
 | `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
-| `02-§91.33` | gap | TOK-23 (planned): `roleDescription()` maps superadmin/admin/early to Swedish rights text; manual: open /token.html with each role and confirm status names recipient, role, and rights |
+| `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |
@@ -1606,7 +1606,7 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 | `02-§106.6` | covered | MINT-02, MINT-08 + PHPUnit parity vector: token = `signToken(sanitised, role, now+days·86400)`; handlers return it without storing |
 | `02-§106.7` | covered | MINT-11, MINT-12: `mintTokenLimiter` (5/h) in `app.js`; `RateLimit::isLimited(.., 'mint-token', 5, 3600)` in PHP |
 | `02-§106.8` | covered | MINT-10: empty secret → no requester verifies → gate false (403) |
-| `02-§106.9` | implemented | MINT-15 (structural: role gate in `admin.js`); manual: open /token.html with superadmin vs admin token and confirm section visibility |
+| `02-§106.9` | covered | MINT-15 (structural: role gate in `admin.js`), MINT-16 (`.admin-form[hidden]` override keeps `hidden` authoritative since `.admin-form` sets display); manual: open /token.html with superadmin vs admin token and confirm section visibility |
 | `02-§106.10` | implemented | MINT-14 (markup: name/role/days with data-days); manual: switch role and confirm day default/max follows (60↔90) |
 | `02-§106.11` | implemented | MINT-15 (structural: `#token=` link build); manual: mint and confirm the link format |
 | `02-§106.12` | implemented | MINT-14 (markup: copy button, share hidden by default); manual: share button appears only when navigator.share exists |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1251,6 +1251,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.30` | implemented | `npm run admin:create` signs offline for `admin`/`early`/`superadmin` (60/90/180 days); manual: minted token round-trips |
 | `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
+| `02-§91.33` | gap | TOK-23 (planned): `roleDescription()` maps superadmin/admin/early to Swedish rights text; manual: open /token.html with each role and confirm status names recipient, role, and rights |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2850,6 +2850,11 @@ body.modal-open {
   gap: var(--space-sm);
 }
 
+/* `.admin-form` sets display, which defeats the `hidden` attribute; restore
+   display:none so the superadmin-only mint section stays hidden until
+   `admin.js` reveals it (02-§106.9). */
+.admin-form[hidden] { display: none; }
+
 .admin-form label {
   display: block;
   margin-bottom: var(--space-xs);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2902,6 +2902,14 @@ body.modal-open {
 .admin-message--success { color: var(--color-sage-hover); }
 .admin-message--error { color: var(--color-error); }
 
+/* Role shown as a bold title on its own line above the status body
+   (02-§91.33). `display: block` puts the following body text underneath. */
+.admin-message-title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
 .admin-remove {
   align-self: flex-start;
 }

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -70,10 +70,43 @@
     return token.split('_')[1] || null;
   }
 
+  // Swedish description of what each role allows, shown in the active-token
+  // status (02-§91.33). An unrecognised or missing role yields '' — the status
+  // still renders, it simply omits the rights sentence. The server, not this
+  // text, enforces every privilege.
+  function roleDescription(role) {
+    switch (role) {
+      case 'superadmin':
+        return 'Du kan ändra alla aktiviteter, öppna formuläret innan lägret öppnar och skapa nya token-länkar.';
+      case 'admin':
+        return 'Du kan ändra alla aktiviteter och öppna formuläret innan det öppnar för alla.';
+      case 'early':
+        return 'Du kan lägga till och ändra dina egna aktiviteter innan formuläret öppnar för alla.';
+      default:
+        return '';
+    }
+  }
+
   // Derive the API base URL from the page's API configuration.
   function apiBase() {
     var feedbackBtn = document.querySelector('.feedback-btn[data-api-url]');
     return feedbackBtn ? feedbackBtn.dataset.apiUrl.replace(/\/feedback$/, '') : '';
+  }
+
+  // ── Node export (tests) ─────────────────────────────────────────────────────
+  // In Node there is no DOM: export the pure helpers and stop before any DOM
+  // wiring runs. In the browser `document` exists, so this branch is skipped and
+  // the page wiring below executes as normal. Mirrors markdown-toolbar.js.
+  if (typeof document === 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      module.exports = {
+        roleDescription: roleDescription,
+        tokenRole: tokenRole,
+        extractExpiry: extractExpiry,
+        isExpired: isExpired,
+      };
+    }
+    return;
   }
 
   // ── Activation form (only on /token.html) ──────────────────────────────────
@@ -88,13 +121,27 @@
     // Pre-fill status if already activated
     var existing = getAdminData();
 
+    // Swedish label per role, paired with the rights sentence and appended to
+    // any "token is active" message so the holder sees which token they have
+    // and what it allows (02-§91.33). Role and recipient come from the token
+    // string (namn_roll_epoch_sig).
+    var ROLE_LABELS = { superadmin: 'Superadmin', admin: 'Admin', early: 'Tidig åtkomst' };
+    var rightsSuffix = function (token) {
+      var label = ROLE_LABELS[tokenRole(token)] || '';
+      var rights = roleDescription(tokenRole(token));
+      return (label ? ' Roll: ' + label + '.' : '') + (rights ? ' ' + rights : '');
+    };
+
     if (existing && !isExpired(existing)) {
       var expiry = extractExpiry(existing.token);
       var expiryDate = expiry ? new Date(expiry * 1000).toLocaleDateString('sv-SE') : '';
       var activatedAt = existing.activated ? new Date(existing.activated).toLocaleString('sv-SE') : '';
-      message.textContent = 'Din token är aktiv' + (expiryDate ? ' till ' + expiryDate : '')
+      var recipient = (existing.token.split('_')[0]) || '';
+      message.textContent = 'Din token' + (recipient ? ' (' + recipient + ')' : '') + ' är aktiv'
+        + (expiryDate ? ' till ' + expiryDate : '')
         + (activatedAt ? ' (aktiverad ' + activatedAt + ')' : '')
-        + '. Du kan byta genom att ange en ny token nedan.';
+        + '.' + rightsSuffix(existing.token)
+        + ' Du kan byta genom att ange en ny token nedan.';
       message.hidden = false;
       message.classList.add('admin-message--success');
     } else if (existing && isExpired(existing)) {
@@ -140,7 +187,7 @@
               token: token,
               activated: Date.now(),
             }));
-            message.textContent = 'Token aktiverad ' + new Date().toLocaleString('sv-SE') + '.';
+            message.textContent = 'Token aktiverad ' + new Date().toLocaleString('sv-SE') + '.' + rightsSuffix(token);
             message.classList.add('admin-message--success');
             message.hidden = false;
             if (removeBtn) removeBtn.hidden = false;

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -121,27 +121,36 @@
     // Pre-fill status if already activated
     var existing = getAdminData();
 
-    // Swedish label per role, paired with the rights sentence and appended to
-    // any "token is active" message so the holder sees which token they have
-    // and what it allows (02-§91.33). Role and recipient come from the token
-    // string (namn_roll_epoch_sig).
+    // Render the active-token status into the message element: a bold
+    // "Roll: <label>" title on top, then the body text below (02-§91.33).
+    // The label and rights come from the token's role (namn_roll_epoch_sig);
+    // an unrecognised role omits both the title and the rights sentence.
+    // Used on load and after a successful activation so both lead with the
+    // role. Built with DOM nodes, not innerHTML — no string is interpolated
+    // into markup on this token-bearing page.
     var ROLE_LABELS = { superadmin: 'Superadmin', admin: 'Admin', early: 'Tidig åtkomst' };
-    var rightsSuffix = function (token) {
+    var setStatusWithRole = function (token, body) {
       var label = ROLE_LABELS[tokenRole(token)] || '';
-      var rights = roleDescription(tokenRole(token));
-      return (label ? ' Roll: ' + label + '.' : '') + (rights ? ' ' + rights : '');
+      message.textContent = '';
+      if (label) {
+        var title = document.createElement('strong');
+        title.className = 'admin-message-title';
+        title.textContent = 'Roll: ' + label;
+        message.appendChild(title);
+      }
+      message.appendChild(document.createTextNode(body));
     };
 
     if (existing && !isExpired(existing)) {
       var expiry = extractExpiry(existing.token);
       var expiryDate = expiry ? new Date(expiry * 1000).toLocaleDateString('sv-SE') : '';
       var activatedAt = existing.activated ? new Date(existing.activated).toLocaleString('sv-SE') : '';
-      var recipient = (existing.token.split('_')[0]) || '';
-      message.textContent = 'Din token' + (recipient ? ' (' + recipient + ')' : '') + ' är aktiv'
+      var rights = roleDescription(tokenRole(existing.token));
+      setStatusWithRole(existing.token, 'Din token är aktiv'
         + (expiryDate ? ' till ' + expiryDate : '')
         + (activatedAt ? ' (aktiverad ' + activatedAt + ')' : '')
-        + '.' + rightsSuffix(existing.token)
-        + ' Du kan byta genom att ange en ny token nedan.';
+        + '.' + (rights ? ' ' + rights : '')
+        + ' Du kan byta genom att ange en ny token nedan.');
       message.hidden = false;
       message.classList.add('admin-message--success');
     } else if (existing && isExpired(existing)) {
@@ -187,7 +196,9 @@
               token: token,
               activated: Date.now(),
             }));
-            message.textContent = 'Token aktiverad ' + new Date().toLocaleString('sv-SE') + '.' + rightsSuffix(token);
+            var actRights = roleDescription(tokenRole(token));
+            setStatusWithRole(token, 'Token aktiverad ' + new Date().toLocaleString('sv-SE') + '.'
+              + (actRights ? ' ' + actRights : ''));
             message.classList.add('admin-message--success');
             message.hidden = false;
             if (removeBtn) removeBtn.hidden = false;

--- a/tests/mint-token.test.js
+++ b/tests/mint-token.test.js
@@ -167,4 +167,14 @@ describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
     assert.match(src, /navigator\.share/);
     assert.doesNotMatch(src, /\?token=/, 'redemption must use the fragment, not a query parameter');
   });
+
+  it('MINT-16: style.css keeps [hidden] authoritative for .admin-form (02-§106.9)', () => {
+    // The mint section is `<div id="mint-section" class="admin-form" hidden>`.
+    // `.admin-form { display: flex }` would defeat the `hidden` attribute
+    // (an author display rule beats the UA `[hidden] { display: none }`),
+    // so an explicit override is required for the role gate to hide the
+    // section from non-superadmins. Without it the form renders for everyone.
+    const css = read('source/assets/cs/style.css');
+    assert.match(css, /\.admin-form\[hidden\]\s*\{\s*display:\s*none/);
+  });
 });

--- a/tests/token-status.test.js
+++ b/tests/token-status.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Tests for the admin token status message: role-aware rights text (02-§91.33).
+//
+// Testable in Node.js:
+//   - tokenRole(): reads the role from the token string (TOK-23)
+//   - roleDescription(): maps each role to its Swedish rights sentence (TOK-24)
+//
+// Browser-only (manual checkpoint in traceability):
+//   - 02-§91.33: the on-page status names the recipient and renders the
+//     rights sentence — open /token.html with each role and confirm.
+//
+// admin.js is a browser IIFE that skips its DOM wiring when `document` is
+// undefined (Node) and exports its pure helpers, so they can be required here.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { roleDescription, tokenRole } = require('../source/assets/js/client/admin.js');
+
+describe('token status rights text (02-§91.33)', () => {
+  it('TOK-23: tokenRole reads the role from namn_roll_epoch_sig', () => {
+    assert.strictEqual(tokenRole('anna_admin_1750000000_abc'), 'admin');
+    assert.strictEqual(tokenRole('bo_early_1750000000_xyz'), 'early');
+    assert.strictEqual(tokenRole('cli_superadmin_1750000000_sig'), 'superadmin');
+    assert.strictEqual(tokenRole(''), null);
+    assert.strictEqual(tokenRole(null), null);
+  });
+
+  it('TOK-24: roleDescription maps each role to its Swedish rights sentence', () => {
+    const su = roleDescription('superadmin');
+    assert.match(su, /alla aktiviteter/i);
+    assert.match(su, /innan lägret öppnar/i);
+    assert.match(su, /token-länk/i);
+
+    const ad = roleDescription('admin');
+    assert.match(ad, /alla aktiviteter/i);
+    assert.match(ad, /innan det öppnar/i);
+    assert.doesNotMatch(ad, /token-länk/i);
+
+    const ea = roleDescription('early');
+    assert.match(ea, /egna aktiviteter/i);
+    assert.match(ea, /innan formuläret öppnar/i);
+    assert.doesNotMatch(ea, /alla aktiviteter/i);
+
+    // An unrecognised or missing role yields no rights text — the status
+    // still works, it simply omits the sentence.
+    assert.strictEqual(roleDescription('whatever'), '');
+    assert.strictEqual(roleDescription(null), '');
+  });
+});


### PR DESCRIPTION
## Summary

Two cleanups to the token page (`/token.html`), both fixing gaps left by the recent token PRs.

- **Mint-section leak (§106.9).** `#mint-section` is `class="admin-form" hidden`, but `.admin-form { display: flex }` defeated the `hidden` attribute (an author `display` rule beats the UA `[hidden] { display: none }`), so the "Skapa token-länk" UI rendered for **every** visitor regardless of role. The superadmin role gate in `admin.js` only ever sets `hidden = false`, so it could not hide the already-visible section. Added `.admin-form[hidden] { display: none }` so the gate is authoritative. The server already rejected every non-superadmin mint; this closes the UI exposure.
- **Token role & rights in status (§91.33, new requirement).** The active-token status now leads with the role as a bold title on its own line (`Roll: Admin` / `Roll: Tidig åtkomst` / `Roll: Superadmin`) and states in Swedish what that role allows, below it. The recipient name in the token is not shown. `admin.js` gains a `roleDescription()` helper and a `typeof document` guard that exports its pure helpers for unit testing (mirrors `markdown-toolbar.js`).

## Phases

Followed the full lifecycle (Phase 0–7): alignment → requirements (§91.33) → docs/traceability → tests → implementation → two rounds of local review by the maintainer (recipient removed, role promoted to a bold title) → traceability update → rebase.

## Test plan

- [x] `npm run lint` (ESLint) — clean
- [x] `npm run lint:css` (Stylelint) — clean
- [x] `npm run lint:md` (markdownlint) — clean
- [x] `npm test` — 1882/1882 pass, incl. new **TOK-23/24** (`tokenRole` + `roleDescription`) and **MINT-16** (`.admin-form[hidden]` regression guard)
- [x] Manual (maintainer, in browser): mint section hidden for no-token / admin / early; appears only for superadmin; status shows the bold role title + rights for each role

🤖 Generated with [Claude Code](https://claude.com/claude-code)