### PR TITLE
docs: retarget repo to SBsommar org; document merge queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # GitHub credentials for the add-event API.
 # Grant the token write access to the repository contents.
 GITHUB_TOKEN=ghp_...
-GITHUB_OWNER=moggleif
+GITHUB_OWNER=SBsommar
 GITHUB_REPO=sbsommar
 GITHUB_BRANCH=main
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SB Sommar is a family camp in Sysslebäck for particularly gifted children, youn
 
 This is the camp's official website — the single place where families find everything they need to understand, trust, and decide to attend.
 
-> **📖 Project documentation:** <https://moggleif.github.io/sbsommar/>
+> **📖 Project documentation:** <https://sbsommar.github.io/sbsommar/>
 > — rendered from [`docs/`](docs/) and republished automatically on
 > every push to `main`. Browse the documentation in your browser
 > instead of clicking through `.md` files here.
@@ -98,7 +98,7 @@ Start by reading [docs/01-CONTRIBUTORS.md](docs/01-CONTRIBUTORS.md). It covers s
 ### Documentation
 
 Read the full documentation in your browser at
-<https://moggleif.github.io/sbsommar/>, or click any file below to
+<https://sbsommar.github.io/sbsommar/>, or click any file below to
 read it directly on GitHub.
 
 | #  | Doc | What it covers |

--- a/SECURITY-ASSESSMENT-2026-06.md
+++ b/SECURITY-ASSESSMENT-2026-06.md
@@ -41,19 +41,19 @@ legacy camp YAML; maintainers reading auto-created GitHub issues.
 
 | # | Finding | Severity | Issue |
 |---|---------|----------|-------|
-| N1 | Feedback metadata (`url`, `viewport`, `userAgent`, `timestamp`) embedded in GitHub-issue Markdown without sanitisation or length limit | Medium | [#383](https://github.com/moggleif/sbsommar/issues/383) |
-| N2 | No HTTP security headers (CSP, nosniff, frame-ancestors, Referrer-Policy, Permissions-Policy, HSTS) | Medium | [#384](https://github.com/moggleif/sbsommar/issues/384) |
-| N3 | Event `link` field rendered without URL-protocol validation (build + client) | Low | [#385](https://github.com/moggleif/sbsommar/issues/385) |
-| N4 | Admin-token comparison short-circuits on length, not fully constant-time (vs §91.8) | Low | [#386](https://github.com/moggleif/sbsommar/issues/386) |
-| N5 | `SESSION_SECRET` undocumented in `.env.example`; no strength guidance (weak value → ownership-HMAC forgery) | Low | [#387](https://github.com/moggleif/sbsommar/issues/387) |
+| N1 | Feedback metadata (`url`, `viewport`, `userAgent`, `timestamp`) embedded in GitHub-issue Markdown without sanitisation or length limit | Medium | [#383](https://github.com/SBsommar/sbsommar/issues/383) |
+| N2 | No HTTP security headers (CSP, nosniff, frame-ancestors, Referrer-Policy, Permissions-Policy, HSTS) | Medium | [#384](https://github.com/SBsommar/sbsommar/issues/384) |
+| N3 | Event `link` field rendered without URL-protocol validation (build + client) | Low | [#385](https://github.com/SBsommar/sbsommar/issues/385) |
+| N4 | Admin-token comparison short-circuits on length, not fully constant-time (vs §91.8) | Low | [#386](https://github.com/SBsommar/sbsommar/issues/386) |
+| N5 | `SESSION_SECRET` undocumented in `.env.example`; no strength guidance (weak value → ownership-HMAC forgery) | Low | [#387](https://github.com/SBsommar/sbsommar/issues/387) |
 
 Already tracked (not re-filed):
 
 | # | Finding | Issue |
 |---|---------|-------|
-| T1 | PHP rate limiting trusts spoofable `X-Forwarded-For`; state file written without locking | [#371](https://github.com/moggleif/sbsommar/issues/371) |
-| T2 | PHP time-gating fails *open* when camp metadata is unavailable | [#370](https://github.com/moggleif/sbsommar/issues/370) |
-| T3 | Event-data PR workflow runs no real validation; misses `event-delete/` prefix | [#369](https://github.com/moggleif/sbsommar/issues/369) |
+| T1 | PHP rate limiting trusts spoofable `X-Forwarded-For`; state file written without locking | [#371](https://github.com/SBsommar/sbsommar/issues/371) |
+| T2 | PHP time-gating fails *open* when camp metadata is unavailable | [#370](https://github.com/SBsommar/sbsommar/issues/370) |
+| T3 | Event-data PR workflow runs no real validation; misses `event-delete/` prefix | [#369](https://github.com/SBsommar/sbsommar/issues/369) |
 
 ---
 
@@ -68,7 +68,7 @@ fields are not run through the injection-pattern scan that `title`/`description`
 `name` get (contradicting §73.12), and none of them is length-limited. A client
 can therefore inject `|`, newlines, or arbitrary Markdown to break the table or
 smuggle misleading content into an issue a maintainer reads, or send a very
-large payload (within the 5/hour limit). See [#383](https://github.com/moggleif/sbsommar/issues/383).
+large payload (within the 5/hour limit). See [#383](https://github.com/SBsommar/sbsommar/issues/383).
 
 ### N2 — Missing HTTP security headers — Medium
 
@@ -77,7 +77,7 @@ large payload (within the 5/hour limit). See [#383](https://github.com/moggleif/
 `frame-ancestors`, `Referrer-Policy`, `Permissions-Policy`, or HSTS anywhere in
 the repo. The site renders user-submitted content as HTML and relies on a
 blocklist + Markdown sanitiser as its only XSS defence; a CSP would be an
-independent second layer. See [#384](https://github.com/moggleif/sbsommar/issues/384).
+independent second layer. See [#384](https://github.com/SBsommar/sbsommar/issues/384).
 
 ### N3 — `link` field rendered without protocol validation — Low
 
@@ -88,14 +88,14 @@ checked only at API submission and in the CI scanner — but per #369 the
 event-data PR validation is effectively a no-op, and manually edited / legacy
 YAML never passes the API. The Markdown sanitiser already guards `description`
 links via `isUnsafeUri()`; the standalone `link` field should get the same
-treatment. See [#385](https://github.com/moggleif/sbsommar/issues/385).
+treatment. See [#385](https://github.com/SBsommar/sbsommar/issues/385).
 
 ### N4 — Admin-token comparison not fully constant-time — Low
 
 `verifyAdminToken` guards with `strlen($candidate) === strlen($valid)` before
 `hash_equals`, leaking length via timing. §91.8 explicitly promises constant-time
 comparison. Real-world exploitability is negligible (UUID-bearing tokens), but
-the code deviates from its own requirement. See [#386](https://github.com/moggleif/sbsommar/issues/386).
+the code deviates from its own requirement. See [#386](https://github.com/SBsommar/sbsommar/issues/386).
 
 ### N5 — `SESSION_SECRET` undocumented, no strength requirement — Low
 
@@ -103,7 +103,7 @@ Activity ownership (edit/delete authorisation) rests on an HMAC-SHA256 signature
 keyed by `SESSION_SECRET`. The variable is absent from `.env.example` and has no
 documented strength requirement. An empty value fails closed (good), but a weak
 *set* value would let an attacker forge ownership cookies and edit/delete other
-people's activities. See [#387](https://github.com/moggleif/sbsommar/issues/387).
+people's activities. See [#387](https://github.com/SBsommar/sbsommar/issues/387).
 
 ---
 

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -798,7 +798,7 @@ existing deployment workflow.
   (above the documentation index) that links back to the source
   repository on GitHub, the rendered `README.md` on GitHub, and the
   GitHub issue tracker. The links target absolute
-  `https://github.com/moggleif/sbsommar` URLs so they resolve
+  `https://github.com/SBsommar/sbsommar` URLs so they resolve
   identically whether the page is viewed on the published Pages site
   or on GitHub's file viewer. <!-- 02-§97.15 -->
 - The landing page does not link to `https://sbsommar.se` (the
@@ -818,7 +818,7 @@ existing deployment workflow.
   discoverable only by direct link and must not appear in search
   engine results. This policy mirrors §1a for the camp site
   (`sbsommar.se`) but applies to the documentation site
-  (`https://moggleif.github.io/sbsommar/`). <!-- 02-§97.18 -->
+  (`https://sbsommar.github.io/sbsommar/`). <!-- 02-§97.18 -->
 - A `docs/robots.txt` file at the documentation site root disallows
   every user agent from every path (`User-agent: *` /
   `Disallow: /`). <!-- 02-§97.19 -->

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -157,6 +157,14 @@ Concurrent form submissions therefore all reach `main` automatically: no PR is
 left stranded `behind` the branch it was forked from, and no manual
 "Update branch" step is needed.
 
+The required `Lint, Test & Build` check reaches a queue branch because `ci.yml`
+triggers on `push` to `**`, which matches `gh-readonly-queue/main/*`. No workflow
+declares a `merge_group:` trigger, so narrowing that `push` filter stops the check
+from reporting on the queue branch: queued PRs then wait out the 60-minute
+status-check timeout, are treated as failed, and drop from the queue without
+merging. Add an explicit `merge_group:` trigger to the check-providing workflows
+before narrowing the `push` trigger.
+
 ### Environment Variables
 
 | Variable         | Default | Description                                              |

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -143,6 +143,20 @@ flowchart TD
     end
 ```
 
+### Merge queue
+
+All pull requests to `main` — including the automated `event/`, `event-edit/`,
+and `event-delete/` PRs opened by the form API — merge through a **merge queue**
+required by the `main` branch ruleset. When a PR's required checks pass and
+auto-merge is enabled, GitHub adds it to the queue instead of merging it directly.
+
+The queue merges one entry at a time. Each queued PR is re-tested on a temporary
+`gh-readonly-queue/main/*` branch built on the current `main` tip, so a PR forked
+from an older `main` is rebuilt against the latest commit and merged in order.
+Concurrent form submissions therefore all reach `main` automatically: no PR is
+left stranded `behind` the branch it was forked from, and no manual
+"Update branch" step is needed.
+
 ### Environment Variables
 
 | Variable         | Default | Description                                              |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1396,7 +1396,7 @@ its requirement rows together with the test-legend rows that evidence them.
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§97.1` | implemented | Pages enabled; `gh api repos/moggleif/sbsommar/pages` returns status `built` with `html_url=https://moggleif.github.io/sbsommar/` |
+| `02-§97.1` | implemented | Pages enabled; `gh api repos/SBsommar/sbsommar/pages` returns status `built` with `html_url=https://sbsommar.github.io/sbsommar/` |
 | `02-§97.2` | implemented | Same API response shows `source.branch=main`, `source.path=/docs` |
 | `02-§97.3` | implemented | Pages' built-in automatic deploy runs on every push to `main` that touches `docs/`; verified after the initial enablement |
 | `02-§97.4` | implemented | `docs/` contains only project documentation; no secrets, env values, or non-docs files — manual content review during this PR |
@@ -1408,7 +1408,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§97.10` | implemented | `deploy-qa.yml`, `deploy-prod.yml`, `deploy-reusable.yml`, `event-data-deploy.yml`, and `event-data-deploy-post-merge.yml` are untouched in this PR |
 | `02-§97.11` | implemented | No `docs/CNAME` file; default `*.github.io` URL in use |
 | `02-§97.12` | implemented | `docs/index.md` lists every other docs file with a one-line description and an `.md` link; `jekyll-relative-links` resolves the links to rendered pages — manual browser verification |
-| `02-§97.13` | covered | README-DOCS-01, README-DOCS-02: `README.md` links to `https://moggleif.github.io/sbsommar/` and the link sits above the `## For Developers` section |
+| `02-§97.13` | covered | README-DOCS-01, README-DOCS-02: `README.md` links to `https://sbsommar.github.io/sbsommar/` and the link sits above the `## For Developers` section |
 | `02-§97.14` | covered | README-DOCS-03, README-DOCS-04: `README.md` doc table includes all 10 `docs/*.md` files; drift test keeps the expected list in sync with `docs/` contents |
 | `02-§97.15` | covered | DOCS-IDX-01..03: `docs/index.md` carries the reverse-discoverability banner with absolute github.com links to repo, README, and issues |
 | `02-§97.16` | covered | DOCS-IDX-04: `docs/index.md` no longer contains any `https://sbsommar.se` link |

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@ title: Project Documentation
 # Project Documentation
 
 > **📦 Source:**
-> [moggleif/sbsommar](https://github.com/moggleif/sbsommar)
-> · [README](https://github.com/moggleif/sbsommar#readme)
-> · [Issues](https://github.com/moggleif/sbsommar/issues)
+> [SBsommar/sbsommar](https://github.com/SBsommar/sbsommar)
+> · [README](https://github.com/SBsommar/sbsommar#readme)
+> · [Issues](https://github.com/SBsommar/sbsommar/issues)
 
 This is the developer-facing documentation for a static-site project.
-Start with the [README](https://github.com/moggleif/sbsommar#readme)
+Start with the [README](https://github.com/SBsommar/sbsommar#readme)
 on GitHub for project context, then use the index below to dive into
 contribution rules, architecture, data contracts, design tokens,
 environments, releasing, and the full requirements traceability matrix.

--- a/tests/docs-site-config.test.js
+++ b/tests/docs-site-config.test.js
@@ -169,12 +169,12 @@ describe('docs/index.md — landing-page contract (02-§97.15–97.17)', () => {
   // (`[text](url)` or `<url>`) so CodeQL sees a complete URL context and
   // does not flag the assertions as incomplete URL substring sanitisation.
   // See 02-§39.4 for the same remediation pattern.
-  const REPO_URL_LINK = '](https://github.com/moggleif/sbsommar)';
+  const REPO_URL_LINK = '](https://github.com/SBsommar/sbsommar)';
   const README_URL_LINKS = [
-    '](https://github.com/moggleif/sbsommar#readme)',
-    '](https://github.com/moggleif/sbsommar/blob/main/README.md)',
+    '](https://github.com/SBsommar/sbsommar#readme)',
+    '](https://github.com/SBsommar/sbsommar/blob/main/README.md)',
   ];
-  const ISSUES_URL_LINK = '](https://github.com/moggleif/sbsommar/issues)';
+  const ISSUES_URL_LINK = '](https://github.com/SBsommar/sbsommar/issues)';
   const CAMP_SITE_PATTERNS = [
     '](https://sbsommar.se',
     '<https://sbsommar.se',
@@ -195,7 +195,7 @@ describe('docs/index.md — landing-page contract (02-§97.15–97.17)', () => {
     }
     assert.ok(
       raw.includes(REPO_URL_LINK),
-      'docs/index.md must link to the source repo via [text](https://github.com/moggleif/sbsommar)',
+      'docs/index.md must link to the source repo via [text](https://github.com/SBsommar/sbsommar)',
     );
   });
 
@@ -218,7 +218,7 @@ describe('docs/index.md — landing-page contract (02-§97.15–97.17)', () => {
     }
     assert.ok(
       raw.includes(ISSUES_URL_LINK),
-      'docs/index.md must link to the issue tracker via [text](https://github.com/moggleif/sbsommar/issues)',
+      'docs/index.md must link to the issue tracker via [text](https://github.com/SBsommar/sbsommar/issues)',
     );
   });
 

--- a/tests/readme-docs-link.test.js
+++ b/tests/readme-docs-link.test.js
@@ -14,7 +14,7 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const README_PATH = path.join(REPO_ROOT, 'README.md');
 const DOCS_DIR = path.join(REPO_ROOT, 'docs');
 
-const DOCS_SITE_URL = 'https://moggleif.github.io/sbsommar/';
+const DOCS_SITE_URL = 'https://sbsommar.github.io/sbsommar/';
 // Match the URL inside a Markdown autolink (`<...>`) so CodeQL recognises
 // the surrounding context — see 02-§39.4.
 const DOCS_SITE_AUTOLINK = `<${DOCS_SITE_URL}>`;


### PR DESCRIPTION
## Summary

Repository ownership moved from `moggleif` to the **SBsommar** org. This patch
realigns the repo with its new home and documents the merge-queue behaviour that
now governs how concurrent event submissions reach `main`.

- **Owner references** retargeted to `github.com/SBsommar/sbsommar` and the docs
  site `https://sbsommar.github.io/sbsommar/` across `README.md`,
  `docs/index.md`, the §97.18 requirement in `build-deploy.md`, the
  §97.1/§97.13 traceability evidence, `SECURITY-ASSESSMENT-2026-06.md`, and
  `.env.example` (`GITHUB_OWNER`). The maintainer/approver `moggleif` is
  intentionally unchanged (personal account, still the maintainer/required reviewer).
- **Tests** `docs-site-config.test.js` and `readme-docs-link.test.js` hardcode
  the published URLs; updated to the SBsommar org so they match the docs.
- **04-OPERATIONS** gains a "Merge queue" subsection, including the
  `merge_group`/`push:['**']` dependency that keeps required checks running on
  queue branches.

## Closes #440 — "Kan inte lägga en event"

Filed via the feedback form during the ownership transfer, when the API token was
not yet authorised for the new org and merges to `main` were blocked. The write
path is restored and verified: event PR #439 was **created by the live add-event
API** in the new org and landed on `main` (merged manually by `moggleif`). This
proves the API reaches `SBsommar/sbsommar`.

⚠️ **Server check still required for durable closure:** the live API runs from
`$DEPLOY_DIR/.env` on Loopia. Confirm there that `GITHUB_OWNER=SBsommar` (not
`moggleif`) and that `GITHUB_TOKEN` has write access to `SBsommar/sbsommar`
**independently of GitHub's rename redirect** — a fine-grained PAT must be
re-scoped to the org. #439 succeeding does not by itself prove the server env was
updated (a stale owner + still-valid classic token would also succeed via redirect).

## Closes #435 — edit-event auto-merge race condition

A concurrent edit could leave its PR stranded `behind` `main` (GitHub auto-merge
does not update a behind branch). The `main` ruleset now requires a **merge
queue**, which serialises merges and re-tests each entry on a temporary
`gh-readonly-queue/main/*` branch built on the latest `main` — so concurrent
submissions all merge automatically. Verified in production: queue branches for
PRs #455/#458 ran `Lint, Test & Build` and merged with `merged_by: null`
(merged by the queue, not a human). Documented in `docs/04-OPERATIONS.md`.

## Test plan

- [x] `npm test` — 1908 pass, 0 fail, 0 skipped
- [x] `npm run lint:md` — clean
- [x] `grep -r moggleif` — only the intentional maintainer line in `08-ENVIRONMENTS.md` remains
- [x] Phase 6 adversarial review (3 reviewers) — no blockers; merge-queue doc caveat added
- [x] CI green on the PR (ci.yml · CodeQL · code quality) — merges via the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
