### PR TITLE
Hide Skolan and Fritidsgården (not available this year)

### DIFF
--- a/source/data/local.yaml
+++ b/source/data/local.yaml
@@ -26,6 +26,7 @@ locations:
     image_path: "images/fotbollsplan.webp"
   - id: fritidsgarden
     name: Fritidsgården
+    active: false
     information: >
       Kom ihåg, det tar cirka 15-20 minuter att gå till fritidsgården från
       campingen. Städa direkt efter eventuellt användande. Entrén är i den
@@ -124,6 +125,7 @@ locations:
     image_path: "images/servicehus.webp"
   - id: skolan
     name: Skolan
+    active: false
     information: >
       Kvistbergsskolan. Kom ihåg, det tar cirka 15-20 minuter att gå till
       skolan från campingen. Alla lokaler i skolan städas direkt efter


### PR DESCRIPTION
## Summary

- Sets `active: false` on `skolan` and `fritidsgarden` in `source/data/local.yaml` so the two locations the camp has no access to this year are hidden.
- Uses the location-availability mechanism added for #404: an unavailable location disappears from the add/edit form dropdowns, the Lokaler schedule grid, and the homepage location accordions. The "Annat" fallback remains selectable.

## Why

The earlier change (PR #405) added the *ability* to hide locations but did not actually hide any. On QA, Skolan and Fritidsgården still appeared everywhere. This change applies the flag to the two locations named in the issue.

## Test plan

- [x] `npm run build` succeeds; location count drops from 21 to 19.
- [x] `Skolan` and `Fritidsgården` no longer appear in `lagg-till.html`, `redigera.html`, `lokaler.html`, or `index.html`.
- [x] An active location (`Servicehus`) and the `Annat` fallback still appear in the form.
- [x] Event count unchanged (172) — no activities lost; any on a hidden location fold into the "Annat" row.
- [x] Full test suite green (`npm test`), `npm run lint`, `npm run lint:md`.

Closes #404

https://claude.ai/code/session_01CPCP5AafnAS9P1yfqEjDNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPCP5AafnAS9P1yfqEjDNV)_