### PR TITLE
Strip trailing whitespace from rendered description HTML

### DIFF
--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -167,6 +167,7 @@ Part of [the traceability index](./index.md).
 | MDP-01..06 | `tests/coverage-css.test.js` | `02-§55.1–55.5 — Modal design polish` |
 | MKD-D01..15, MKD-D25..30 | `tests/markdown.test.js` | `renderDescriptionHtml (02-§56.1, 02-§56.6, 02-§56.7)` (incl. nested-attack, whitespace, tel-hyphens, case-insensitive scheme, raw-HTML drop, image-src neutralization) |
 | MKD-D16..24 | `tests/markdown.test.js` | `stripMarkdown (02-§56.4, 02-§56.5)` |
+| MKD-D31..34 | `tests/markdown.test.js` | `renderDescriptionHtml` / `stripTrailingWhitespace` strip line-trailing whitespace from rendered HTML (CL-§5.1) |
 | EVT-23..25 | `tests/render-event.test.js` | `renderEventPage – markdown description (02-§56.1, 02-§56.6, 02-§56.7)` |
 | RSS-16 | `tests/render-rss.test.js` | `renderRssFeed – markdown stripped (02-§56.4)` |
 | ICAL-32..33 | `tests/render-ical.test.js` | `iCal DESCRIPTION markdown stripped (02-§56.5)` |

--- a/source/build/markdown.js
+++ b/source/build/markdown.js
@@ -16,6 +16,21 @@ function fixTelHyphens(html) {
 }
 
 /**
+ * Removes trailing whitespace from every line of an HTML string.
+ *
+ * Event descriptions are free text: a participant can type a trailing space at
+ * the end of a line, and a multi-paragraph description carries blank lines.
+ * Marked preserves both, so the rendered HTML would contain trailing whitespace
+ * that fails html-validate's `no-trailing-whitespace` rule (CL-§5.1). Stripping
+ * it here — the single point every schedule, today, display, archive and
+ * per-event page renders a description through — keeps every HTML output valid
+ * regardless of what is stored in the event data.
+ */
+function stripTrailingWhitespace(html) {
+  return html.replace(/[ \t]+$/gm, '');
+}
+
+/**
  * Converts a Markdown description string to sanitized HTML.
  *
  * Sanitization is performed by the marked renderer overrides defined in
@@ -29,7 +44,7 @@ function fixTelHyphens(html) {
 function renderDescriptionHtml(text) {
   if (!text || !text.trim()) return '';
   const md = new Marked({ renderer: renderers });
-  const html = md.parse(text).trim();
+  const html = stripTrailingWhitespace(md.parse(text).trim());
   return fixTelHyphens(html);
 }
 
@@ -70,4 +85,4 @@ function stripMarkdown(text) {
     .trim();
 }
 
-module.exports = { renderDescriptionHtml, stripMarkdown };
+module.exports = { renderDescriptionHtml, stripMarkdown, stripTrailingWhitespace };

--- a/source/data/2026-06-syssleback/avslutningsmote-alla-deltar-2026-06-27-1800.yaml
+++ b/source/data/2026-06-syssleback/avslutningsmote-alla-deltar-2026-06-27-1800.yaml
@@ -11,10 +11,10 @@ event:
     Vi börjar med avetablering, alla hjälps åt!
     När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.
     Ofta en gemensam bild på alla deltagare (som vill).
-    
+
     **Avetablering:**
     Gemensam översyn på området med iordningställande och städ.
-    
+
     - Alla tält packas ner.
     - All utrustning tas om hand.
     - Alla gemensamma ytor sopas.

--- a/source/data/2026-06-syssleback/besok-pa-finngarden-keski-i-kindsjon-2026-06-25-1230.yaml
+++ b/source/data/2026-06-syssleback/besok-pa-finngarden-keski-i-kindsjon-2026-06-25-1230.yaml
@@ -9,9 +9,9 @@ event:
   description: |
     Vi besöker Finngården Keski i Kindsjön.
     Lars Nordström tar emot och visar gården, talar om kompostering och allt annat inom självhushåll.
-    
+
     Mer info på finnskogsgarden.se
-    
+
   link: 'https://finnskogsgarden.se'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/bradspel-2026-06-22-1900.yaml
+++ b/source/data/2026-06-syssleback/bradspel-2026-06-22-1900.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi ses och spelar brädspel tillsammans. Kunskapsspel. Ofta TP eller När då då.
     Aktiviteten kommer att ställas in den kväll som det blir grillkväll.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/bradspel-2026-06-23-1900.yaml
+++ b/source/data/2026-06-syssleback/bradspel-2026-06-23-1900.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi ses och spelar brädspel tillsammans. Kunskapsspel. Ofta TP eller När då då.
     Aktiviteten kommer att ställas in den kväll som det blir grillkväll.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/bradspel-2026-06-24-1900.yaml
+++ b/source/data/2026-06-syssleback/bradspel-2026-06-24-1900.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi ses och spelar brädspel tillsammans. Kunskapsspel. Ofta TP eller När då då.
     Aktiviteten kommer att ställas in den kväll som det blir grillkväll.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/bradspel-2026-06-25-1900.yaml
+++ b/source/data/2026-06-syssleback/bradspel-2026-06-25-1900.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi ses och spelar brädspel tillsammans. Kunskapsspel. Ofta TP eller När då då.
     Aktiviteten kommer att ställas in den kväll som det blir grillkväll.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/bradspel-2026-06-26-1900.yaml
+++ b/source/data/2026-06-syssleback/bradspel-2026-06-26-1900.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi ses och spelar brädspel tillsammans. Kunskapsspel. Ofta TP eller När då då.
     Aktiviteten kommer att ställas in den kväll som det blir grillkväll.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/brain-games-2026-06-24-1500.yaml
+++ b/source/data/2026-06-syssleback/brain-games-2026-06-24-1500.yaml
@@ -11,7 +11,7 @@ event:
     Lag på 4-5 personer.
     2 klasser: alla under 13 samt blandade åldrar.
     Lös klurigheter i olika stationer. Alla stationer har en maxtid på 7 minuter.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/dalarna-gavleborg-lokalforeningstraff-2026-06-23-1400.yaml
+++ b/source/data/2026-06-syssleback/dalarna-gavleborg-lokalforeningstraff-2026-06-23-1400.yaml
@@ -8,9 +8,9 @@ event:
   responsible: Lisa Lautrup
   description: |
     Passa på att träffa andra på lägret från samma geografiska område 🎉
-    
+
     Hitta nya och gamla bekanta. Fundera på vilka aktiviteter som kan göras lokalt. Och bara ha trevligt!
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/esp32-arduino-workshop-2026-06-23-1500.yaml
+++ b/source/data/2026-06-syssleback/esp32-arduino-workshop-2026-06-23-1500.yaml
@@ -7,7 +7,7 @@ event:
   location: GA Datorsal
   responsible: Fridian Fransila
   description: |
-    ESP32/Arduino programmering på valfri nivå. Jag tillhandahåller enheter och breadboards(kopplings plattor). Kom gärna både som nybörjare och erfaren då det är en workshop och det är tänkt att vi lär av varandra. 
+    ESP32/Arduino programmering på valfri nivå. Jag tillhandahåller enheter och breadboards(kopplings plattor). Kom gärna både som nybörjare och erfaren då det är en workshop och det är tänkt att vi lär av varandra.
     Ta gärna med en laptop och USB-c sladd.
   link: null
   owner:

--- a/source/data/2026-06-syssleback/gor-din-egen-slime-drop-in-2026-06-23-1500.yaml
+++ b/source/data/2026-06-syssleback/gor-din-egen-slime-drop-in-2026-06-23-1500.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Kajsa Ögård
   description: |
     Kom och gör fluffig eller genomskinlig slime i olika färger. Vi har tillbehören och visar hur. Mindre barn bör ha med en vuxen som hjälper till. Vuxna är varmt välkomna att själva göra slime i mån om plats. Drop-in i tältet vid servicehuset - man behöver inte vara med från start.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/gora-karaktarer-ellens-kampanj-2026-06-22-1500.yaml
+++ b/source/data/2026-06-syssleback/gora-karaktarer-ellens-kampanj-2026-06-22-1500.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Göra karaktärer Ellens kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/gora-karaktarer-johans-kampanj-2026-06-22-1500.yaml
+++ b/source/data/2026-06-syssleback/gora-karaktarer-johans-kampanj-2026-06-22-1500.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Göra karaktärer Johans kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/gora-karaktarer-tovas-kampanj-2026-06-22-1300.yaml
+++ b/source/data/2026-06-syssleback/gora-karaktarer-tovas-kampanj-2026-06-22-1300.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Göra karaktärer Tovas kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/gora-karaktarer-xanders-kampanj-2026-06-22-1300.yaml
+++ b/source/data/2026-06-syssleback/gora-karaktarer-xanders-kampanj-2026-06-22-1300.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Göra karaktärer Xanders kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/introduktionsmote-trans-2026-06-22-1115.yaml
+++ b/source/data/2026-06-syssleback/introduktionsmote-trans-2026-06-22-1115.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Lisa Lautrup
   description: |
     Barn, unga och vuxna som har koppling till trans är välkomna på ett första introduktionsmöte. Syftet är att knyta kontakter tidigt i veckan så att vi hinner lära känna varandra.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/jamtland-harjedalen-2026-06-23-1400.yaml
+++ b/source/data/2026-06-syssleback/jamtland-harjedalen-2026-06-23-1400.yaml
@@ -8,9 +8,9 @@ event:
   responsible: Karin Back Swedin
   description: |
     Passa på att träffa andra på lägret från samma geografiska område 🎉
-    
+
     Hitta nya och gamla bekanta. Fundera på vilka aktiviteter som kan göras lokalt. Och bara ha trevligt!
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/japansk-bakning-2-2026-06-24-1900.yaml
+++ b/source/data/2026-06-syssleback/japansk-bakning-2-2026-06-24-1900.yaml
@@ -7,12 +7,12 @@ event:
   location: Servicehus
   responsible: Lisa Lautrup
   description: |
-    Vi bakar årets första recept CHOUX CREAM tillsammans baserat på Ai Venturas bakbok ”Japanska bakverk”. 
-    
+    Vi bakar årets första recept CHOUX CREAM tillsammans baserat på Ai Venturas bakbok ”Japanska bakverk”.
+
     Anmälan öppnar 17/6 kl 14:00 och sker via separat bokningsapp.
-    
+
     Se länk till Fb-inlägg för mer info!
-    
+
   link: 'https://www.facebook.com/share/p/1Cre9gFRC9/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/japansk-bakning-3-2026-06-26-1400.yaml
+++ b/source/data/2026-06-syssleback/japansk-bakning-3-2026-06-26-1400.yaml
@@ -8,11 +8,11 @@ event:
   responsible: Lisa Lautrup
   description: |
     Vi bakar årets första recept CHOUX CREAM tillsammans baserat på Ai Venturas bakbok ”Japanska bakverk”.
-    
+
     Anmälan öppnar 17/6 kl 14:00 och sker via separat bokningsapp.
-    
+
     Se länk till Fb-inlägg för mer info!
-    
+
   link: 'https://www.facebook.com/share/p/1Cre9gFRC9/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/japansk-bskning-1-2026-06-22-1400.yaml
+++ b/source/data/2026-06-syssleback/japansk-bskning-1-2026-06-22-1400.yaml
@@ -7,12 +7,12 @@ event:
   location: Servicehus
   responsible: Lisa Lautrup
   description: |
-    Vi bakar årets första recept CHOUX CREAM tillsammans baserat på Ai Venturas bakbok ”Japanska bakverk”. 
-    
+    Vi bakar årets första recept CHOUX CREAM tillsammans baserat på Ai Venturas bakbok ”Japanska bakverk”.
+
     Anmälan öppnar 17/6 kl 14:00 och sker via separat bokningsapp.
-    
+
     Se länk till Fb-inlägg för mer info!
-    
+
   link: 'https://www.facebook.com/share/p/1Cre9gFRC9/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/lar-kanna-varandra-och-lagret-ish-tipsrunda-2026-06-22-0915.yaml
+++ b/source/data/2026-06-syssleback/lar-kanna-varandra-och-lagret-ish-tipsrunda-2026-06-22-0915.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Cecilia Löfgreen
   description: |
     Varmt välkomna på en rundtur i grupp där ni får lära känna varandra och lägret bättre.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/musikproduktion-intro-2026-06-23-1300.yaml
+++ b/source/data/2026-06-syssleback/musikproduktion-intro-2026-06-23-1300.yaml
@@ -11,11 +11,11 @@ event:
     Vad är audio/midi?
     Vad är en DAW?
     Starta en egen prodd!
-    
+
     Ta med dator med lämpligt program, tex GarageBand, Logic, Ableton Live, Audacity eller Reason. Du behöver även någon typ av hörlurar! :-)
-    
+
     Plats: Holevägen 7
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/parkour-intro-2026-06-24-1400.yaml
+++ b/source/data/2026-06-syssleback/parkour-intro-2026-06-24-1400.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Joel Tegnander
   description: |
     Alla välkomna. Behövs bra kläder samt inneskor om man vill.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/popcorn-2026-06-24-0200.yaml
+++ b/source/data/2026-06-syssleback/popcorn-2026-06-24-0200.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Popcorn.  två olika lag ett lag är popcorn och hoppar jämnfota när deras musikdel spelas.
     Andra laget är zombies och går långsamt när deras musikdel spelas. zombiernas mål är att ta alla popcorn blir man tagen blir man också en zombie.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/prova-pa-naltovning-2026-06-25-1000.yaml
+++ b/source/data/2026-06-syssleback/prova-pa-naltovning-2026-06-25-1000.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Lisa Lautrup
   description: |
     Vi testar nåltovning tills baserat på steg-för-steg instruktioner från Japan :)
-    
+
   link: 'https://www.facebook.com/share/p/196Fs9yPsk/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/prova-pa-sprayfarg-grafitti-2026-06-23-1300.yaml
+++ b/source/data/2026-06-syssleback/prova-pa-sprayfarg-grafitti-2026-06-23-1300.yaml
@@ -7,10 +7,10 @@ event:
   location: Fotbollsplan
   responsible: Eila och Jonas Colling
   description: |
-    Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan. Man kan vända kläder ut och in för att dölja fläckar eller klippa till en sopsäck att ha som förekläde. Vi ger lite tips och tricks men inte så mycket konstnärlig handledning som möjlighet prova på mediet och uttrycka sig fritt. 
-    
+    Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan. Man kan vända kläder ut och in för att dölja fläckar eller klippa till en sopsäck att ha som förekläde. Vi ger lite tips och tricks men inte så mycket konstnärlig handledning som möjlighet prova på mediet och uttrycka sig fritt.
+
     Platsen är beroende av vind och väder, vid regn eller stark vind ställer vi in och kör ett nytt tillfälle senare. Antagligen är vi mellan rollspelstälten och fotbollsplanen, annars sätter vi en skylt vid ingången till hallen där det står var vi är. Om ni har något särskilt ni vill måla på, t ex ett par crocs, en pannå eller vepa är det bara att ta med det.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/prova-pa-sprayfarg-grafitti-2026-06-25-1300.yaml
+++ b/source/data/2026-06-syssleback/prova-pa-sprayfarg-grafitti-2026-06-25-1300.yaml
@@ -7,10 +7,10 @@ event:
   location: Fotbollsplan
   responsible: Eila och Jonas Colling
   description: |
-    Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan. Man kan vända kläder ut och in för att dölja fläckar eller klippa till en sopsäck att ha som förekläde. Vi ger lite tips och tricks men inte så mycket konstnärlig handledning som möjlighet prova på mediet och uttrycka sig fritt. 
-    
+    Testa att måla med sprayfärg eller skapa ditt livs grafittikonstverk. Vi har färger, kartongskivor och skyddsutrustning för mun och ögon, du har oömma kläder och vill prova hur det funkar att jobba nära eller lite längre ifrån ytan. Man kan vända kläder ut och in för att dölja fläckar eller klippa till en sopsäck att ha som förekläde. Vi ger lite tips och tricks men inte så mycket konstnärlig handledning som möjlighet prova på mediet och uttrycka sig fritt.
+
     Platsen är beroende av vind och väder, vid regn eller stark vind ställer vi in och kör ett nytt tillfälle senare. Antagligen är vi mellan rollspelstälten och fotbollsplanen, annars sätter vi en skylt vid ingången till hallen där det står var vi är. Om ni har något särskilt ni vill måla på, t ex ett par crocs, en pannå eller vepa är det bara att ta med det.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/pyssel-med-lufttorkande-lera-drop-in-2026-06-22-1300.yaml
+++ b/source/data/2026-06-syssleback/pyssel-med-lufttorkande-lera-drop-in-2026-06-22-1300.yaml
@@ -7,10 +7,10 @@ event:
   location: AndreasTältet
   responsible: Kajsa Ögård
   description: |
-    Drop-in pyssel med skumlera (soft clay) i många färger i tältet vid servicehuset. 
-    
+    Drop-in pyssel med skumlera (soft clay) i många färger i tältet vid servicehuset.
+
     Ta gärna med saker som du eller andra kan använda för att forma och dekorera leran – små skålar, sugrör, svampar, penslar, grillpinnar, gem, stekspadar etc. Extra knivar (vassa) och släta glasflaskor/burkar som kan användas som brödkavlar är också välkommet.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/qal-infotraff-2026-06-23-1000.yaml
+++ b/source/data/2026-06-syssleback/qal-infotraff-2026-06-23-1000.yaml
@@ -9,7 +9,7 @@ event:
   description: |
     Vi träffas och handarbetar tillsammans. Material för virkning finns på plats men man kan även ta med egna arbeten.
     Alla åldrar och nivåer är varmt välkomna!
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-23-1530.yaml
+++ b/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-23-1530.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Ellens kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-24-1530.yaml
+++ b/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-24-1530.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Ellens kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-25-1530.yaml
+++ b/source/data/2026-06-syssleback/rollspel-ellens-kampanj-2026-06-25-1530.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Ellens kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-24-1900.yaml
+++ b/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-24-1900.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johans kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-25-1900.yaml
+++ b/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-25-1900.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johans kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-26-1900.yaml
+++ b/source/data/2026-06-syssleback/rollspel-johans-kampanj-2026-06-26-1900.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johans kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-one-shot-for-nyborjare-och-erfarna-2026-06-24-1000.yaml
+++ b/source/data/2026-06-syssleback/rollspel-one-shot-for-nyborjare-och-erfarna-2026-06-24-1000.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Johan Eellend
   description: |
     Ett kort äventyr till Drakar och demoner. Passar både nybörjare och de som spelat tidigare.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-one-shot-prova-pa-2026-06-23-1000.yaml
+++ b/source/data/2026-06-syssleback/rollspel-one-shot-prova-pa-2026-06-23-1000.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Prova på rollspel
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-23-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-23-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johan kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-24-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-24-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johan kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-25-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-tovas-kampanj-2026-06-25-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Johan kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-23-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-23-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Xanders kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-24-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-24-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Xanders kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-25-1230.yaml
+++ b/source/data/2026-06-syssleback/rollspel-xanders-kampanj-2026-06-25-1230.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Elin Sommerfeld
   description: |
     Rollspel Xanders kampanj
-    
+
   link: 'https://www.facebook.com/share/p/1C3XR35MzC/?'
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/smote-for-stationsvardar-2026-06-23-1300.yaml
+++ b/source/data/2026-06-syssleback/smote-for-stationsvardar-2026-06-23-1300.yaml
@@ -8,7 +8,7 @@ event:
   responsible: Birgitta
   description: |
     De som är stationsvärdar ses för en genongång inför Brain Games.
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/stockholm-malardalen-lokalforeningstraff-2026-06-23-1400.yaml
+++ b/source/data/2026-06-syssleback/stockholm-malardalen-lokalforeningstraff-2026-06-23-1400.yaml
@@ -8,9 +8,9 @@ event:
   responsible: Johan Nyh
   description: |
     Passa på att träffa andra på lägret från samma geografiska område 🎉
-    
+
     Hitta nya och gamla bekanta. Fundera på vilka aktiviteter som kan göras lokalt. Och bara ha trevligt!
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/2026-06-syssleback/syd-skane-o-blekinge-2026-06-23-1400.yaml
+++ b/source/data/2026-06-syssleback/syd-skane-o-blekinge-2026-06-23-1400.yaml
@@ -8,9 +8,9 @@ event:
   responsible: Emma Lindstrii
   description: |
     Passa på att träffa andra på lägret från samma geografiska område 🎉
-    
+
     Hitta nya och gamla bekanta. Fundera på vilka aktiviteter som kan göras lokalt. Och bara ha trevligt!
-    
+
   link: null
   owner:
     name: ''

--- a/source/data/local.yaml
+++ b/source/data/local.yaml
@@ -31,7 +31,7 @@ locations:
       Kom ihåg, det tar cirka 15-20 minuter att gå till fritidsgården från
       campingen. Städa direkt efter eventuellt användande. Entrén är i den
       gula byggnaden. Där finns:
-      
+
       * TV-rum
       * Grupprum
       * Biljardbord
@@ -131,7 +131,7 @@ locations:
       skolan från campingen. Alla lokaler i skolan städas direkt efter
       användning och återställes i samma skick (helst bättre) som de var i när
       ni kom. Sopor medtages.
-      
+
       * Lektionssalar
       * Bildsal
       * Hemkunskap

--- a/tests/markdown.test.js
+++ b/tests/markdown.test.js
@@ -4,7 +4,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
 // Module under test — will be created in Phase 4
-const { renderDescriptionHtml, stripMarkdown } = require('../source/build/markdown');
+const { renderDescriptionHtml, stripMarkdown, stripTrailingWhitespace } = require('../source/build/markdown');
 
 // ── renderDescriptionHtml (02-§56.1, 02-§56.2, 02-§56.6, 02-§56.7, 02-§56.10) ──
 
@@ -120,6 +120,31 @@ describe('renderDescriptionHtml (02-§56.1, 02-§56.2, 02-§56.6, 02-§56.7)', (
 
   it('MKD-D15 (02-§56.10): function is exported from markdown.js', () => {
     assert.strictEqual(typeof renderDescriptionHtml, 'function');
+  });
+
+  it('MKD-D31 (CL-§5.1): a soft-wrapped line ending in a space leaves no trailing whitespace (the esp32 case)', () => {
+    // A `|` block whose first line ends with a space renders as `<p>line1. \nline2</p>`
+    // — html-validate flags the trailing space before the newline (CI failure on #482).
+    const html = renderDescriptionHtml('Kom som du är. \nTa med en laptop.');
+    assert.ok(!/[ \t]+$/m.test(html), `Expected no line-trailing whitespace, got: ${JSON.stringify(html)}`);
+    assert.ok(html.includes('Ta med en laptop.'), `Expected both lines present, got: ${html}`);
+  });
+
+  it('MKD-D32 (CL-§5.1): blank lines between paragraphs leave no trailing whitespace', () => {
+    const html = renderDescriptionHtml('Första stycket.\n\nAndra stycket.');
+    assert.ok(!/[ \t]+$/m.test(html), `Expected no line to end with whitespace, got: ${JSON.stringify(html)}`);
+  });
+});
+
+// ── stripTrailingWhitespace (CL-§5.1) ──────────────────────────────────────
+
+describe('stripTrailingWhitespace (CL-§5.1)', () => {
+  it('MKD-D33: removes trailing spaces and tabs from every line', () => {
+    assert.strictEqual(stripTrailingWhitespace('a  \nb\t\nc'), 'a\nb\nc');
+  });
+
+  it('MKD-D34: leaves content without trailing whitespace unchanged', () => {
+    assert.strictEqual(stripTrailingWhitespace('<p>hej</p>\n<ul>\n<li>x</li>\n</ul>'), '<p>hej</p>\n<ul>\n<li>x</li>\n</ul>');
   });
 });
 


### PR DESCRIPTION
## Background

`Lint, Test & Build` (`lint:html`) fails on `main` whenever a code PR runs full CI, because some event descriptions contain trailing whitespace that ends up in the rendered HTML:

```
public/schema.html  384:270  error  Trailing whitespace  no-trailing-whitespace
public/schema/esp32-arduino-workshop-.../index.html  71:221  error  Trailing whitespace
```

Root cause: event descriptions are free text. A `|` block whose line ends with a space (e.g. the ESP32 workshop: "…lär av varandra. ") renders via marked as `<p>line1. \nline2</p>` — a line-trailing space that html-validate's `no-trailing-whitespace` rule rejects (CL-§5.1). **Data-only event PRs skip full `ci.yml`** (CL-§9.4), so `lint:html` never ran on these fragments; the failure only surfaces on the first code PR after they landed (#482).

This is pre-existing and not introduced by any single feature PR — it blocks any code PR until fixed.

## Fix

- `renderDescriptionHtml` (`source/build/markdown.js`) strips line-trailing whitespace from the rendered HTML. This is the single point every schedule, today, display, archive and per-event page renders a description through, so HTML output stays valid **regardless of what is stored in the event data** — durable against the live add/edit form re-introducing trailing whitespace.
- Existing fragment files (47) are tidied as a one-time cleanup (cosmetic; the render fix is what guarantees CI stays green).

## Verification

- [x] Restored the original (dirty) ESP32 fragment, rebuilt, `lint:html` passes — proves the render fix alone resolves it
- [x] `npm test` — 1959 tests pass (new: MKD-D31..34)
- [x] `npm run lint` (eslint) clean
- [x] `npm run lint:md` clean
- [x] `npm run build` + `npm run lint:html` clean

## Why a separate PR

This unblocks `lint:html` for every code PR. #482 (split-on-open) is currently red for this reason; once this merges, #482 rebases and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1Ho5cDbvP4ouehpuD7HKp)_