### PR TITLE
fix: token page UX — Swedish validation, styling, removal confirm

### DIFF
--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -1437,8 +1437,11 @@ Agreed in #391.
 - Submitting the form sends `POST /mint-token` with the stored superadmin
   token. On success the UI shows an activation link of the form
   `<site-origin>/token.html#token=<token>`. <!-- 02-§106.11 -->
-- The result row has a copy button, and a share button (`navigator.share`)
-  that is displayed only when the browser supports sharing. <!-- 02-§106.12 -->
+- The result row has a copy button that copies the activation link to the
+  clipboard. There is no native share button: the Web Share API
+  (`navigator.share`) is unreliable on desktop — the share sheet often never
+  opens and the failure is silent — so copying the link is the single, clear
+  way to hand it over. <!-- 02-§106.12 -->
 - Error responses are displayed in Swedish in the mint section's message
   area. <!-- 02-§106.13 -->
 - The mint form suppresses native browser validation (`novalidate`) and

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -653,6 +653,9 @@ reuses the format, signing, and activation flow described here.
 - The page must use the same layout (header, navigation, footer) as
   other site pages. <!-- 02-§91.14 -->
 - The page must not be listed in the site navigation. <!-- 02-§91.15 -->
+- The buttons on `/token.html` use the site's standard button styles
+  (`.btn-primary` for primary actions, `.btn-secondary` for secondary
+  actions), so they match the buttons elsewhere on the site. <!-- 02-§91.34 -->
 
 ### 91.5 Token expiry (site requirements)
 
@@ -1430,6 +1433,19 @@ Agreed in #391.
   that is displayed only when the browser supports sharing. <!-- 02-§106.12 -->
 - Error responses are displayed in Swedish in the mint section's message
   area. <!-- 02-§106.13 -->
+- The mint form suppresses native browser validation (`novalidate`) and
+  validates client-side, so no browser-native (non-Swedish) validation
+  messages appear. It uses the same per-field inline-error model as the
+  add-activity form (02-§6.5): an invalid field is marked `aria-invalid`
+  and a Swedish `field-error` message appears beneath it, cleared as soon as
+  the user edits that field. On submit, the first invalid field receives
+  focus. The rules are: the recipient name is required (non-empty after
+  trimming); the validity in days is an integer between 1 and the selected
+  role's maximum. <!-- 02-§106.19 -->
+- The generated activation-link field is read-only and styled to read as
+  output rather than input: a muted background and default cursor
+  distinguish it from the editable form fields, so it is not mistaken for a
+  field to fill in. <!-- 02-§106.20 -->
 
 ### 106.4 Redemption via link (user requirements)
 

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -656,6 +656,14 @@ reuses the format, signing, and activation flow described here.
 - The buttons on `/token.html` use the site's standard button styles
   (`.btn-primary` for primary actions, `.btn-secondary` for secondary
   actions), so they match the buttons elsewhere on the site. <!-- 02-§91.34 -->
+- "Ta bort min token" does not remove the stored token immediately. It opens
+  a confirmation dialog — the site's `.submit-modal` alertdialog pattern, the
+  same one used to delete an activity — that asks the user to confirm. The
+  token is removed only when the user confirms with "Ja, ta bort"; "Avbryt"
+  or the Escape key closes the dialog and keeps the token. Focus moves to the
+  cancel button on open and returns to the trigger on close, and focus is
+  trapped within the dialog. This guards against an accidental
+  click. <!-- 02-§91.35 -->
 
 ### 91.5 Token expiry (site requirements)
 

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -268,8 +268,9 @@ the section stays invisible to every non-superadmin (02-§106.9). Visibility
 is cosmetic regardless — the server gates each mint — but without the
 override the form would render for all visitors. It builds an activation
 link
-`<site-origin>/token.html#token=<token>` with copy and `navigator.share`
-buttons. On load the same page redeems incoming links: it reads
+`<site-origin>/token.html#token=<token>` with a copy button (no native
+share button — `navigator.share` is a silent no-op on desktop). On load the
+same page redeems incoming links: it reads
 `location.hash`, posts the value to `/verify-admin`, stores it like a
 manual activation, and clears the fragment with `history.replaceState`.
 The token travels in the fragment — never a query parameter — so it stays

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -324,6 +324,13 @@ the token's expiry date, its activation time, and the note that a new token
 can be entered below to replace it. The recipient name in the token is not
 displayed.
 
+"Ta bort min token" does not delete the stored token directly; it opens a
+confirmation alertdialog that reuses the site's `.submit-modal` pattern
+(markup in `render-admin.js`, open/close and focus-trap helpers in
+`admin.js`, mirroring the delete-activity dialog in `redigera.js`). The
+token is cleared from `localStorage` only when the user confirms with "Ja,
+ta bort"; "Avbryt" or Escape keeps it (02-§91.35).
+
 ### Footer status indicator
 
 A small icon in the shared site footer shows admin status:

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -278,6 +278,14 @@ individual token cannot be revoked without rotating `ADMIN_TOKEN_SECRET`
 (which invalidates all tokens at once); short embedded expiries bound the
 exposure of a leaked token.
 
+The mint form sets `novalidate` and validates client-side, reusing the
+add-activity form's per-field inline-error model (`setMintFieldError()`
+mirrors `lagg-till.js`'s `setFieldError()`): the recipient name is required
+and the day count must be an integer within the role's range, each reported
+as a Swedish `field-error` below its field rather than a native browser
+bubble (02-§106.19). The generated link field is read-only and styled as
+output, not input (02-§106.20).
+
 ### Token storage (client)
 
 The admin token is stored in `localStorage` under the key `sb_admin`:

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -135,6 +135,19 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
   and font rules as secondary. Hover: background
   `var(--color-error, #b91c1c)`, text white. <!-- 07-§6.85 -->
 
+### Token page form (admin)
+
+The activation and mint forms on `/token.html` reuse the site's standard
+form components rather than bespoke styles: buttons follow Buttons
+(07-§6.15, 07-§6.16) — `.btn-primary` for Aktivera and Skapa länk,
+`.btn-secondary` for Ta bort min token, Kopiera länken and Dela — and the
+mint form's per-field validation uses the inline field-error component
+(07-§6.34) with Swedish messages, so no native browser bubble appears.
+
+- The generated activation-link field (`#mint-link`, read-only) reads as
+  output, not input: `background: var(--color-cream)` and `cursor: default`
+  set it apart from the editable fields above it. <!-- 07-§6.124 -->
+
 ### Cards (info blocks, testimonials)
 
 - Background: white `#FFFFFF`. <!-- 07-§6.19 -->

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1253,6 +1253,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
 | `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
 | `02-§91.34` | gap | MINT-17 (planned, structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; manual: token page buttons match the rest of the site |
+| `02-§91.35` | gap | MINT-19 (planned, structural): render-admin.js has the `#token-remove-confirm` alertdialog and `admin.js` opens it from the remove button (no direct `removeItem` on click); manual: click "Ta bort min token" → dialog; Avbryt/Escape keeps token, "Ja, ta bort" removes it |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1611,7 +1611,7 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 | `02-§106.9` | covered | MINT-15 (structural: role gate in `admin.js`), MINT-16 (`.admin-form[hidden]` override keeps `hidden` authoritative since `.admin-form` sets display); manual: open /token.html with superadmin vs admin token and confirm section visibility |
 | `02-§106.10` | implemented | MINT-14 (markup: name/role/days with data-days); manual: switch role and confirm day default/max follows (60↔90) |
 | `02-§106.11` | implemented | MINT-15 (structural: `#token=` link build); manual: mint and confirm the link format |
-| `02-§106.12` | implemented | MINT-14 (markup: copy button, share hidden by default); manual: share button appears only when navigator.share exists |
+| `02-§106.12` | covered | MINT-14 (markup: copy button present, no `#mint-share`), MINT-15 (`admin.js` has no `navigator.share`); manual: copy button copies the link |
 | `02-§106.13` | implemented | Swedish error strings in `admin.js`/server handlers; manual/visual check |
 | `02-§106.14` | implemented | MINT-15 (structural: hash parse + /verify-admin reuse via activateToken); manual: open an activation link and confirm activation |
 | `02-§106.15` | implemented | MINT-15 (structural: history.replaceState); manual: confirm the fragment leaves the address bar on success and failure |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1252,8 +1252,8 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
 | `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
-| `02-§91.34` | gap | MINT-17 (planned, structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; manual: token page buttons match the rest of the site |
-| `02-§91.35` | gap | MINT-19 (planned, structural): render-admin.js has the `#token-remove-confirm` alertdialog and `admin.js` opens it from the remove button (no direct `removeItem` on click); manual: click "Ta bort min token" → dialog; Avbryt/Escape keeps token, "Ja, ta bort" removes it |
+| `02-§91.34` | covered | MINT-17 (structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; `.admin-form form button[type="submit"]` has margin-top; manual: token page buttons match the rest of the site |
+| `02-§91.35` | covered | MINT-19 (structural): render-admin.js has the `#token-remove-confirm` alertdialog and `admin.js` opens it from the remove button (no direct `removeItem` on click); manual: click "Ta bort min token" → dialog; Avbryt/Escape keeps token, "Ja, ta bort" removes it |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |
@@ -1618,5 +1618,5 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 | `02-§106.16` | covered | MINT-15: `admin.js` matches `#token=` and contains no `?token=`; link built with `#token=` |
 | `02-§106.17` | implemented | Architectural: signing only in `app.js`/`api/index.php` via the shared helpers; no secret reference in any client file |
 | `02-§106.18` | implemented | Swedish text; reuses `.admin-form` components; new CSS uses only `--space-*`/`--color-*`/`--font-*`/`--radius-*` tokens; manual/visual |
-| `02-§106.19` | gap | MINT-18 (planned): mint form has `novalidate` + `mint-err-*` field-error spans; `validateMintForm()` rejects empty name and out-of-range days with Swedish messages; manual: submit empty → Swedish inline errors, no English bubble |
-| `02-§106.20` | gap | MINT-17 (planned, structural): `#mint-link` read-only styling present; manual: link field looks like output, not an input |
+| `02-§106.19` | covered | MINT-18: `validateMintFields()` rejects empty name and out-of-range/non-integer days with Swedish messages; mint form has `novalidate` + `mint-err-*` field-error spans wired by `setMintFieldError()`; manual: submit empty → Swedish inline errors, no English bubble |
+| `02-§106.20` | covered | MINT-17 (structural): `#mint-link` read-only styling (`background` + `cursor: default`) present; manual: link field looks like output, not an input |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1252,6 +1252,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.31` | covered | TOK-13, TOK-14: `admin`/`superadmin` admin-equivalent; `early` recognised but not admin |
 | `02-§91.32` | covered | TOK-22: `app.js` / `api/index.php` warn when `ADMIN_TOKEN_SECRET` < 32 bytes (parallels SESSION_SECRET, §387) |
 | `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
+| `02-§91.34` | gap | MINT-17 (planned, structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; manual: token page buttons match the rest of the site |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |
@@ -1616,3 +1617,5 @@ Doc ref: `03-architecture/platform-and-security.md §30`.
 | `02-§106.16` | covered | MINT-15: `admin.js` matches `#token=` and contains no `?token=`; link built with `#token=` |
 | `02-§106.17` | implemented | Architectural: signing only in `app.js`/`api/index.php` via the shared helpers; no secret reference in any client file |
 | `02-§106.18` | implemented | Swedish text; reuses `.admin-form` components; new CSS uses only `--space-*`/`--color-*`/`--font-*`/`--radius-*` tokens; manual/visual |
+| `02-§106.19` | gap | MINT-18 (planned): mint form has `novalidate` + `mint-err-*` field-error spans; `validateMintForm()` rejects empty name and out-of-range days with Swedish messages; manual: submit empty → Swedish inline errors, no English bubble |
+| `02-§106.20` | gap | MINT-17 (planned, structural): `#mint-link` read-only styling present; manual: link field looks like output, not an input |

--- a/docs/99-traceability/07-design.md
+++ b/docs/99-traceability/07-design.md
@@ -81,7 +81,7 @@ Part of [the traceability index](./index.md).
 | `07-§6.30` | Alternatively, a sage-green label appears above the heading at `12px` uppercase | 07-design/components.md §6 | — | `source/assets/cs/style.css` | implemented |
 | `07-§6.31` | Schedule event rows show a bold start time and a lighter end time | 07-design/components.md §6 | — | `source/build/render.js` – `renderEventRow()`; `source/assets/cs/style.css` | implemented |
 | `07-§6.32` | Location is shown as small text below the time in event rows | 07-design/components.md §6 | — | `source/build/render.js` – `renderEventRow()` | implemented |
-| `07-§6.124` | The read-only activation-link field reads as output, not input (muted background, default cursor) | 07-design/components.md §6 | MINT-17 (structural: `#mint-link` read-only style) | `source/assets/cs/style.css` – `#mint-link` muted background + `cursor: default` | gap |
+| `07-§6.124` | The read-only activation-link field reads as output, not input (muted background, default cursor) | 07-design/components.md §6 | MINT-17 (structural: `#mint-link` read-only style) | `source/assets/cs/style.css` – `#mint-link` muted background + `cursor: default` | covered |
 | `07-§7.2` | CSS is written for a component only once its HTML structure exists; no speculative CSS | 07-design/css-strategy.md §7 | — | Convention; assessed through code review | implemented |
 | `07-§7.3` | CSS is organized in one main file: reset → tokens → base → layout → components → utilities | 07-design/css-strategy.md §7 | — | `source/assets/cs/style.css` | implemented |
 | `07-§7.4` | No CSS preprocessor is used; CSS custom properties are sufficient | 07-design/css-strategy.md §7 | CSS-36 | `source/assets/cs/style.css` – plain CSS with custom properties | covered |

--- a/docs/99-traceability/07-design.md
+++ b/docs/99-traceability/07-design.md
@@ -81,6 +81,7 @@ Part of [the traceability index](./index.md).
 | `07-§6.30` | Alternatively, a sage-green label appears above the heading at `12px` uppercase | 07-design/components.md §6 | — | `source/assets/cs/style.css` | implemented |
 | `07-§6.31` | Schedule event rows show a bold start time and a lighter end time | 07-design/components.md §6 | — | `source/build/render.js` – `renderEventRow()`; `source/assets/cs/style.css` | implemented |
 | `07-§6.32` | Location is shown as small text below the time in event rows | 07-design/components.md §6 | — | `source/build/render.js` – `renderEventRow()` | implemented |
+| `07-§6.124` | The read-only activation-link field reads as output, not input (muted background, default cursor) | 07-design/components.md §6 | MINT-17 (structural: `#mint-link` read-only style) | `source/assets/cs/style.css` – `#mint-link` muted background + `cursor: default` | gap |
 | `07-§7.2` | CSS is written for a component only once its HTML structure exists; no speculative CSS | 07-design/css-strategy.md §7 | — | Convention; assessed through code review | implemented |
 | `07-§7.3` | CSS is organized in one main file: reset → tokens → base → layout → components → utilities | 07-design/css-strategy.md §7 | — | `source/assets/cs/style.css` | implemented |
 | `07-§7.4` | No CSS preprocessor is used; CSS custom properties are sufficient | 07-design/css-strategy.md §7 | CSS-36 | `source/assets/cs/style.css` – plain CSS with custom properties | covered |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2845,6 +2845,10 @@ body.modal-open {
 .admin-form {
   max-width: var(--container-narrow);
   margin-top: var(--space-md);
+
+  /* `.site-content` has no bottom padding, so without this the last control
+     (e.g. "Kopiera länken") sits flush against the footer. */
+  margin-bottom: var(--space-lg);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2887,6 +2887,14 @@ body.modal-open {
   gap: var(--space-xs);
 }
 
+/* The generated link is read-only output, not a field to fill in (02-§106.20,
+   07-§6.124): a muted background and default cursor set it apart from the
+   editable inputs above it. */
+#mint-link {
+  background: var(--color-cream);
+  cursor: default;
+}
+
 .mint-actions {
   display: flex;
   gap: var(--space-sm);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2881,6 +2881,12 @@ body.modal-open {
   outline-offset: 2px;
 }
 
+/* Submit buttons sit inside the form, so the `.admin-form` gap does not
+   reach them — give them air above the field they follow (02-§91.34). */
+.admin-form form button[type="submit"] {
+  margin-top: var(--space-sm);
+}
+
 .mint-result {
   display: flex;
   flex-direction: column;

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -87,6 +87,26 @@
     }
   }
 
+  // Validate the mint form's fields (02-§106.19). Pure — returns Swedish
+  // messages keyed by field, or null when valid. The recipient name is
+  // required; the day count must be an integer within 1..max for the role.
+  // Mirrors the add-activity form's per-field model (02-§6.5).
+  function validateMintFields(fields) {
+    var f = fields || {};
+    var errors = { name: null, days: null };
+    var name = (f.name == null ? '' : String(f.name)).trim();
+    if (!name) errors.name = 'Namn är obligatoriskt.';
+    var max = Number(f.max);
+    var rawDays = f.days;
+    var days = Number(rawDays);
+    if (rawDays === '' || rawDays == null || !isFinite(days)) {
+      errors.days = 'Giltighetstid är obligatorisk.';
+    } else if (days % 1 !== 0 || days < 1 || (isFinite(max) && days > max)) {
+      errors.days = 'Giltighetstiden måste vara 1–' + (isFinite(max) ? max : '') + ' dagar.';
+    }
+    return errors;
+  }
+
   // Derive the API base URL from the page's API configuration.
   function apiBase() {
     var feedbackBtn = document.querySelector('.feedback-btn[data-api-url]');
@@ -104,6 +124,7 @@
         tokenRole: tokenRole,
         extractExpiry: extractExpiry,
         isExpired: isExpired,
+        validateMintFields: validateMintFields,
       };
     }
     return;
@@ -251,6 +272,7 @@
 
     var mintForm = document.getElementById('mint-form');
     var mintMessage = document.getElementById('mint-message');
+    var mintName = document.getElementById('mint-name');
     var mintRoleSel = document.getElementById('mint-role');
     var mintDays = document.getElementById('mint-days');
     var mintResult = document.getElementById('mint-result');
@@ -264,6 +286,29 @@
       mintMessage.hidden = false;
     };
 
+    // Per-field inline errors for the mint form, mirroring lagg-till.js's
+    // model (02-§106.19, §6.5): field name → its input + #mint-err-<field>
+    // span. The error clears as soon as the user edits the field.
+    var MINT_FIELDS = { name: mintName, days: mintDays };
+    var setMintFieldError = function (field, msg) {
+      var el = MINT_FIELDS[field];
+      var span = document.getElementById('mint-err-' + field);
+      if (!el || !span) return;
+      if (msg) {
+        el.setAttribute('aria-invalid', 'true');
+        span.textContent = msg;
+        span.hidden = false;
+      } else {
+        el.removeAttribute('aria-invalid');
+        span.textContent = '';
+        span.hidden = true;
+      }
+    };
+    Object.keys(MINT_FIELDS).forEach(function (field) {
+      if (!MINT_FIELDS[field]) return;
+      MINT_FIELDS[field].addEventListener('input', function () { setMintFieldError(field, null); });
+    });
+
     // Role change updates the day field's default and maximum (02-§106.10).
     mintRoleSel.addEventListener('change', function () {
       var opt = mintRoleSel.options[mintRoleSel.selectedIndex];
@@ -276,6 +321,20 @@
       e.preventDefault();
       mintMessage.hidden = true;
       mintResult.hidden = true;
+
+      // Client-side validation with Swedish inline errors (02-§106.19) —
+      // `novalidate` on the form suppresses the browser's native bubbles.
+      var errors = validateMintFields({
+        name: mintName.value,
+        days: mintDays.value,
+        max: Number(mintDays.max),
+      });
+      setMintFieldError('name', errors.name);
+      setMintFieldError('days', errors.days);
+      if (errors.name || errors.days) {
+        (errors.name ? mintName : mintDays).focus();
+        return;
+      }
 
       // Read the stored token fresh on every mint, in case it was replaced
       // since the section was revealed. The server is the real gate.

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -325,7 +325,6 @@
     var mintResult = document.getElementById('mint-result');
     var mintLink = document.getElementById('mint-link');
     var mintCopy = document.getElementById('mint-copy');
-    var mintShare = document.getElementById('mint-share');
 
     var showMintMessage = function (text, ok) {
       mintMessage.textContent = text;
@@ -407,8 +406,7 @@
           // Activation link with the token in the fragment (02-§106.11, §106.16).
           mintLink.value = location.origin + '/token.html#token=' + encodeURIComponent(data.token);
           mintResult.hidden = false;
-          if (navigator.share) mintShare.hidden = false;
-          showMintMessage('Länk skapad. Dela den privat med mottagaren.', true);
+          showMintMessage('Länk skapad. Kopiera och dela den privat med mottagaren.', true);
         })
         .catch(function () {
           showMintMessage('Kunde inte skapa token. Kontrollera din anslutning.', false);
@@ -427,11 +425,6 @@
       } else {
         fallbackCopy();
       }
-    });
-
-    mintShare.addEventListener('click', function () {
-      navigator.share({ title: 'SB Sommar – aktivera din token', url: mintLink.value })
-        .catch(function () { /* user cancelled the share sheet */ });
     });
   }
 

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -185,16 +185,63 @@
       removeBtn.hidden = false;
     }
 
+    // ── Remove-token confirmation (02-§91.35) ─────────────────────────────────
+    // "Ta bort min token" is destructive, so it opens a confirmation dialog
+    // (the site's .submit-modal alertdialog, like delete-activity) instead of
+    // removing the token on the first click. Focus moves to Avbryt on open and
+    // is trapped; Escape or Avbryt keeps the token, "Ja, ta bort" removes it.
+    var removeConfirm = document.getElementById('token-remove-confirm');
+    var removeYes = document.getElementById('token-remove-yes');
+    var removeNo = document.getElementById('token-remove-no');
+    var preRemoveFocus = null;
+
+    var closeRemoveConfirm = function () {
+      if (!removeConfirm) return;
+      removeConfirm.hidden = true;
+      document.body.classList.remove('modal-open');
+      removeConfirm.removeEventListener('keydown', trapRemoveFocus);
+      if (preRemoveFocus) preRemoveFocus.focus();
+    };
+
+    var trapRemoveFocus = function (e) {
+      if (e.key === 'Escape') { closeRemoveConfirm(); return; }
+      if (e.key !== 'Tab' || !removeConfirm) return;
+      var focusable = Array.prototype.slice.call(
+        removeConfirm.querySelectorAll('button:not([disabled])'));
+      if (!focusable.length) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+
+    var openRemoveConfirm = function () {
+      if (!removeConfirm) return;
+      preRemoveFocus = document.activeElement;
+      removeConfirm.hidden = false;
+      document.body.classList.add('modal-open');
+      removeConfirm.addEventListener('keydown', trapRemoveFocus);
+      if (removeNo) removeNo.focus();
+    };
+
+    var performRemove = function () {
+      localStorage.removeItem(STORAGE_KEY);
+      closeRemoveConfirm();
+      message.textContent = 'Token borttagen.';
+      message.className = 'admin-message admin-message--success';
+      message.hidden = false;
+      removeBtn.hidden = true;
+      renderFooterIcon();
+    };
+
     if (removeBtn) {
-      removeBtn.addEventListener('click', function () {
-        localStorage.removeItem(STORAGE_KEY);
-        message.textContent = 'Token borttagen.';
-        message.className = 'admin-message admin-message--success';
-        message.hidden = false;
-        removeBtn.hidden = true;
-        renderFooterIcon();
-      });
+      removeBtn.addEventListener('click', openRemoveConfirm);
     }
+    if (removeYes) removeYes.addEventListener('click', performRemove);
+    if (removeNo) removeNo.addEventListener('click', closeRemoveConfirm);
 
     // Verify a token against the server and store it on success. Used by the
     // manual form and by activation links (02-§91.11–91.13, 02-§106.14).

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -235,6 +235,10 @@
       message.hidden = false;
       removeBtn.hidden = true;
       renderFooterIcon();
+      // The remove button is now hidden, so closeRemoveConfirm()'s focus
+      // restore would land on a hidden element — move focus to the token
+      // input instead, the natural next step (enter a new token).
+      if (input) input.focus();
     };
 
     if (removeBtn) {
@@ -356,11 +360,14 @@
     });
 
     // Role change updates the day field's default and maximum (02-§106.10).
+    // Setting the value programmatically does not fire `input`, so clear any
+    // stale days error here — the reset value is always valid for the role.
     mintRoleSel.addEventListener('change', function () {
       var opt = mintRoleSel.options[mintRoleSel.selectedIndex];
       var days = (opt && opt.dataset.days) || '60';
       mintDays.max = days;
       mintDays.value = days;
+      setMintFieldError('days', null);
     });
 
     mintForm.addEventListener('submit', function (e) {

--- a/source/build/render-admin.js
+++ b/source/build/render-admin.js
@@ -61,6 +61,19 @@ ${nav}
         </div>
       </div>
     </div>
+    <div id="token-remove-confirm" class="submit-modal" role="alertdialog" aria-modal="true" aria-labelledby="token-remove-heading" hidden>
+      <div class="modal-backdrop"></div>
+      <div class="modal-box">
+        <h2 id="token-remove-heading" class="modal-heading" tabindex="-1">Ta bort token</h2>
+        <div class="modal-content">
+          <p>Är du säker på att du vill ta bort din token? Behörigheten försvinner direkt och du behöver aktivera en ny token för att få tillbaka den.</p>
+          <div class="delete-actions">
+            <button type="button" id="token-remove-yes" class="btn-destructive">Ja, ta bort</button>
+            <button type="button" id="token-remove-no" class="btn-secondary">Avbryt</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </main>
 ${footer}
   <script src="admin.js"></script>

--- a/source/build/render-admin.js
+++ b/source/build/render-admin.js
@@ -30,32 +30,34 @@ ${nav}
       <form id="admin-activate">
         <label for="admin-token">Ange din token</label>
         <input type="text" id="admin-token" name="token" required autocomplete="off" placeholder="namn_roll_epoch_signatur">
-        <button type="submit" class="btn btn--primary">Aktivera</button>
+        <button type="submit" class="btn-primary">Aktivera</button>
       </form>
-      <button type="button" id="admin-remove" class="btn btn--secondary admin-remove" hidden>Ta bort min token</button>
+      <button type="button" id="admin-remove" class="btn-secondary admin-remove" hidden>Ta bort min token</button>
     </div>
     <div id="mint-section" class="admin-form" hidden>
       <h2>Skapa token-länk</h2>
       <p class="admin-intro">Skapa en aktiveringslänk för en ny token och dela den med mottagaren. Superadmin kan inte skapas här.</p>
       <p id="mint-message" class="admin-message" aria-live="polite" hidden></p>
-      <form id="mint-form">
+      <form id="mint-form" novalidate>
         <label for="mint-name">Namn på mottagaren</label>
-        <input type="text" id="mint-name" name="name" required autocomplete="off">
+        <input type="text" id="mint-name" name="name" required autocomplete="off" aria-describedby="mint-err-name">
+        <span class="field-error" id="mint-err-name" hidden></span>
         <label for="mint-role">Roll</label>
         <select id="mint-role" name="role">
           <option value="admin" data-days="60">Admin (max 60 dagar)</option>
           <option value="early" data-days="90">Tidig åtkomst (max 90 dagar)</option>
         </select>
         <label for="mint-days">Giltighetstid (dagar)</label>
-        <input type="number" id="mint-days" name="days" min="1" max="60" value="60" required>
-        <button type="submit" class="btn btn--primary">Skapa länk</button>
+        <input type="number" id="mint-days" name="days" min="1" max="60" value="60" required aria-describedby="mint-err-days">
+        <span class="field-error" id="mint-err-days" hidden></span>
+        <button type="submit" class="btn-primary">Skapa länk</button>
       </form>
       <div id="mint-result" class="mint-result" hidden>
         <label for="mint-link">Aktiveringslänk – dela privat med mottagaren</label>
         <input type="text" id="mint-link" readonly>
         <div class="mint-actions">
-          <button type="button" id="mint-copy" class="btn btn--secondary">Kopiera länken</button>
-          <button type="button" id="mint-share" class="btn btn--secondary" hidden>Dela …</button>
+          <button type="button" id="mint-copy" class="btn-secondary">Kopiera länken</button>
+          <button type="button" id="mint-share" class="btn-secondary" hidden>Dela …</button>
         </div>
       </div>
     </div>

--- a/source/build/render-admin.js
+++ b/source/build/render-admin.js
@@ -57,7 +57,6 @@ ${nav}
         <input type="text" id="mint-link" readonly>
         <div class="mint-actions">
           <button type="button" id="mint-copy" class="btn-secondary">Kopiera länken</button>
-          <button type="button" id="mint-share" class="btn-secondary" hidden>Dela …</button>
         </div>
       </div>
     </div>

--- a/tests/mint-token.test.js
+++ b/tests/mint-token.test.js
@@ -157,7 +157,7 @@ describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
     assert.match(html, /id="mint-days"/);
     assert.match(html, /id="mint-link"/);
     assert.match(html, /id="mint-copy"/);
-    assert.match(html, /id="mint-share"[^>]*hidden/);
+    assert.doesNotMatch(html, /id="mint-share"/, 'the unreliable native share button is removed (02-§106.12)');
     assert.match(html, /Tidig åtkomst/);
   });
 
@@ -167,7 +167,7 @@ describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
     assert.match(src, /location\.hash/);
     assert.match(src, /history\.replaceState/);
     assert.match(src, /#token=/);
-    assert.match(src, /navigator\.share/);
+    assert.doesNotMatch(src, /navigator\.share/, 'the native share button is removed (02-§106.12)');
     assert.doesNotMatch(src, /\?token=/, 'redemption must use the fragment, not a query parameter');
   });
 

--- a/tests/mint-token.test.js
+++ b/tests/mint-token.test.js
@@ -204,4 +204,19 @@ describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
     assert.match(validateMintFields({ name: 'a', days: 1.5, max: 60 }).days, /1–60/);
     assert.strictEqual(validateMintFields({ name: 'a', days: 90, max: 90 }).days, null);
   });
+
+  it('MINT-19: token removal goes through a confirmation dialog (02-§91.35)', () => {
+    const { renderAdminPage } = require('../source/build/render-admin');
+    const html = renderAdminPage({ name: 'SB Sommar 2026' }, '<p>f</p>');
+    // The confirmation alertdialog and its two buttons exist, hidden by default.
+    assert.match(html, /id="token-remove-confirm"[^>]*role="alertdialog"[^>]*hidden/);
+    assert.match(html, /id="token-remove-yes"/);
+    assert.match(html, /id="token-remove-no"/);
+
+    // admin.js opens the dialog from the remove button and clears the token
+    // only on confirmation — never directly on the remove button's click.
+    const src = read('source/assets/js/client/admin.js');
+    assert.match(src, /removeBtn\.addEventListener\('click', openRemoveConfirm\)/);
+    assert.match(src, /removeYes\.addEventListener\('click', performRemove\)/);
+  });
 });

--- a/tests/mint-token.test.js
+++ b/tests/mint-token.test.js
@@ -29,6 +29,9 @@ const {
   sanitizeTokenName,
 } = require('../source/api/admin');
 
+// Pure client-side mint-form validation (admin.js exports it under Node).
+const { validateMintFields } = require('../source/assets/js/client/admin');
+
 const SECRET = 'mint-token-test-secret-32-bytes!';
 const NOW = 2000000000; // fixed, mirrored in api/tests/MintTokenTest.php
 const DAY = 86400;
@@ -176,5 +179,29 @@ describe('mint UI and redemption wiring (02-§106.9–106.16)', () => {
     // section from non-superadmins. Without it the form renders for everyone.
     const css = read('source/assets/cs/style.css');
     assert.match(css, /\.admin-form\[hidden\]\s*\{\s*display:\s*none/);
+  });
+
+  it('MINT-17: token page uses site button styles and a read-only link field (02-§91.34, §106.20)', () => {
+    const { renderAdminPage } = require('../source/build/render-admin');
+    const html = renderAdminPage({ name: 'SB Sommar 2026' }, '<p>f</p>');
+    // Buttons use the site classes, not the orphaned (unstyled) BEM .btn--* ones.
+    assert.doesNotMatch(html, /btn--(primary|secondary)/);
+    assert.match(html, /class="btn-primary"/);
+    assert.match(html, /class="btn-secondary/);
+    // The generated link field is de-emphasised so it reads as output.
+    const css = read('source/assets/cs/style.css');
+    assert.match(css, /#mint-link\s*\{[^}]*cursor:\s*default/);
+    assert.match(css, /#mint-link\s*\{[^}]*background/);
+  });
+
+  it('MINT-18: validateMintFields enforces required name and in-range integer days (02-§106.19)', () => {
+    assert.deepStrictEqual(validateMintFields({ name: 'anna', days: 60, max: 60 }), { name: null, days: null });
+    assert.match(validateMintFields({ name: '', days: 60, max: 60 }).name, /obligatorisk/i);
+    assert.match(validateMintFields({ name: '   ', days: 60, max: 60 }).name, /obligatorisk/i);
+    assert.match(validateMintFields({ name: 'a', days: '', max: 60 }).days, /obligatorisk/i);
+    assert.match(validateMintFields({ name: 'a', days: 90, max: 60 }).days, /1–60 dagar/);
+    assert.match(validateMintFields({ name: 'a', days: 0, max: 60 }).days, /1–60/);
+    assert.match(validateMintFields({ name: 'a', days: 1.5, max: 60 }).days, /1–60/);
+    assert.strictEqual(validateMintFields({ name: 'a', days: 90, max: 90 }).days, null);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #395: a round of token-page (`/token.html`) UX fixes found while reviewing the page in the browser. Each was an inconsistency left by the earlier token PRs.

- **Swedish inline validation on the mint form (§106.19).** The mint form was `required`-only, so an empty submit triggered the browser's native (English) validation bubble — a different model from the rest of the site. It now uses `novalidate` + the add-activity form's per-field `field-error` model: `validateMintFields()` checks the name (required) and days (integer within the role's range) and shows Swedish messages below each field, cleared on edit.
- **Read-only link field reads as output (§106.20 / §6.124).** The generated activation link sat in a field styled like an editable input. `#mint-link` now has a muted background and default cursor.
- **Site button styles (§91.34).** The token page used `btn--primary`/`btn--secondary` (BEM) classes that have **no CSS**, so the buttons fell back to browser defaults. They now use the site's `.btn-primary`/`.btn-secondary`, plus `margin-top` so a submit button is not flush against the field above it, and `.admin-form` gets `margin-bottom` so the last control is not flush against the footer.
- **Confirm before removing the token (§91.35).** "Ta bort min token" deleted the stored token on the first click — a mis-click lost it silently. It now opens a confirmation alertdialog reusing the site's `.submit-modal` pattern (like delete-activity): focus moves to Avbryt and is trapped; Escape/Avbryt keeps the token, "Ja, ta bort" removes it and focus moves to the token input.
- **Remove the dead share button (§106.12).** The "Dela …" button relied on `navigator.share`, a silent no-op on desktop — it looked clickable but did nothing. Copying the link is now the single, clear hand-over path.

## Phases

Full lifecycle (Phase 0–7) with several rounds of local browser review by the maintainer, who drove the scope (button spacing, removal confirmation, dead share button, bottom spacing) one finding at a time.

## Test plan

- [x] `npm run lint` / `lint:css` / `lint:html` / `lint:md` — clean
- [x] `npm test` — 1885/1885 pass, incl. new **MINT-17** (site buttons + read-only link), **MINT-18** (`validateMintFields`), **MINT-19** (removal confirmation dialog); **MINT-14/15** updated to require the share button gone
- [x] Manual (maintainer, in browser): empty/out-of-range mint submit → Swedish inline errors, no English bubble; read-only link looks like output; buttons match the site; "Ta bort min token" confirms before removing; no share button

🤖 Generated with [Claude Code](https://claude.com/claude-code)