### PR TITLE
Fix iCal export times shifting +2h (anchor to Europe/Stockholm)

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -226,9 +226,14 @@ Each per-event `.ics` file must include exactly one `VEVENT` with: <!-- 02-§45.
 - `URL` — absolute URL to the event detail page
 - `UID` — `{event-id}@{hostname}` (stable, unique)
 
-All times must use floating local format (`YYYYMMDDTHHMMSS` with no `Z`
-suffix and no `TZID`) — consistent with the no-timezone policy
-(05-§4.5). <!-- 02-§45.5 -->
+All event times are expressed in the `Europe/Stockholm` time zone.
+`DTSTART` and `DTEND` carry a `TZID=Europe/Stockholm` parameter
+(`DTSTART;TZID=Europe/Stockholm:YYYYMMDDTHHMMSS`), and the `VCALENDAR`
+includes a matching `VTIMEZONE` component that defines `Europe/Stockholm`
+with its CET/CEST daylight-saving rules. The naive local times stored in
+the event data (05-§4.5) are thereby anchored to a concrete zone, so
+calendar apps display every activity at its correct wall-clock time
+regardless of the device's own time zone. <!-- 02-§45.5 -->
 
 When `end` is null, `DTEND` must be omitted. <!-- 02-§45.6 -->
 

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -332,9 +332,26 @@ VERSION:2.0
 PRODID:-//SB Sommar//Schema//SV
 X-WR-CALNAME:Schema – {camp name}
 METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:Europe/Stockholm
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20260630T163000
-DTEND:20260630T180000
+DTSTART;TZID=Europe/Stockholm:20260630T163000
+DTEND;TZID=Europe/Stockholm:20260630T180000
 DTSTAMP:20260228T120000Z
 SUMMARY:{title}
 LOCATION:{location}
@@ -346,8 +363,13 @@ END:VEVENT
 END:VCALENDAR
 ```
 
-Times use floating local format (`YYYYMMDDTHHMMSS`, no `Z`, no `TZID`)
-consistent with the no-timezone policy (05-§4.5).
+`DTSTART` and `DTEND` carry a `TZID=Europe/Stockholm` parameter, and the
+`VCALENDAR` embeds a matching `VTIMEZONE` component with the EU CET/CEST
+daylight-saving rules. The naive local times in the event data (05-§4.5)
+are thereby anchored to a concrete zone, so calendar apps (notably
+Apple/iOS, which otherwise treats unqualified times as UTC) display every
+activity at its correct wall-clock time. The renderer emits one shared
+`VTIMEZONE` per `.ics` file, placed before the first `VEVENT`.
 
 `DTSTAMP` is a UTC timestamp set to the build time. RFC 5545 §3.6.1
 requires it in every `VEVENT`.

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -601,7 +601,7 @@ Part of [the traceability index](./index.md).
 | `02-§45.2` | Per-event `.ics` file at `/schema/{event-id}/event.ics` | 03-architecture/pages-and-content.md §22 | ICAL-06, ICAL-07 | `source/build/render-ical.js` – `renderEventIcal()`, `source/build/build.js` | covered |
 | `02-§45.3` | Per-event `.ics` is valid iCalendar (RFC 5545) | 03-architecture/pages-and-content.md §22 | ICAL-06 | `source/build/render-ical.js` – `renderEventIcal()` | covered |
 | `02-§45.4` | VEVENT includes DTSTART, DTEND, SUMMARY, LOCATION, DESCRIPTION, URL, UID | 03-architecture/pages-and-content.md §22 | ICAL-08..15 | `source/build/render-ical.js` – `renderVevent()` | covered |
-| `02-§45.5` | Times use floating local format (no Z, no TZID) | 03-architecture/pages-and-content.md §22 | ICAL-16 | `source/build/render-ical.js` – `toIcalDatetime()` | covered |
+| `02-§45.5` | Times anchored to Europe/Stockholm via TZID + VTIMEZONE | 03-architecture/pages-and-content.md §22 | ICAL-16, ICAL-34, ICAL-35 | `source/build/render-ical.js` – `toIcalDatetime()`, `buildVtimezone()` | covered |
 | `02-§45.6` | DTEND omitted when end is null | 03-architecture/pages-and-content.md §22 | ICAL-17, ICAL-18 | `source/build/render-ical.js` – `renderVevent()` | covered |
 | `02-§45.7` | iCal renderer has no external library dependency | 03-architecture/pages-and-content.md §22 | ICAL-28 | `source/build/render-ical.js` (source inspection) | covered |
 | `02-§45.8` | Event detail page includes iCal download link | 03-architecture/pages-and-content.md §22 | EVT-21 | `source/build/render-event.js` | covered |

--- a/source/build/render-ical.js
+++ b/source/build/render-ical.js
@@ -18,13 +18,48 @@ function escapeIcal(str) {
 }
 
 /**
- * Formats a date string (YYYY-MM-DD) and time string (HH:MM) as iCalendar
- * floating local datetime: YYYYMMDDTHHMMSS (no Z suffix, no TZID).
+ * IANA time zone for all camp times. Event data stores naive local times
+ * (05-§4.5); the iCal export anchors them to this concrete zone so calendar
+ * apps render the correct wall-clock time regardless of the device zone.
+ */
+const TZID = 'Europe/Stockholm';
+
+/**
+ * Formats a date string (YYYY-MM-DD) and time string (HH:MM) as an
+ * iCalendar local datetime: YYYYMMDDTHHMMSS (no Z suffix). It is paired with
+ * a TZID=Europe/Stockholm parameter on the DTSTART/DTEND property.
  */
 function toIcalDatetime(dateStr, timeStr) {
   const d = toDateString(dateStr).replace(/-/g, '');
   const t = String(timeStr).replace(':', '') + '00';
   return `${d}T${t}`;
+}
+
+/**
+ * Returns the VTIMEZONE component (RFC 5545 §3.6.5) defining Europe/Stockholm
+ * with its EU CET/CEST daylight-saving rules. Embedded once per .ics file so
+ * the TZID referenced by every DTSTART/DTEND resolves unambiguously.
+ */
+function buildVtimezone() {
+  return [
+    'BEGIN:VTIMEZONE',
+    `TZID:${TZID}`,
+    'BEGIN:DAYLIGHT',
+    'TZOFFSETFROM:+0100',
+    'TZOFFSETTO:+0200',
+    'TZNAME:CEST',
+    'DTSTART:19700329T020000',
+    'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+    'END:DAYLIGHT',
+    'BEGIN:STANDARD',
+    'TZOFFSETFROM:+0200',
+    'TZOFFSETTO:+0100',
+    'TZNAME:CET',
+    'DTSTART:19701025T030000',
+    'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+    'END:STANDARD',
+    'END:VTIMEZONE',
+  ].join('\r\n');
 }
 
 /**
@@ -67,10 +102,10 @@ function renderVevent(event, siteUrl) {
   const hostname = extractHostname(siteUrl);
   const lines = [
     'BEGIN:VEVENT',
-    `DTSTART:${toIcalDatetime(event.date, event.start)}`,
+    `DTSTART;TZID=${TZID}:${toIcalDatetime(event.date, event.start)}`,
   ];
   if (event.end) {
-    lines.push(`DTEND:${toIcalDatetime(event.date, event.end)}`);
+    lines.push(`DTEND;TZID=${TZID}:${toIcalDatetime(event.date, event.end)}`);
   }
   lines.push(
     `DTSTAMP:${buildDtstamp()}`,
@@ -99,6 +134,7 @@ function renderEventIcal(event, camp, siteUrl) {
     'PRODID:-//SB Sommar//Schema//SV',
     `X-WR-CALNAME:${escapeIcal(camp.name)}`,
     'METHOD:PUBLISH',
+    buildVtimezone(),
     renderVevent(event, siteUrl),
     'END:VCALENDAR',
     '',
@@ -122,6 +158,7 @@ function renderIcalFeed(camp, events, siteUrl) {
     'PRODID:-//SB Sommar//Schema//SV',
     `X-WR-CALNAME:Schema – ${escapeIcal(camp.name)}`,
     'METHOD:PUBLISH',
+    buildVtimezone(),
   ];
   if (vevents) {
     lines.push(vevents);

--- a/tests/render-ical.test.js
+++ b/tests/render-ical.test.js
@@ -96,14 +96,14 @@ describe('renderEventIcal – per-event .ics (02-§45.2–45.6)', () => {
     assert.strictEqual(count, 1, 'should have exactly one VEVENT');
   });
 
-  it('ICAL-08 (02-§45.4): VEVENT includes DTSTART', () => {
+  it('ICAL-08 (02-§45.4): VEVENT includes DTSTART with Stockholm TZID', () => {
     const ics = renderEventIcal(fullEvent, camp, siteUrl);
-    assert.ok(ics.includes('DTSTART:20260629T100000'), 'should have DTSTART in floating local format');
+    assert.ok(ics.includes('DTSTART;TZID=Europe/Stockholm:20260629T100000'), 'should have DTSTART anchored to Europe/Stockholm');
   });
 
   it('ICAL-09 (02-§45.4): VEVENT includes DTEND when end is set', () => {
     const ics = renderEventIcal(fullEvent, camp, siteUrl);
-    assert.ok(ics.includes('DTEND:20260629T120000'), 'should have DTEND in floating local format');
+    assert.ok(ics.includes('DTEND;TZID=Europe/Stockholm:20260629T120000'), 'should have DTEND anchored to Europe/Stockholm');
   });
 
   it('ICAL-10 (02-§45.4): VEVENT includes SUMMARY', () => {
@@ -138,12 +138,13 @@ describe('renderEventIcal – per-event .ics (02-§45.2–45.6)', () => {
     assert.ok(ics.includes('UID:fotboll-2026-06-29-1000@sommar.digitalasynctransparency.com'), 'should have UID with hostname');
   });
 
-  it('ICAL-16 (02-§45.5): times use floating local format (no Z, no TZID)', () => {
+  it('ICAL-16 (02-§45.5): times are anchored to Europe/Stockholm (TZID, no Z)', () => {
     const ics = renderEventIcal(fullEvent, camp, siteUrl);
-    // Should NOT have Z suffix
-    assert.ok(!ics.includes('DTSTART:20260629T100000Z'), 'should not have Z suffix');
-    // Should NOT have TZID
-    assert.ok(!ics.includes('TZID'), 'should not have TZID');
+    // DTSTART/DTEND must NOT use a UTC Z suffix — they are zoned local times
+    assert.ok(!/DTSTART[^\r\n]*Z\r?\n/.test(ics), 'DTSTART should not have Z suffix');
+    assert.ok(!/DTEND[^\r\n]*Z\r?\n/.test(ics), 'DTEND should not have Z suffix');
+    // They must carry the Europe/Stockholm TZID parameter
+    assert.ok(ics.includes('DTSTART;TZID=Europe/Stockholm:'), 'DTSTART should carry TZID=Europe/Stockholm');
   });
 
   it('ICAL-17 (02-§45.6): DTEND omitted when end is null', () => {
@@ -153,7 +154,7 @@ describe('renderEventIcal – per-event .ics (02-§45.2–45.6)', () => {
 
   it('ICAL-18 (02-§45.6): DTSTART present even when end is null', () => {
     const ics = renderEventIcal(minimalEvent, camp, siteUrl);
-    assert.ok(ics.includes('DTSTART:20260629T080000'), 'should have DTSTART');
+    assert.ok(ics.includes('DTSTART;TZID=Europe/Stockholm:20260629T080000'), 'should have DTSTART');
   });
 
   it('ICAL-19: DESCRIPTION for event without description only shows responsible', () => {
@@ -244,6 +245,30 @@ describe('DTSTAMP in VEVENT (02-§46.14–46.15)', () => {
     const veventCount = (ics.match(/BEGIN:VEVENT/g) || []).length;
     const dtstampCount = (ics.match(/DTSTAMP:/g) || []).length;
     assert.strictEqual(dtstampCount, veventCount, 'every VEVENT should have DTSTAMP');
+  });
+});
+
+// ── VTIMEZONE / Europe/Stockholm anchoring (02-§45.5) ───────────────────────
+
+describe('VTIMEZONE anchoring (02-§45.5)', () => {
+  it('ICAL-34 (02-§45.5): per-event .ics embeds a Europe/Stockholm VTIMEZONE with DST rules', () => {
+    const ics = renderEventIcal(fullEvent, camp, siteUrl);
+    assert.ok(ics.includes('BEGIN:VTIMEZONE'), 'should open VTIMEZONE');
+    assert.ok(ics.includes('TZID:Europe/Stockholm'), 'should declare TZID:Europe/Stockholm');
+    assert.ok(ics.includes('BEGIN:DAYLIGHT'), 'should define the DAYLIGHT (CEST) sub-component');
+    assert.ok(ics.includes('BEGIN:STANDARD'), 'should define the STANDARD (CET) sub-component');
+    assert.ok(ics.includes('END:VTIMEZONE'), 'should close VTIMEZONE');
+  });
+
+  it('ICAL-35 (02-§45.5): VTIMEZONE appears before the first VEVENT', () => {
+    const ics = renderEventIcal(fullEvent, camp, siteUrl);
+    assert.ok(ics.indexOf('BEGIN:VTIMEZONE') < ics.indexOf('BEGIN:VEVENT'), 'VTIMEZONE should precede VEVENT');
+  });
+
+  it('ICAL-36 (02-§45.5): full-camp feed includes exactly one shared VTIMEZONE', () => {
+    const ics = renderIcalFeed(camp, events, siteUrl);
+    const count = (ics.match(/BEGIN:VTIMEZONE/g) || []).length;
+    assert.strictEqual(count, 1, 'should embed one shared VTIMEZONE regardless of event count');
   });
 });
 


### PR DESCRIPTION
## Bakgrund

Issue #430: när man lägger till en aktivitet från schemat till sin kalender hoppar tiden fram 2 timmar (en aktivitet kl. 15 hamnar kl. 17). Rapporterat på iPhone/iOS Calendar.

**Orsak:** iCal-exporten skrev ut tider som flytande lokaltid (`DTSTART:YYYYMMDDTHHMMSS`, utan `Z` och utan `TZID`). Apple/iOS Calendar tolkar tvetydig flytande tid som UTC och förskjuter den till enhetens tidszon — på sommaren Europe/Stockholm = UTC+2 — så 15:00 visades som 17:00.

## Lösning

Förankra exporttiderna till en konkret tidszon:

- `DTSTART`/`DTEND` får parametern `;TZID=Europe/Stockholm`.
- Varje `.ics`-fil (både per-event och hela lägret) bäddar in ett `VTIMEZONE`-block med EU:s CET/CEST-regler, placerat före första `VEVENT`.
- Datamodellen (naiv lokaltid i YAML, 05-§4.5) är orörd — det är bara exporten som talar om vilken zon "lokal" betyder.

## Ändringar

- `docs/02-requirements/schedule-and-detail.md` — krav 02-§45.5 omskrivet till önskat läge (TZID + VTIMEZONE).
- `docs/03-architecture/pages-and-content.md` — iCal-strukturen (§22.3) uppdaterad med VTIMEZONE-exempel och förklaring.
- `docs/99-traceability/02-requirements.md` — spårbarhetsrad uppdaterad.
- `tests/render-ical.test.js` — ICAL-08/09/16/18 justerade; nya ICAL-34/35/36 för VTIMEZONE.
- `source/build/render-ical.js` — `buildVtimezone()` + TZID-parameter på DTSTART/DTEND.

## Testplan

- [x] `npm test` — hela sviten grön (1908 tester)
- [x] `npm run lint` (eslint + markdownlint) rent
- [x] Byggde sajten och inspekterade utdata: en 12:00-lunch exporteras som `DTSTART;TZID=Europe/Stockholm:20260622T120000` med inbäddat `VTIMEZONE`
- [ ] Manuell verifiering: ladda ner en `event.ics` på iPhone och bekräfta att tiden visas rätt

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYBGV4h5f5hYm3ZQssyYwr)_