### PR TITLE
fix: clear token field on activation, disable Aktivera when empty

### DIFF
--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -664,6 +664,16 @@ reuses the format, signing, and activation flow described here.
   cancel button on open and returns to the trigger on close, and focus is
   trapped within the dialog. This guards against an accidental
   click. <!-- 02-§91.35 -->
+- On a successful activation — whether the token was typed in or arrived via
+  an activation link — the token input field is cleared. The token is stored
+  in `localStorage`, so leaving the full string visible in the field serves
+  no purpose; for the activation-link flow it would also leave the token on
+  screen after the URL fragment has already been removed
+  (02-§106.15). <!-- 02-§91.36 -->
+- The "Aktivera" button is disabled while the token input is empty — on page
+  load and after a successful activation clears the field — and becomes
+  enabled as soon as the field contains non-whitespace text. This prevents
+  submitting an empty activation. <!-- 02-§91.37 -->
 
 ### 91.5 Token expiry (site requirements)
 

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -311,6 +311,14 @@ On submit, it calls `POST /verify-admin`. If valid, the token and
 timestamp are stored in `localStorage`. The page shares the site layout
 (header, navigation, footer) but is **not listed in the navigation**.
 
+`activateToken()` clears the input on success (02-§91.36), so the token —
+typed in or carried by an activation link — does not linger on screen once
+it is stored (the link flow has already stripped it from the URL fragment).
+The "Aktivera" button is kept disabled whenever the input is empty: an
+`input` listener (and one call at load) sets `submitBtn.disabled =
+!input.value.trim()`, so an empty activation cannot be submitted and the
+cleared field leaves the button disabled (02-§91.37).
+
 When a valid token is already stored, the status message leads with the
 role as a bold title (`Roll: <label>`, a `.admin-message-title` `<strong>`
 on its own line) — read client-side from the token's second

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1254,8 +1254,8 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
 | `02-§91.34` | covered | MINT-17 (structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; `.admin-form form button[type="submit"]` has margin-top; manual: token page buttons match the rest of the site |
 | `02-§91.35` | covered | MINT-19 (structural): render-admin.js has the `#token-remove-confirm` alertdialog and `admin.js` opens it from the remove button (no direct `removeItem` on click); manual: click "Ta bort min token" → dialog; Avbryt/Escape keeps token, "Ja, ta bort" removes it |
-| `02-§91.36` | gap | TOK-25 (planned, structural): `admin.js` clears `input.value` in the valid-activation branch; manual: activate via link → field is empty afterwards |
-| `02-§91.37` | gap | TOK-26 (planned, structural): `admin.js` toggles `submitBtn.disabled` from `input.value.trim()` on `input` + at load; manual: empty field → Aktivera disabled, type → enabled, after activation → disabled |
+| `02-§91.36` | covered | TOK-25 (structural): `admin.js` clears `input.value` in the valid-activation branch; manual: activate via link → field is empty afterwards |
+| `02-§91.37` | covered | TOK-26 (structural): `admin.js` toggles `submitBtn.disabled` from `input.value.trim()` on `input` + at load; manual: empty field → Aktivera disabled, type → enabled, after activation → disabled |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1254,6 +1254,8 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§91.33` | covered | TOK-23, TOK-24: `tokenRole()` + `roleDescription()` map superadmin/admin/early to Swedish rights text; `setStatusWithRole()` renders the bold `Roll: <label>` title; manual: open /token.html with each role and confirm the title and rights (recipient name not shown) |
 | `02-§91.34` | covered | MINT-17 (structural): render-admin.js buttons use `.btn-primary`/`.btn-secondary`, no `.btn--*`; `.admin-form form button[type="submit"]` has margin-top; manual: token page buttons match the rest of the site |
 | `02-§91.35` | covered | MINT-19 (structural): render-admin.js has the `#token-remove-confirm` alertdialog and `admin.js` opens it from the remove button (no direct `removeItem` on click); manual: click "Ta bort min token" → dialog; Avbryt/Escape keeps token, "Ja, ta bort" removes it |
+| `02-§91.36` | gap | TOK-25 (planned, structural): `admin.js` clears `input.value` in the valid-activation branch; manual: activate via link → field is empty afterwards |
+| `02-§91.37` | gap | TOK-26 (planned, structural): `admin.js` toggles `submitBtn.disabled` from `input.value.trim()` on `input` + at load; manual: empty field → Aktivera disabled, type → enabled, after activation → disabled |
 | `02-§91.4` | implemented | `app.js` POST /verify-admin; `api/index.php` handleVerifyAdmin() |
 | `02-§91.5` | implemented | Request body parsed in both Node.js and PHP handlers |
 | `02-§91.6` | covered | TOK-03, TOK-04, TOK-13: valid signature + recognised role + future epoch accepted |

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -138,6 +138,16 @@
     var input = document.getElementById('admin-token');
     var message = document.getElementById('admin-message');
     var removeBtn = document.getElementById('admin-remove');
+    var submitBtn = form.querySelector('button[type="submit"]');
+
+    // Keep "Aktivera" disabled while the field is empty (02-§91.37), so an
+    // empty activation can't be submitted and a cleared field leaves the
+    // button disabled. Re-synced as the user types.
+    var syncActivateBtn = function () {
+      if (submitBtn) submitBtn.disabled = !input.value.trim();
+    };
+    input.addEventListener('input', syncActivateBtn);
+    syncActivateBtn();
 
     // Pre-fill status if already activated
     var existing = getAdminData();
@@ -274,6 +284,11 @@
             message.classList.add('admin-message--success');
             message.hidden = false;
             if (removeBtn) removeBtn.hidden = false;
+            // Clear the field so the token does not linger on screen — it is
+            // stored now, and for the link flow the URL fragment is already
+            // gone (02-§91.36). The empty field re-disables "Aktivera".
+            input.value = '';
+            syncActivateBtn();
             renderFooterIcon();
             initMintSection();
           } else {

--- a/source/assets/js/client/admin.js
+++ b/source/assets/js/client/admin.js
@@ -320,6 +320,9 @@
       var incoming = decodeURIComponent(hashMatch[1]);
       history.replaceState(null, '', location.pathname + location.search);
       input.value = incoming;
+      // Setting the value programmatically does not fire `input`; sync so the
+      // button reflects the field (and stays usable if this activation fails).
+      syncActivateBtn();
       activateToken(incoming);
     }
   }

--- a/tests/token-status.test.js
+++ b/tests/token-status.test.js
@@ -15,6 +15,10 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
 
 const { roleDescription, tokenRole } = require('../source/assets/js/client/admin.js');
 
@@ -47,5 +51,21 @@ describe('token status rights text (02-§91.33)', () => {
     // still works, it simply omits the sentence.
     assert.strictEqual(roleDescription('whatever'), '');
     assert.strictEqual(roleDescription(null), '');
+  });
+});
+
+// These two are DOM behaviours (input value, button disabled state), so they
+// are checked structurally here and verified manually in the browser.
+describe('activation field + button state (02-§91.36, §91.37)', () => {
+  const src = read('source/assets/js/client/admin.js');
+
+  it('TOK-25: admin.js clears the token input on successful activation (02-§91.36)', () => {
+    assert.match(src, /input\.value = ''/);
+  });
+
+  it('TOK-26: admin.js disables Aktivera while the input is empty (02-§91.37)', () => {
+    assert.match(src, /submitBtn/);
+    assert.match(src, /\.disabled = !.*\.value\.trim\(\)/);
+    assert.match(src, /input\.addEventListener\('input'/);
   });
 });


### PR DESCRIPTION
## Summary

Two small activation-form fixes on `/token.html`, found while activating a token via an activation link.

- **Clear the input on successful activation (§91.36).** Activating via a link pre-fills the input with the token (`input.value = incoming`) and `activateToken()` never cleared it, so the full token string stayed visible in the "Ange din token" field after activation. It is now cleared on success — the token is already stored, and for the link flow this matches the existing intent of stripping it from the URL fragment (§106.15) so it does not linger on screen.
- **Disable "Aktivera" while the field is empty (§91.37).** The button was always clickable; submitting an empty field did nothing. It is now disabled whenever the input is empty (synced on `input` and at load, and after a link pre-fills the field), so an empty activation cannot be submitted and the cleared field re-disables the button.

## Phases

Full lifecycle (Phase 0–7), local browser review by the maintainer (activation-link flow + button enable/disable states).

## Test plan

- [x] `npm run lint` / `lint:html` / `lint:md` — clean
- [x] `npm test` — 1887/1887 pass, incl. new structural **TOK-25** (input cleared on success) and **TOK-26** (Aktivera disabled from `input.value.trim()`)
- [x] Manual (maintainer, in browser): open an activation link → field is empty afterwards; empty field → Aktivera disabled; typing → enabled; after activation → disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)