### PR TITLE
fix: duplicate-safe event submission (#480)

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -10,7 +10,7 @@ name: Event Data Deploy (Post-Merge)
 #   1. deploy-qa      – detect inline + build + rsync to QA
 #   2. deploy-prod    – detect inline + QA check + build + SCP to Production
 #   3. close-redundant-event-prs – close duplicate event PRs made redundant by
-#                                  this merge (02-§110.6–110.9)
+#                                  this merge (02-§111.6–111.9)
 
 permissions:
   contents: read
@@ -189,7 +189,7 @@ jobs:
     name: Close redundant duplicate event PRs
     runs-on: ubuntu-latest
     # Needs write access to close a pull request and delete its branch; the
-    # default workflow token is read-only here (02-§110.7).
+    # default workflow token is read-only here (02-§111.7).
     permissions:
       contents: write
       pull-requests: write
@@ -203,7 +203,7 @@ jobs:
 
       # When a duplicate's first identical submission merged in this push, the
       # second pull request now has an empty net diff against main. Close it and
-      # delete its branch so no maintainer has to (02-§110.6–110.9). Uses the
+      # delete its branch so no maintainer has to (02-§111.6–111.9). Uses the
       # pre-installed gh CLI; no dependency install needed.
       - name: Close event PRs made redundant by this merge
         run: node source/scripts/close-redundant-event-prs.js

--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -9,6 +9,8 @@ name: Event Data Deploy (Post-Merge)
 # Jobs:
 #   1. deploy-qa      – detect inline + build + rsync to QA
 #   2. deploy-prod    – detect inline + QA check + build + SCP to Production
+#   3. close-redundant-event-prs – close duplicate event PRs made redundant by
+#                                  this merge (02-§110.6–110.9)
 
 permissions:
   contents: read
@@ -182,3 +184,29 @@ jobs:
           source: staging/*
           target: ${{ secrets.DEPLOY_DIR }}/public_html
           strip_components: 1
+
+  close-redundant-event-prs:
+    name: Close redundant duplicate event PRs
+    runs-on: ubuntu-latest
+    # Needs write access to close a pull request and delete its branch; the
+    # default workflow token is read-only here (02-§110.7).
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # When a duplicate's first identical submission merged in this push, the
+      # second pull request now has an empty net diff against main. Close it and
+      # delete its branch so no maintainer has to (02-§110.6–110.9). Uses the
+      # pre-installed gh CLI; no dependency install needed.
+      - name: Close event PRs made redundant by this merge
+        run: node source/scripts/close-redundant-event-prs.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/api/index.php
+++ b/api/index.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use SBSommar\ActiveCamp;
 use SBSommar\Admin;
+use SBSommar\DuplicateEventException;
 use SBSommar\Feedback;
 use SBSommar\GitHub;
 use SBSommar\RateLimit;
@@ -282,6 +283,11 @@ function handleAddEvent(?array $activeCamp, string $adminTokenSecret, string $se
     try {
         $gh = new GitHub();
         $gh->addEventToActiveCamp($body);
+    } catch (DuplicateEventException $e) {
+        // Same activity already in the schedule — reject cleanly (02-§110.2).
+        jsonResponse(['success' => false, 'error' => 'Den här aktiviteten finns redan i schemat.'], 409);
+
+        return;
     } catch (\Throwable $e) {
         error_log('POST /add-event error: ' . $e->getMessage());
         jsonResponse(['success' => false, 'error' => GitHub::classifyGitHubError($e)], 500);
@@ -364,6 +370,12 @@ function handleAddEvents(?array $activeCamp, string $adminTokenSecret, string $s
     try {
         $gh = new GitHub();
         $eventIds = $gh->addEventsToActiveCamp($body);
+    } catch (DuplicateEventException $e) {
+        // One or more of the chosen dates already have this activity — reject the
+        // whole batch cleanly (02-§110.5).
+        jsonResponse(['success' => false, 'error' => 'Aktiviteten finns redan i schemat för ett eller flera av de valda datumen.'], 409);
+
+        return;
     } catch (\Throwable $e) {
         error_log('POST /add-events error: ' . $e->getMessage());
         jsonResponse(['success' => false, 'error' => GitHub::classifyGitHubError($e)], 500);

--- a/api/index.php
+++ b/api/index.php
@@ -284,7 +284,7 @@ function handleAddEvent(?array $activeCamp, string $adminTokenSecret, string $se
         $gh = new GitHub();
         $gh->addEventToActiveCamp($body);
     } catch (DuplicateEventException $e) {
-        // Same activity already in the schedule — reject cleanly (02-§110.2).
+        // Same activity already in the schedule — reject cleanly (02-§111.2).
         jsonResponse(['success' => false, 'error' => 'Den här aktiviteten finns redan i schemat.'], 409);
 
         return;
@@ -372,7 +372,7 @@ function handleAddEvents(?array $activeCamp, string $adminTokenSecret, string $s
         $eventIds = $gh->addEventsToActiveCamp($body);
     } catch (DuplicateEventException $e) {
         // One or more of the chosen dates already have this activity — reject the
-        // whole batch cleanly (02-§110.5).
+        // whole batch cleanly (02-§111.5).
         jsonResponse(['success' => false, 'error' => 'Aktiviteten finns redan i schemat för ett eller flera av de valda datumen.'], 409);
 
         return;

--- a/api/src/DuplicateEventException.php
+++ b/api/src/DuplicateEventException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBSommar;
+
+/**
+ * Thrown by the add flow when the target fragment already exists on main — i.e.
+ * the same activity (same title + date + start) is already in the schedule. The
+ * HTTP layer maps this to 409 with a clear Swedish message instead of a generic
+ * write-conflict 500 (02-§110.2).
+ */
+final class DuplicateEventException extends \RuntimeException
+{
+}

--- a/api/src/DuplicateEventException.php
+++ b/api/src/DuplicateEventException.php
@@ -8,7 +8,7 @@ namespace SBSommar;
  * Thrown by the add flow when the target fragment already exists on main — i.e.
  * the same activity (same title + date + start) is already in the schedule. The
  * HTTP layer maps this to 409 with a clear Swedish message instead of a generic
- * write-conflict 500 (02-§110.2).
+ * write-conflict 500 (02-§111.2).
  */
 final class DuplicateEventException extends \RuntimeException
 {

--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -79,7 +79,7 @@ final class GitHub
 
         // Reject a duplicate before any branch/PR is created, so an already-merged
         // identical activity fails cleanly (409) instead of a dangling branch and a
-        // generic write-conflict error (02-§110.1, §110.2).
+        // generic write-conflict error (02-§111.1, §111.2).
         if ($this->getFileMaybe($fragPath) !== null) {
             throw new DuplicateEventException("Event already exists: {$event['id']}");
         }
@@ -156,7 +156,7 @@ final class GitHub
 
         // Reject the whole batch before any branch/PR if any date's fragment already
         // exists on main — atomic, so a partial overlap never creates some files
-        // (02-§110.4, §110.5).
+        // (02-§111.4, §111.5).
         foreach ($fragments as [$fragPath, , $eventId]) {
             if ($this->getFileMaybe($fragPath) !== null) {
                 throw new DuplicateEventException("Event already exists: {$eventId}");

--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -77,6 +77,13 @@ final class GitHub
         self::assertFragmentYamlValid($content, $event['id']);
         $commitMsg  = "Add event to {$camp['name']}: {$title} ({$date})";
 
+        // Reject a duplicate before any branch/PR is created, so an already-merged
+        // identical activity fails cleanly (409) instead of a dangling branch and a
+        // generic write-conflict error (02-§110.1, §110.2).
+        if ($this->getFileMaybe($fragPath) !== null) {
+            throw new DuplicateEventException("Event already exists: {$event['id']}");
+        }
+
         // 3. Ephemeral branch → create the new fragment file (no sha) → PR → auto-merge.
         $mainSha    = $this->getMainSha();
         $branchName = 'event/' . $date . '-' . self::slugify($title) . '-' . time();
@@ -143,9 +150,18 @@ final class GitHub
         foreach ($events as $event) {
             $content = self::buildFragmentYaml($event) . "\n";
             self::assertFragmentYamlValid($content, $event['id']);
-            $fragments[] = [self::fragmentPath($camp['file'], $event['id']), $content];
+            $fragments[] = [self::fragmentPath($camp['file'], $event['id']), $content, $event['id']];
         }
         $commitMsg  = "Add " . count($dates) . " recurring events to {$camp['name']}: {$title}";
+
+        // Reject the whole batch before any branch/PR if any date's fragment already
+        // exists on main — atomic, so a partial overlap never creates some files
+        // (02-§110.4, §110.5).
+        foreach ($fragments as [$fragPath, , $eventId]) {
+            if ($this->getFileMaybe($fragPath) !== null) {
+                throw new DuplicateEventException("Event already exists: {$eventId}");
+            }
+        }
 
         // 3. Ephemeral branch → create every fragment file on it → PR → auto-merge.
         $mainSha    = $this->getMainSha();

--- a/app.js
+++ b/app.js
@@ -161,7 +161,7 @@ app.post('/add-event', addEventLimiter, async (req, res) => {
   }
 
   // Duplicate pre-check — runs synchronously so the user sees the rejection even
-  // though the GitHub write below is fire-and-forget (02-§110.2, §110.3). PHP is
+  // though the GitHub write below is fire-and-forget (02-§111.2, §111.3). PHP is
   // synchronous and gets this for free; here it must come before res.json.
   try {
     if (await isDuplicateEvent(req.body)) {

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const fs        = require('fs');
 const path      = require('path');
 const yaml      = require('js-yaml');
 
-const { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, slugify } = require('./source/api/github');
+const { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify } = require('./source/api/github');
 const { validateEventRequest, validateEditRequest }              = require('./source/api/validate');
 const { isEventPast }                                            = require('./source/api/edit-event');
 const {
@@ -133,7 +133,7 @@ app.post('/mint-token', mintTokenLimiter, (req, res) => {
   res.json({ success: true, token: result.token });
 });
 
-app.post('/add-event', addEventLimiter, (req, res) => {
+app.post('/add-event', addEventLimiter, async (req, res) => {
   // Time-gating with pre-camp bypass for admin/early roles (02-§26.17,
   // 02-§26.18, 02-§105.1, 02-§105.3).
   if (activeCamp) {
@@ -158,6 +158,19 @@ app.post('/add-event', addEventLimiter, (req, res) => {
       success: false,
       error: 'Sessionen kunde inte sparas. Kontakta arrangören.',
     });
+  }
+
+  // Duplicate pre-check — runs synchronously so the user sees the rejection even
+  // though the GitHub write below is fire-and-forget (02-§110.2, §110.3). PHP is
+  // synchronous and gets this for free; here it must come before res.json.
+  try {
+    if (await isDuplicateEvent(req.body)) {
+      return res.status(409).json({ success: false, error: DUPLICATE_EVENT_MESSAGE });
+    }
+  } catch (err) {
+    // Pre-check unavailable (e.g. network) — fall through; the background write's
+    // own duplicate guard (github.js) still applies.
+    console.error('POST /add-event duplicate pre-check failed:', err.message);
   }
 
   // Build the event ID the same way github.js does, so we can include it

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -832,3 +832,72 @@ open → fragments while the camp is live → compaction at archive.
   when a camp opens for editing (at or shortly before its `opens_for_editing`
   date), placed in the camp lifecycle as: split at open → fragments while the camp
   is live → compaction at archive. <!-- 02-§110.8 -->
+
+---
+
+## 111. Duplicate Submission Hardening
+
+### 110.1 Context
+
+Activities are submitted in bursts (§109.1). An event's id is derived from its
+title, date, and start time, so submitting the same activity twice produces the
+same id and therefore the same fragment file path
+(`source/data/<stem>/<event-id>.yaml`). Two such submissions try to create the
+same new file, which collides in one of two windows:
+
+- **Already merged.** The first submission has already merged, so the fragment
+  exists on `main`. The second submission cuts a branch and tries to create a
+  file that already exists. Today this surfaces as a generic write-conflict
+  error ("En skrivkonflikt uppstod", §109.8) raised *after* a branch has been
+  created — or, in the Node runtime where the GitHub write is fire-and-forget, as
+  a silent background failure after the form has already reported success.
+- **Concurrent.** Both submissions are in flight before either merges, so neither
+  sees the other's fragment on `main`. Both pull requests are created; the first
+  merges, and the second becomes redundant — the file it would add already exists
+  on `main`. It lingers as an open pull request that a maintainer must close by
+  hand (issue #480; observed as #473/#474, "Färga t-shirt pass 5-6").
+
+The id formula (title + date + start) is intentional and unchanged: two
+submissions that resolve to the same id are treated as the same activity. The
+desired state is that neither window produces a stuck pull request or a confusing
+error.
+
+### 110.2 Duplicate pre-check before submission (site requirements)
+
+- Before any branch or pull request is created, the add flow checks whether the
+  target fragment file (`source/data/<stem>/<event-id>.yaml`) already exists on
+  `main`. <!-- 02-§111.1 -->
+- If the target fragment already exists on `main`, the submission is rejected with
+  HTTP 409 and a Swedish message stating that the activity already exists in the
+  schedule — not a generic write-conflict message. No branch or pull request is
+  created. This refines §109.8. <!-- 02-§111.2 -->
+- The duplicate pre-check runs synchronously, before the success response is sent,
+  so the user always sees the rejection. This holds both in the PHP runtime, where
+  the whole submission is synchronous, and in the Node runtime, where the GitHub
+  write is otherwise fire-and-forget and the check must therefore complete before
+  the response. <!-- 02-§111.3 -->
+- The duplicate pre-check applies to both a single submission (`POST /add-event`)
+  and a batch submission (`POST /add-events`). <!-- 02-§111.4 -->
+- A batch submission is rejected as a whole when any of its target fragment files
+  already exists on `main`; the Swedish message states that one or more of the
+  chosen dates already have this activity. No fragment from a rejected batch is
+  created. <!-- 02-§111.5 -->
+
+### 110.3 Concurrent-duplicate cleanup (site requirements)
+
+- When two identical submissions are created before either merges, both
+  pre-checks pass because neither fragment is yet on `main`. After the first
+  merges, the second submission's pull request adds a file that already exists on
+  `main` with identical content, so its net diff against `main` is
+  empty. <!-- 02-§111.6 -->
+- An event pull request — a branch named `event/*` that changes only files under
+  `source/data/` — whose net diff against `main` is empty is closed automatically
+  and its branch deleted, without maintainer action. The activity is already on
+  the site from the first pull request, so nothing is lost. <!-- 02-§111.7 -->
+- The cleanup runs after each merge of event data to `main`, re-evaluating the
+  open event pull requests so that one made redundant by the merge is closed
+  promptly. <!-- 02-§111.8 -->
+- A concurrent submission that resolves to the same id but carries a different body
+  (so its net diff against `main` is not empty) is outside this automatic cleanup;
+  it is logged for manual attention rather than closed silently, so the residual
+  edge stays visible. <!-- 02-§111.9 -->

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -837,7 +837,7 @@ open → fragments while the camp is live → compaction at archive.
 
 ## 111. Duplicate Submission Hardening
 
-### 110.1 Context
+### 111.1 Context
 
 Activities are submitted in bursts (§109.1). An event's id is derived from its
 title, date, and start time, so submitting the same activity twice produces the
@@ -862,7 +862,7 @@ submissions that resolve to the same id are treated as the same activity. The
 desired state is that neither window produces a stuck pull request or a confusing
 error.
 
-### 110.2 Duplicate pre-check before submission (site requirements)
+### 111.2 Duplicate pre-check before submission (site requirements)
 
 - Before any branch or pull request is created, the add flow checks whether the
   target fragment file (`source/data/<stem>/<event-id>.yaml`) already exists on
@@ -883,7 +883,7 @@ error.
   chosen dates already have this activity. No fragment from a rejected batch is
   created. <!-- 02-§111.5 -->
 
-### 110.3 Concurrent-duplicate cleanup (site requirements)
+### 111.3 Concurrent-duplicate cleanup (site requirements)
 
 - When two identical submissions are created before either merges, both
   pre-checks pass because neither fragment is yet on `main`. After the first

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -21,7 +21,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
-| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109 |
+| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103, §108 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
 | [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105, §106 |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -102,7 +102,7 @@ their `source/data/**.yaml` path filter matches files nested one level under
 | --- | --- | --- |
 | `ci.yml` | All branches + PRs | Lint, test, build for code changes; pass-through for data-only |
 | `event-data-deploy.yml` | PRs from `event/**`, `event-edit/**` | No-op branch protection gate |
-| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus a write-scoped job that closes duplicate event PRs made redundant by the merge (02-§110.7) |
+| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus a write-scoped job that closes duplicate event PRs made redundant by the merge (02-§111.7) |
 | `deploy-qa.yml` | Push to `main` (ignores per-camp event YAMLs) | Full build + SCP/SSH swap (QA) |
 | `deploy-prod.yml` | Manual `workflow_dispatch` | Full build + SCP/SSH swap (Production) |
 | `deploy-reusable.yml` | Called by `deploy-qa.yml` / `deploy-prod.yml` | Shared build-and-deploy logic |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -102,7 +102,7 @@ their `source/data/**.yaml` path filter matches files nested one level under
 | --- | --- | --- |
 | `ci.yml` | All branches + PRs | Lint, test, build for code changes; pass-through for data-only |
 | `event-data-deploy.yml` | PRs from `event/**`, `event-edit/**` | No-op branch protection gate |
-| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production |
+| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus a write-scoped job that closes duplicate event PRs made redundant by the merge (02-§110.7) |
 | `deploy-qa.yml` | Push to `main` (ignores per-camp event YAMLs) | Full build + SCP/SSH swap (QA) |
 | `deploy-prod.yml` | Manual `workflow_dispatch` | Full build + SCP/SSH swap (Production) |
 | `deploy-reusable.yml` | Called by `deploy-qa.yml` / `deploy-prod.yml` | Shared build-and-deploy logic |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -164,8 +164,10 @@ filename stem, failing the build (and therefore the post-merge deploy) on a
 mismatch (02-§109.19). When an id appears in both the camp file and a fragment it
 de-duplicates by keeping the fragment and logging a warning (02-§109.15), so the
 rendered set always has unique ids. Strict cross-source id uniqueness
-(02-§109.20) is enforced at the source: the add API rejects a duplicate create
-with HTTP 422 (§3.4). Submitted content destined for a fragment passes the same
+(02-§109.20) is enforced at the source: the add API rejects a duplicate
+submission with a pre-check against `main` (HTTP 409; see *Duplicate-submission
+hardening* below), with the HTTP 422 new-file-create conflict (§3.4) remaining
+only as a deep backstop. Submitted content destined for a fragment passes the same
 API-layer field validation and security scan (`validate.js` / `Validate.php`,
 above) as content destined for the camp file. The PR-check workflow
 (`event-data-deploy.yml`) runs `check-yaml-security.js` (hard block) and
@@ -176,6 +178,43 @@ belonging to a non-archived camp (02-§109.18, 02-§109.21).
 Carriage returns in `description` are normalised to line feeds in
 `buildEventYaml()` before the literal block is emitted, so the stored value uses
 `\n` line endings regardless of the submitter's platform (02-§102.4).
+
+#### Duplicate-submission hardening (02-§111)
+
+Because an event id is derived from title + date + start, the same activity
+submitted twice resolves to the same fragment path. Two defences keep that from
+producing a stuck pull request, one per timing window.
+
+**Pre-check before a branch (02-§111.1–111.5).** Before any branch is created, the
+add and batch-add flows look up the target fragment on `main`
+(`getFileMaybe(fragmentPath)` in `source/api/github.js` / `GitHub::getFileMaybe()`
+in PHP — the same lookup edit and delete already use). If the fragment already
+exists, the submission is rejected with **HTTP 409** and a Swedish message saying
+the activity is already in the schedule, rather than the generic "En skrivkonflikt
+uppstod". No branch or pull request is created, so no dangling branch is left
+behind. This is the primary realisation of cross-source id uniqueness (02-§109.20)
+and refines the duplicate handling of 02-§109.8. The PHP entrypoint runs the whole
+add synchronously, so the rejection reaches the user as-is; the Node entrypoint
+(`app.js`) responds before its fire-and-forget GitHub write, so the pre-check runs
+as an awaited step *before* `res.json(...)` rather than inside the background call
+(02-§111.3). A batch is rejected atomically — if any chosen date's fragment already
+exists, none of the batch's fragments are created (02-§111.5).
+
+The pre-check closes the **already-merged** window. The HTTP 422 new-file-create
+conflict (§3.4) remains a last resort but is no longer the normal path.
+
+**Auto-close of concurrent duplicates (02-§111.6–111.9).** The pre-check cannot see
+a duplicate that has not merged yet: when two identical submissions are in flight,
+each is cut from a `main` that lacks the other's fragment, so both creates succeed
+and both pull requests open. The first merges; the second's diff against the new
+`main` is then empty, because it would add a file that already exists with
+identical content. A post-merge cleanup — a job in/alongside
+`event-data-deploy-post-merge.yml`, triggered on push to `main` for
+`source/data/**` — re-evaluates the open `event/*` pull requests and closes
+(deleting the branch) any whose net diff against `main` is empty (02-§111.7,
+§111.8). A collision that resolves to the same id but a *different* body has a
+non-empty diff; it is left open and logged for manual attention rather than closed
+silently (02-§111.9).
 
 ### 11.7 Required repository settings
 

--- a/docs/03-architecture/data-layer.md
+++ b/docs/03-architecture/data-layer.md
@@ -272,7 +272,7 @@ mutation endpoints share the same logic. Error messages never expose tokens,
 file paths, or stack traces. <!-- 03-§3.3a -->
 
 A duplicate submission is handled before this table applies: the add flow's
-pre-check (02-§110.2) answers HTTP 409 with "Den här aktiviteten finns redan i
+pre-check (02-§111.2) answers HTTP 409 with "Den här aktiviteten finns redan i
 schemat." directly, without going through `classifyGitHubError`. The 409 / 422
 row above therefore covers only genuine GitHub conflict responses — the
 create-time backstop, not the duplicate pre-check. <!-- 03-§3.3b -->
@@ -292,7 +292,7 @@ camp YAML file (§1.1). The mutation endpoints behave as follows: <!-- 03-§3.4 
   the same activity at the same date and start time), the submission is rejected
   with **HTTP 409** and the Swedish message "Den här aktiviteten finns redan i
   schemat." (batch: "…för ett eller flera av de valda datumen."), rather than
-  creating a branch or overwriting the existing event (02-§110.2, refining
+  creating a branch or overwriting the existing event (02-§111.2, refining
   02-§109.8). The older create-time HTTP 422 conflict (§3.3) remains only as a
   deep backstop. <!-- 03-§3.4a -->
 

--- a/docs/03-architecture/data-layer.md
+++ b/docs/03-architecture/data-layer.md
@@ -271,6 +271,12 @@ The classification is implemented in a single helper method so all three
 mutation endpoints share the same logic. Error messages never expose tokens,
 file paths, or stack traces. <!-- 03-§3.3a -->
 
+A duplicate submission is handled before this table applies: the add flow's
+pre-check (02-§110.2) answers HTTP 409 with "Den här aktiviteten finns redan i
+schemat." directly, without going through `classifyGitHubError`. The 409 / 422
+row above therefore covers only genuine GitHub conflict responses — the
+create-time backstop, not the duplicate pre-check. <!-- 03-§3.3b -->
+
 ### 3.4 Fragment writes, edits, and deletes
 
 Every add and batch-add writes new fragment files rather than appending to the
@@ -281,10 +287,14 @@ camp YAML file (§1.1). The mutation endpoints behave as follows: <!-- 03-§3.4 
   (02-§109.5).
 - **Batch add** — one new fragment file per date, all on a single branch and PR
   (02-§109.6).
-- If a fragment with the target id already exists (a genuine duplicate of the
-  same activity at the same date and start time), the create call returns
-  HTTP 422 and the API surfaces the "En skrivkonflikt uppstod" message (§3.3)
-  rather than overwriting the existing event (02-§109.8). <!-- 03-§3.4a -->
+- Before any branch is created, the add and batch-add flows check whether the
+  target fragment already exists on `main`. If it does (a genuine duplicate of
+  the same activity at the same date and start time), the submission is rejected
+  with **HTTP 409** and the Swedish message "Den här aktiviteten finns redan i
+  schemat." (batch: "…för ett eller flera av de valda datumen."), rather than
+  creating a branch or overwriting the existing event (02-§110.2, refining
+  02-§109.8). The older create-time HTTP 422 conflict (§3.3) remains only as a
+  deep backstop. <!-- 03-§3.4a -->
 
 Edit and delete operate only on the event's fragment file (02-§109.9):
 <!-- 03-§3.4b -->

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1664,7 +1664,7 @@ Doc ref: `03-architecture/data-layer.md §1.1`, `§3`, `§3.1`, `§3.4`, `§4a`;
 | `02-§109.5` | implemented | `addEventToActiveCamp()` writes a fragment via `fragmentPath`+`buildFragmentYaml` (FRAG-35 path); network write is the e2e/manual checkpoint |
 | `02-§109.6` | implemented | `GitHub::addEventsToActiveCamp()` writes one fragment per date on one branch/PR; network write manual |
 | `02-§109.7` | covered | FRAG-37, FRAG-38: distinct ids → distinct files (no shared file); same id → same path |
-| `02-§109.8` | implemented | New-file create on an existing id → GitHub 422 → `classifyGitHubError` "En skrivkonflikt uppstod" (§3.3, FRAG-38); live 422 manual |
+| `02-§109.8` | implemented | Primary path is now the §110.2 pre-check (409 + clear Swedish message, DEDUP-02/-08); the new-file-create-on-existing-id → GitHub 422 → `classifyGitHubError` "En skrivkonflikt uppstod" (§3.3, FRAG-38) is a deep backstop; live 422 manual |
 | `02-§109.9` | covered | FRAGONLY-01..04, -10, -11: Node+PHP edit/delete bodies act on `fragmentPath` only and never reference `campFilePath` |
 | `02-§109.10` | covered | EDIT-05..15, EEC-01..04: `patchEventObject` preserves id/created_at and bumps updated_at; edit rewrites the fragment via `buildFragmentYaml` |
 | `02-§109.11` | covered | FRAGONLY-04, -11: fragment delete via `deleteFile()`, no `putFile` in the delete path |
@@ -1676,7 +1676,7 @@ Doc ref: `03-architecture/data-layer.md §1.1`, `§3`, `§3.1`, `§3.4`, `§4a`;
 | `02-§109.17` | covered | FRAG-40..43 (+ PHP): `assertFragmentYamlValid()` parses one `event:` with the expected id before any branch |
 | `02-§109.18` | covered | FRAG-60..66: `validateFragment()` in `lint-yaml.js` checks fields, date, end-after-start |
 | `02-§109.19` | covered | FRAG-04: `loadCampEvents()` throws when `event.id` ≠ filename stem; `lint-yaml.js` CLI repeats the check |
-| `02-§109.20` | implemented | Add API rejects a duplicate id with 422 (02-§109.8); `loadCampEvents()` dedup (FRAG-05) keeps the rendered set unique |
+| `02-§109.20` | implemented | Add API rejects a duplicate id before any branch via the §110.2 pre-check (409, DEDUP-01/-05), with the 422 create-conflict (02-§109.8) as backstop; `loadCampEvents()` dedup (FRAG-05) keeps the rendered set unique |
 | `02-§109.21` | covered | FRAG-80..82 (`check-yaml-security.js` scans a fragment), FRAG-60..66 (`lint-yaml.js` fragment mode) |
 | `02-§109.22` | covered | FRAG-50..58: `campFileForPath()` in `source/scripts/changed-camp-file.js`; EDW-29 wires it into the deploy gate |
 | `02-§109.23` | covered | EDW-29, EDW-30, FRAG-52: prod gate maps fragment → camp file, then the camps.yaml `qa` lookup |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1664,7 +1664,7 @@ Doc ref: `03-architecture/data-layer.md §1.1`, `§3`, `§3.1`, `§3.4`, `§4a`;
 | `02-§109.5` | implemented | `addEventToActiveCamp()` writes a fragment via `fragmentPath`+`buildFragmentYaml` (FRAG-35 path); network write is the e2e/manual checkpoint |
 | `02-§109.6` | implemented | `GitHub::addEventsToActiveCamp()` writes one fragment per date on one branch/PR; network write manual |
 | `02-§109.7` | covered | FRAG-37, FRAG-38: distinct ids → distinct files (no shared file); same id → same path |
-| `02-§109.8` | implemented | Primary path is now the §110.2 pre-check (409 + clear Swedish message, DEDUP-02/-08); the new-file-create-on-existing-id → GitHub 422 → `classifyGitHubError` "En skrivkonflikt uppstod" (§3.3, FRAG-38) is a deep backstop; live 422 manual |
+| `02-§109.8` | implemented | Primary path is now the §111.2 pre-check (409 + clear Swedish message, DEDUP-02/-08); the new-file-create-on-existing-id → GitHub 422 → `classifyGitHubError` "En skrivkonflikt uppstod" (§3.3, FRAG-38) is a deep backstop; live 422 manual |
 | `02-§109.9` | covered | FRAGONLY-01..04, -10, -11: Node+PHP edit/delete bodies act on `fragmentPath` only and never reference `campFilePath` |
 | `02-§109.10` | covered | EDIT-05..15, EEC-01..04: `patchEventObject` preserves id/created_at and bumps updated_at; edit rewrites the fragment via `buildFragmentYaml` |
 | `02-§109.11` | covered | FRAGONLY-04, -11: fragment delete via `deleteFile()`, no `putFile` in the delete path |
@@ -1676,7 +1676,7 @@ Doc ref: `03-architecture/data-layer.md §1.1`, `§3`, `§3.1`, `§3.4`, `§4a`;
 | `02-§109.17` | covered | FRAG-40..43 (+ PHP): `assertFragmentYamlValid()` parses one `event:` with the expected id before any branch |
 | `02-§109.18` | covered | FRAG-60..66: `validateFragment()` in `lint-yaml.js` checks fields, date, end-after-start |
 | `02-§109.19` | covered | FRAG-04: `loadCampEvents()` throws when `event.id` ≠ filename stem; `lint-yaml.js` CLI repeats the check |
-| `02-§109.20` | implemented | Add API rejects a duplicate id before any branch via the §110.2 pre-check (409, DEDUP-01/-05), with the 422 create-conflict (02-§109.8) as backstop; `loadCampEvents()` dedup (FRAG-05) keeps the rendered set unique |
+| `02-§109.20` | implemented | Add API rejects a duplicate id before any branch via the §111.2 pre-check (409, DEDUP-01/-05), with the 422 create-conflict (02-§109.8) as backstop; `loadCampEvents()` dedup (FRAG-05) keeps the rendered set unique |
 | `02-§109.21` | covered | FRAG-80..82 (`check-yaml-security.js` scans a fragment), FRAG-60..66 (`lint-yaml.js` fragment mode) |
 | `02-§109.22` | covered | FRAG-50..58: `campFileForPath()` in `source/scripts/changed-camp-file.js`; EDW-29 wires it into the deploy gate |
 | `02-§109.23` | covered | EDW-29, EDW-30, FRAG-52: prod gate maps fragment → camp file, then the camps.yaml `qa` lookup |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1698,3 +1698,20 @@ Doc ref: `02-requirements/event-data.md §110`; `03-architecture/data-layer.md �
 | `02-§110.6` | covered | SPLIT-05: idempotent no-op when the camp file's `events:` list is already empty |
 | `02-§110.7` | covered | SPLIT-06: pre-existing fragment for a seeded id aborts with an error and writes nothing |
 | `02-§110.8` | covered | `04-OPERATIONS.md` (Camp Lifecycle → When a Camp Opens) documents the manual step run at/just before `opens_for_editing`; manual checkpoint |
+
+### §111 — Duplicate Submission Hardening
+
+Doc ref: `02-requirements/event-data.md §111`;
+`03-architecture/ci-and-deploy.md §11.6` (Duplicate-submission hardening).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§111.1` | gap | Pre-check via `getFileMaybe(fragmentPath)` against `main` before any branch — to add to `addEventToActiveCamp`/`addEventsToActiveCamp` (Node + PHP) |
+| `02-§111.2` | gap | Duplicate → HTTP 409 + Swedish "finns redan i schemat"; refines 02-§109.8 (replaces the 422 "skrivkonflikt" path); no branch/PR created |
+| `02-§111.3` | gap | Pre-check runs synchronously before the response in both runtimes; in `app.js` it must be awaited before `res.json`, not inside the fire-and-forget write |
+| `02-§111.4` | gap | Pre-check applies to single `POST /add-event` and batch `POST /add-events` |
+| `02-§111.5` | gap | Batch rejected atomically when any target fragment exists; no batch fragment created |
+| `02-§111.6` | gap | Concurrent window: both pre-checks pass; after the first merge the second PR's net diff vs `main` is empty |
+| `02-§111.7` | gap | Auto-close: an `event/*` PR with empty net diff vs `main` is closed and its branch deleted, no maintainer action |
+| `02-§111.8` | gap | Cleanup runs after each event-data merge to `main` (push, `source/data/**`), re-evaluating open event PRs |
+| `02-§111.9` | gap | Same-id/different-body collision (non-empty diff) is logged for manual attention, not closed silently |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1706,12 +1706,12 @@ Doc ref: `02-requirements/event-data.md §111`;
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§111.1` | gap | Pre-check via `getFileMaybe(fragmentPath)` against `main` before any branch — to add to `addEventToActiveCamp`/`addEventsToActiveCamp` (Node + PHP) |
-| `02-§111.2` | gap | Duplicate → HTTP 409 + Swedish "finns redan i schemat"; refines 02-§109.8 (replaces the 422 "skrivkonflikt" path); no branch/PR created |
-| `02-§111.3` | gap | Pre-check runs synchronously before the response in both runtimes; in `app.js` it must be awaited before `res.json`, not inside the fire-and-forget write |
-| `02-§111.4` | gap | Pre-check applies to single `POST /add-event` and batch `POST /add-events` |
-| `02-§111.5` | gap | Batch rejected atomically when any target fragment exists; no batch fragment created |
-| `02-§111.6` | gap | Concurrent window: both pre-checks pass; after the first merge the second PR's net diff vs `main` is empty |
-| `02-§111.7` | gap | Auto-close: an `event/*` PR with empty net diff vs `main` is closed and its branch deleted, no maintainer action |
-| `02-§111.8` | gap | Cleanup runs after each event-data merge to `main` (push, `source/data/**`), re-evaluating open event PRs |
-| `02-§111.9` | gap | Same-id/different-body collision (non-empty diff) is logged for manual attention, not closed silently |
+| `02-§111.1` | covered | DEDUP-01 (Node), DEDUP-05 (PHP): `getFileMaybe(fragPath)` runs before `createBranch` in `addEventToActiveCamp`/`addEventsToActiveCamp`; DEDUP-03: `isDuplicateEvent` exported |
+| `02-§111.2` | covered | DEDUP-02, DEDUP-08: duplicate → `duplicateEventError`/`DuplicateEventException` → 409 + "Den här aktiviteten finns redan i schemat."; refines 02-§109.8, replaces the 422 path; live 409 is DEDUP-M01 |
+| `02-§111.3` | covered | DEDUP-04: `app.js` awaits `isDuplicateEvent` and answers 409 before `res.json(success)`; PHP add is already synchronous (SYNC-03) |
+| `02-§111.4` | covered | DEDUP-05/-06/-09: single `addEventToActiveCamp` and batch `addEventsToActiveCamp` both pre-check (PHP); Node has only `/add-event` |
+| `02-§111.5` | covered | DEDUP-06, DEDUP-09: batch checks every target before `createBranch` and `handleAddEvents` maps the throw to 409 — atomic, no partial create |
+| `02-§111.6` | covered | DEDUPCLEAN-01, -02: `classifyEventPr` treats an empty net diff as redundant → close; the live empty-diff-after-merge premise is DEDUP-M02 |
+| `02-§111.7` | implemented | DEDUPCLEAN-01/-02 decide `close`; `main()` runs `gh pr close --delete-branch` on an `event/*` PR — the GitHub close + branch delete is the DEDUP-M02 manual checkpoint |
+| `02-§111.8` | implemented | `close-redundant-event-prs` job in `event-data-deploy-post-merge.yml` runs the script on push to `main` (`source/data/**`); CI/manual checkpoint (DEDUP-M02) |
+| `02-§111.9` | covered | DEDUPCLEAN-04: a modified (same-id/different-body) fragment → `log-manual`, not closed |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening in progress, #480: 02-§111.1–111.9 gap; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered).
 
 ---
 
@@ -139,20 +139,24 @@ Test IDs referenced in the `Test(s)` column are defined in the
 
 ```text
 Total requirements:            1397
-Covered (implemented + tested): 742
-Implemented, not tested:        646
-Gap (no implementation):          9
+Covered (implemented + tested): 749
+Implemented, not tested:        648
+Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
 Note: §111 (Duplicate Submission Hardening) adds 9 requirements
-  (02-§111.1–111.9), in progress (status gap pending implementation, #480). A
-  duplicate add (same title+date+start → same fragment path) is rejected by a
-  synchronous pre-check against main (HTTP 409, Swedish "finns redan i
-  schemat") before any branch is created, refining 02-§109.8 and replacing the
-  422 "skrivkonflikt" path. The pre-check covers single and batch add and runs
-  before the response in both runtimes. A concurrent duplicate that slips past
-  the pre-check is auto-closed after the first merges, when its net diff against
-  main is empty; a same-id/different-body collision is logged instead of closed.
+  (02-§111.1–111.9): 7 covered (DEDUP-01..09, DEDUPCLEAN-01..09,
+  tests/dedup-submission.test.js + tests/dedup-cleanup.test.js, plus PHPUnit
+  parity) and 2 implemented (the gh-CLI PR close + the workflow job, DEDUP-M02
+  manual). A duplicate add (same title+date+start → same fragment path) is
+  rejected by a synchronous pre-check against main (HTTP 409, Swedish "Den här
+  aktiviteten finns redan i schemat.") before any branch is created, refining
+  02-§109.8 and replacing the 422 "skrivkonflikt" path. The pre-check covers
+  single and batch add and runs before the response in both runtimes. A
+  concurrent duplicate that slips past the pre-check is auto-closed by
+  close-redundant-event-prs after the first merges, when its net diff against
+  main is empty; a same-id/different-body collision is logged instead of closed
+  (#480).
 
 Note: §109 (Concurrent Event Submission via Fragment Files) adds 26
   requirements (02-§109.1–109.26): 22 covered, 4 implemented. Each submitted

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening in progress, #480: 02-§111.1–111.9 gap; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered).
 
 ---
 
@@ -126,7 +126,7 @@ The matrix is split by ID family. Each file carries the rows for one family.
 
 | Family | Source | Rows | File |
 | --- | --- | --- | --- |
-| `02` | `docs/02-requirements/` | 1315 | [02-requirements](./02-requirements.md) |
+| `02` | `docs/02-requirements/` | 1324 | [02-requirements](./02-requirements.md) |
 | `03` | `docs/03-architecture/` | 0 | [03-architecture](./03-architecture.md) |
 | `05` | `docs/05-DATA_CONTRACT.md` | 19 | [05-data-contract](./05-data-contract.md) |
 | `07` | `docs/07-design/` | 91 | [07-design](./07-design.md) |
@@ -138,11 +138,21 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1388
+Total requirements:            1397
 Covered (implemented + tested): 742
 Implemented, not tested:        646
-Gap (no implementation):          0
+Gap (no implementation):          9
 Orphan tests (no requirement):    0
+
+Note: §111 (Duplicate Submission Hardening) adds 9 requirements
+  (02-§111.1–111.9), in progress (status gap pending implementation, #480). A
+  duplicate add (same title+date+start → same fragment path) is rejected by a
+  synchronous pre-check against main (HTTP 409, Swedish "finns redan i
+  schemat") before any branch is created, refining 02-§109.8 and replacing the
+  422 "skrivkonflikt" path. The pre-check covers single and batch add and runs
+  before the response in both runtimes. A concurrent duplicate that slips past
+  the pre-check is auto-closed after the first merges, when its net diff against
+  main is empty; a same-id/different-body collision is logged instead of closed.
 
 Note: §109 (Concurrent Event Submission via Fragment Files) adds 26
   requirements (02-§109.1–109.26): 22 covered, 4 implemented. Each submitted

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -214,3 +214,6 @@ Part of [the traceability index](./index.md).
 | EDW-29..32 | `tests/event-deploy-workflow.test.js` | Fragment-aware production QA gating + workflow triggers (02-§109.22, 109.23, 109.25) |
 | (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the fragment helpers: `buildFragmentYaml`, `fragmentPath`, `assertFragmentYamlValid` (02-§109) |
 | SPLIT-01..10 | `tests/split-camp-events.test.js` | `splitCampEvents` / `resolveCampFile` / `emptyEventsList` split-at-open (02-§110) |
+| DEDUP-01..09 | `tests/dedup-submission.test.js` | Duplicate pre-check (Node + PHP): `getFileMaybe` before any branch, 409 + Swedish message, awaited before `app.js`'s response, atomic batch reject (02-§111.1–111.5) |
+| DEDUP-M01..M02 | (manual) | Live 409 on a duplicate submission; a concurrent duplicate's redundant PR is auto-closed (02-§111.2, 111.6–111.9) |
+| DEDUPCLEAN-01..09 | `tests/dedup-cleanup.test.js` | `classifyEventPr` decision table: empty diff → close, fresh add → keep, same-id/different-body → log-manual, out-of-scope → ignore (02-§111.6–111.9) |

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -328,13 +328,13 @@ async function resolveActiveCampFromGitHub() {
 }
 
 // Swedish message shown when a submission duplicates an activity already in the
-// schedule (02-§110.2).
+// schedule (02-§111.2).
 const DUPLICATE_EVENT_MESSAGE = 'Den här aktiviteten finns redan i schemat.';
 
 // Build the error thrown when a fragment with the target id already exists. The
 // `status`/`userMessage` mark it as a duplicate so a synchronous caller can answer
 // 409; the Node entrypoint instead calls isDuplicateEvent() before its
-// fire-and-forget write, while PHP maps DuplicateEventException → 409 (02-§110.2).
+// fire-and-forget write, while PHP maps DuplicateEventException → 409 (02-§111.2).
 function duplicateEventError(eventId) {
   const err = new Error(`Event already exists: ${eventId}`);
   err.status = 409;
@@ -344,8 +344,8 @@ function duplicateEventError(eventId) {
 }
 
 // Resolve the event id the add flow would write for this body and report whether
-// its fragment already exists on main (02-§110.1). Used by the Node entrypoint to
-// reject a duplicate synchronously, before the fire-and-forget write (02-§110.3).
+// its fragment already exists on main (02-§111.1). Used by the Node entrypoint to
+// reject a duplicate synchronously, before the fire-and-forget write (02-§111.3).
 async function isDuplicateEvent(body) {
   const title = String(body.title).trim();
   const date  = String(body.date).trim();
@@ -389,7 +389,7 @@ async function addEventToActiveCamp(body) {
 
   // Reject a duplicate before any branch/PR is created, so an already-merged
   // identical activity fails cleanly (409) instead of a dangling branch and a
-  // generic write-conflict error (02-§110.1, §110.2).
+  // generic write-conflict error (02-§111.1, §111.2).
   if (await getFileMaybe(fragPath)) throw duplicateEventError(event.id);
 
   // Ephemeral branch → create the new fragment file (no sha) → PR → auto-merge.

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -332,7 +332,9 @@ async function resolveActiveCampFromGitHub() {
 const DUPLICATE_EVENT_MESSAGE = 'Den här aktiviteten finns redan i schemat.';
 
 // Build the error thrown when a fragment with the target id already exists. The
-// `status` lets the HTTP layer answer 409 instead of a generic 500 (02-§110.2).
+// `status`/`userMessage` mark it as a duplicate so a synchronous caller can answer
+// 409; the Node entrypoint instead calls isDuplicateEvent() before its
+// fire-and-forget write, while PHP maps DuplicateEventException → 409 (02-§110.2).
 function duplicateEventError(eventId) {
   const err = new Error(`Event already exists: ${eventId}`);
   err.status = 409;

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -327,6 +327,33 @@ async function resolveActiveCampFromGitHub() {
   return resolveActiveCamp(campsData.camps || [], undefined, buildEnv);
 }
 
+// Swedish message shown when a submission duplicates an activity already in the
+// schedule (02-§110.2).
+const DUPLICATE_EVENT_MESSAGE = 'Den här aktiviteten finns redan i schemat.';
+
+// Build the error thrown when a fragment with the target id already exists. The
+// `status` lets the HTTP layer answer 409 instead of a generic 500 (02-§110.2).
+function duplicateEventError(eventId) {
+  const err = new Error(`Event already exists: ${eventId}`);
+  err.status = 409;
+  err.code = 'DUPLICATE_EVENT';
+  err.userMessage = DUPLICATE_EVENT_MESSAGE;
+  return err;
+}
+
+// Resolve the event id the add flow would write for this body and report whether
+// its fragment already exists on main (02-§110.1). Used by the Node entrypoint to
+// reject a duplicate synchronously, before the fire-and-forget write (02-§110.3).
+async function isDuplicateEvent(body) {
+  const title = String(body.title).trim();
+  const date  = String(body.date).trim();
+  const start = String(body.start).trim();
+  const eventId  = `${slugify(title)}-${date}-${start.replace(':', '')}`;
+  const camp     = await resolveActiveCampFromGitHub();
+  const fragPath = fragmentPath(camp.file, eventId);
+  return (await getFileMaybe(fragPath)) !== null;
+}
+
 // Writes a new event as its own fragment file in the active camp's directory
 // (02-§109.5). Because the file is brand-new and named after the event id, the
 // resulting PR can never conflict with another in-flight submission (02-§109.7).
@@ -357,6 +384,11 @@ async function addEventToActiveCamp(body) {
   const content    = buildFragmentYaml(event) + '\n';
   assertFragmentYamlValid(content, event.id);
   const commitMsg  = `Add event to ${camp.name}: ${title} (${date})`;
+
+  // Reject a duplicate before any branch/PR is created, so an already-merged
+  // identical activity fails cleanly (409) instead of a dangling branch and a
+  // generic write-conflict error (02-§110.1, §110.2).
+  if (await getFileMaybe(fragPath)) throw duplicateEventError(event.id);
 
   // Ephemeral branch → create the new fragment file (no sha) → PR → auto-merge.
   const mainSha    = await getMainSha();
@@ -412,4 +444,4 @@ async function removeEventFromActiveCamp(eventId) {
   await enableAutoMerge(pr.node_id);
 }
 
-module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, githubRequest, env };
+module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, githubRequest, env };

--- a/source/scripts/close-redundant-event-prs.js
+++ b/source/scripts/close-redundant-event-prs.js
@@ -1,11 +1,11 @@
 'use strict';
 
 // Closes event-submission pull requests that a merge to main has made redundant
-// (02-§110.6–110.9). Runs in event-data-deploy-post-merge.yml after each
+// (02-§111.6–111.9). Runs in event-data-deploy-post-merge.yml after each
 // event-data merge.
 //
 // A duplicate submission (same title + date + start → same fragment path) can slip
-// past the add-API duplicate pre-check (02-§110.2) when it is opened before the
+// past the add-API duplicate pre-check (02-§111.2) when it is opened before the
 // first identical submission merges: at branch-cut time neither fragment is on main
 // yet, so both pull requests are created. Once the first merges, the second would
 // add a file that already exists on main with identical content, so its net diff
@@ -14,7 +14,7 @@
 //
 // A pull request that instead modifies an existing fragment (same id, different
 // body → a non-empty diff) is left open and logged for manual attention, so the
-// residual edge stays visible rather than being closed silently (02-§110.9).
+// residual edge stays visible rather than being closed silently (02-§111.9).
 
 const { execFileSync } = require('node:child_process');
 
@@ -76,7 +76,7 @@ function main() {
           '--comment', 'Stänger automatiskt: aktiviteten finns redan på sajten (identiskt inskick). Inget går förlorat.',
         ]);
       } else if (verdict === 'log-manual') {
-        console.log(`::warning::Event PR #${pr.number} (${pr.headRefName}) shares an id with an existing activity but has a different body — needs manual review (02-§110.9)`);
+        console.log(`::warning::Event PR #${pr.number} (${pr.headRefName}) shares an id with an existing activity but has a different body — needs manual review (02-§111.9)`);
       }
     } catch (err) {
       console.log(`::warning::Could not process event PR #${pr.number} (${pr.headRefName}): ${err.message}`);

--- a/source/scripts/close-redundant-event-prs.js
+++ b/source/scripts/close-redundant-event-prs.js
@@ -62,17 +62,24 @@ function main() {
   for (const pr of prs) {
     if (!pr.headRefName || !pr.headRefName.startsWith('event/')) continue;
 
-    const files = JSON.parse(gh(['api', `repos/${repo}/pulls/${pr.number}/files`, '--paginate']));
-    const verdict = classifyEventPr({ branch: pr.headRefName, files });
+    // Isolate per-PR failures so one bad fetch/close does not abort the sweep.
+    try {
+      // An event PR changes one fragment (a batch a few) — well under one page,
+      // so no --paginate (which can concatenate pages into invalid JSON).
+      const files = JSON.parse(gh(['api', `repos/${repo}/pulls/${pr.number}/files`]));
+      const verdict = classifyEventPr({ branch: pr.headRefName, files });
 
-    if (verdict === 'close') {
-      console.log(`Closing redundant duplicate PR #${pr.number} (${pr.headRefName}) — empty net diff against main`);
-      gh([
-        'pr', 'close', String(pr.number), ...repoArgs, '--delete-branch',
-        '--comment', 'Stänger automatiskt: aktiviteten finns redan på sajten (identiskt inskick). Inget går förlorat.',
-      ]);
-    } else if (verdict === 'log-manual') {
-      console.log(`::warning::Event PR #${pr.number} (${pr.headRefName}) shares an id with an existing activity but has a different body — needs manual review (02-§110.9)`);
+      if (verdict === 'close') {
+        console.log(`Closing redundant duplicate PR #${pr.number} (${pr.headRefName}) — empty net diff against main`);
+        gh([
+          'pr', 'close', String(pr.number), ...repoArgs, '--delete-branch',
+          '--comment', 'Stänger automatiskt: aktiviteten finns redan på sajten (identiskt inskick). Inget går förlorat.',
+        ]);
+      } else if (verdict === 'log-manual') {
+        console.log(`::warning::Event PR #${pr.number} (${pr.headRefName}) shares an id with an existing activity but has a different body — needs manual review (02-§110.9)`);
+      }
+    } catch (err) {
+      console.log(`::warning::Could not process event PR #${pr.number} (${pr.headRefName}): ${err.message}`);
     }
   }
 }

--- a/source/scripts/close-redundant-event-prs.js
+++ b/source/scripts/close-redundant-event-prs.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Closes event-submission pull requests that a merge to main has made redundant
+// (02-§110.6–110.9). Runs in event-data-deploy-post-merge.yml after each
+// event-data merge.
+//
+// A duplicate submission (same title + date + start → same fragment path) can slip
+// past the add-API duplicate pre-check (02-§110.2) when it is opened before the
+// first identical submission merges: at branch-cut time neither fragment is on main
+// yet, so both pull requests are created. Once the first merges, the second would
+// add a file that already exists on main with identical content, so its net diff
+// against main is empty. This script finds such pull requests and closes them,
+// deleting their branches.
+//
+// A pull request that instead modifies an existing fragment (same id, different
+// body → a non-empty diff) is left open and logged for manual attention, so the
+// residual edge stays visible rather than being closed silently (02-§110.9).
+
+const { execFileSync } = require('node:child_process');
+
+const DATA_PREFIX = 'source/data/';
+
+/**
+ * Decide what to do with an event pull request, given its head branch and the
+ * list of files it changes against the base (each: { filename, status,
+ * additions, deletions }). Pure and side-effect free so it can be unit-tested.
+ *
+ * Returns one of:
+ *   'ignore'     – not an add-submission PR, or it touches non-event-data files
+ *   'close'      – empty net diff: the file already exists on main (redundant)
+ *   'keep'       – genuine new event(s): every changed file is freshly added
+ *   'log-manual' – same id but a different body (modified/removed file)
+ */
+function classifyEventPr({ branch, files } = {}) {
+  // Add submissions use `event/<...>` branches; edit/delete use `event-edit/`,
+  // `event-delete/`, which do not start with `event/` and are out of scope.
+  if (typeof branch !== 'string' || !branch.startsWith('event/')) return 'ignore';
+
+  const list = Array.isArray(files) ? files : [];
+
+  // Only act on pull requests whose changes are confined to event data.
+  if (list.some((f) => !String(f && f.filename).startsWith(DATA_PREFIX))) return 'ignore';
+
+  const changed = list.filter((f) => ((f.additions || 0) + (f.deletions || 0)) > 0);
+  if (changed.length === 0) return 'close';                      // redundant: identical file already on main
+  if (changed.every((f) => f.status === 'added')) return 'keep'; // genuine new event(s)
+  return 'log-manual';                                           // modified/removed: surface it
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function main() {
+  const repo = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
+  const repoArgs = repo ? ['--repo', repo] : [];
+
+  const prs = JSON.parse(
+    gh(['pr', 'list', ...repoArgs, '--state', 'open', '--limit', '100', '--json', 'number,headRefName']),
+  );
+
+  for (const pr of prs) {
+    if (!pr.headRefName || !pr.headRefName.startsWith('event/')) continue;
+
+    const files = JSON.parse(gh(['api', `repos/${repo}/pulls/${pr.number}/files`, '--paginate']));
+    const verdict = classifyEventPr({ branch: pr.headRefName, files });
+
+    if (verdict === 'close') {
+      console.log(`Closing redundant duplicate PR #${pr.number} (${pr.headRefName}) — empty net diff against main`);
+      gh([
+        'pr', 'close', String(pr.number), ...repoArgs, '--delete-branch',
+        '--comment', 'Stänger automatiskt: aktiviteten finns redan på sajten (identiskt inskick). Inget går förlorat.',
+      ]);
+    } else if (verdict === 'log-manual') {
+      console.log(`::warning::Event PR #${pr.number} (${pr.headRefName}) shares an id with an existing activity but has a different body — needs manual review (02-§110.9)`);
+    }
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('close-redundant-event-prs failed:', err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { classifyEventPr };

--- a/tests/dedup-cleanup.test.js
+++ b/tests/dedup-cleanup.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Unit tests for the redundant-duplicate-PR cleanup decision (02-§110.6–110.9).
+// classifyEventPr is pure, so its full decision table is tested here; the GitHub
+// API wiring in the script's main() is a manual/integration checkpoint.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { classifyEventPr } = require('../source/scripts/close-redundant-event-prs');
+
+const DATA = 'source/data/2026-06-syssleback/x-2026-06-22-0800.yaml';
+
+describe('classifyEventPr — redundant duplicate cleanup (02-§110.6–110.9)', () => {
+  it('DEDUPCLEAN-01: event/ branch with no changed files → close (empty net diff)', () => {
+    assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files: [] }), 'close');
+  });
+
+  it('DEDUPCLEAN-02: event/ branch where the only file has 0 additions+deletions → close', () => {
+    const files = [{ filename: DATA, status: 'modified', additions: 0, deletions: 0 }];
+    assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files }), 'close');
+  });
+
+  it('DEDUPCLEAN-03: event/ branch adding a genuinely new fragment → keep', () => {
+    const files = [{ filename: DATA, status: 'added', additions: 16, deletions: 0 }];
+    assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files }), 'keep');
+  });
+
+  it('DEDUPCLEAN-04: event/ branch modifying an existing fragment (same id, diff body) → log-manual', () => {
+    const files = [{ filename: DATA, status: 'modified', additions: 3, deletions: 2 }];
+    assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files }), 'log-manual');
+  });
+
+  it('DEDUPCLEAN-05: a batch add with several freshly added fragments → keep', () => {
+    const files = [
+      { filename: 'source/data/c/a-2026-06-22-0800.yaml', status: 'added', additions: 16, deletions: 0 },
+      { filename: 'source/data/c/a-2026-06-23-0800.yaml', status: 'added', additions: 16, deletions: 0 },
+    ];
+    assert.equal(classifyEventPr({ branch: 'event/batch-a-1', files }), 'keep');
+  });
+
+  it('DEDUPCLEAN-06: non-event branch → ignore', () => {
+    const files = [{ filename: DATA, status: 'added', additions: 16, deletions: 0 }];
+    assert.equal(classifyEventPr({ branch: 'fix/something', files }), 'ignore');
+  });
+
+  it('DEDUPCLEAN-07: edit/delete branches (event-edit/, event-delete/) are out of scope → ignore', () => {
+    const files = [{ filename: DATA, status: 'modified', additions: 1, deletions: 1 }];
+    assert.equal(classifyEventPr({ branch: 'event-edit/x-1', files }), 'ignore');
+    assert.equal(classifyEventPr({ branch: 'event-delete/x-1', files }), 'ignore');
+  });
+
+  it('DEDUPCLEAN-08: event/ branch touching a non-event-data file → ignore (conservative)', () => {
+    const files = [
+      { filename: DATA, status: 'added', additions: 16, deletions: 0 },
+      { filename: 'source/build/build.js', status: 'modified', additions: 1, deletions: 0 },
+    ];
+    assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files }), 'ignore');
+  });
+
+  it('DEDUPCLEAN-09: missing/garbage input → ignore (no branch)', () => {
+    assert.equal(classifyEventPr({}), 'ignore');
+    assert.equal(classifyEventPr(), 'ignore');
+    assert.equal(classifyEventPr({ branch: null, files: null }), 'ignore');
+  });
+});

--- a/tests/dedup-cleanup.test.js
+++ b/tests/dedup-cleanup.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Unit tests for the redundant-duplicate-PR cleanup decision (02-§110.6–110.9).
+// Unit tests for the redundant-duplicate-PR cleanup decision (02-§111.6–111.9).
 // classifyEventPr is pure, so its full decision table is tested here; the GitHub
 // API wiring in the script's main() is a manual/integration checkpoint.
 
@@ -11,7 +11,7 @@ const { classifyEventPr } = require('../source/scripts/close-redundant-event-prs
 
 const DATA = 'source/data/2026-06-syssleback/x-2026-06-22-0800.yaml';
 
-describe('classifyEventPr — redundant duplicate cleanup (02-§110.6–110.9)', () => {
+describe('classifyEventPr — redundant duplicate cleanup (02-§111.6–111.9)', () => {
   it('DEDUPCLEAN-01: event/ branch with no changed files → close (empty net diff)', () => {
     assert.equal(classifyEventPr({ branch: 'event/2026-06-22-x-1', files: [] }), 'close');
   });

--- a/tests/dedup-submission.test.js
+++ b/tests/dedup-submission.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// Structural checks for the duplicate-submission pre-check (02-§110.1–110.5).
+//
+// The pre-check lives inside the network-touching add flow (github.js / GitHub.php)
+// and its entrypoints (app.js / index.php), which cannot run in Node tests. As with
+// api-sync-errors.test.js, these are source-code structural checks: they pin the
+// ordering and the 409/Swedish-message contract. The live behaviour is a manual
+// checkpoint:
+//   DEDUP-M01: submit an activity that already exists → API answers 409 with
+//     "Den här aktiviteten finns redan i schemat." and no PR is created.
+//   DEDUP-M02: submit the same activity twice concurrently → one lands; the
+//     redundant PR is auto-closed by close-redundant-event-prs (02-§110.6–110.9).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = (...p) => path.join(__dirname, '..', ...p);
+const read = (...p) => fs.readFileSync(root(...p), 'utf8');
+
+const GH_JS = read('source', 'api', 'github.js');
+const APP_JS = read('app.js');
+const GH_PHP = read('api', 'src', 'GitHub.php');
+const INDEX_PHP = read('api', 'index.php');
+
+// Slice out one function/method body so ordering checks are scoped to it.
+function slice(src, startNeedle, endNeedle) {
+  const start = src.indexOf(startNeedle);
+  assert.ok(start >= 0, `expected to find "${startNeedle}"`);
+  const end = endNeedle ? src.indexOf(endNeedle, start + startNeedle.length) : src.length;
+  return src.slice(start, end > start ? end : src.length);
+}
+
+describe('02-§110 — github.js duplicate pre-check (DEDUP-01..03)', () => {
+  const body = slice(GH_JS, 'async function addEventToActiveCamp', 'async function updateEventInActiveCamp');
+
+  it('DEDUP-01: addEventToActiveCamp checks getFileMaybe before creating a branch', () => {
+    const guardIdx = body.indexOf('getFileMaybe');
+    const branchIdx = body.indexOf('createBranch');
+    assert.ok(guardIdx > 0, 'add flow must call getFileMaybe');
+    assert.ok(branchIdx > 0, 'add flow must call createBranch');
+    assert.ok(guardIdx < branchIdx, 'duplicate pre-check must run BEFORE createBranch');
+  });
+
+  it('DEDUP-02: a duplicate throws an error carrying HTTP 409 and the Swedish message', () => {
+    assert.ok(body.includes('duplicateEventError'), 'add flow must throw the duplicate error');
+    assert.ok(GH_JS.includes('err.status = 409'), 'duplicate error must carry status 409');
+    assert.ok(
+      GH_JS.includes("DUPLICATE_EVENT_MESSAGE = 'Den här aktiviteten finns redan i schemat.'"),
+      'Swedish duplicate message must be defined',
+    );
+  });
+
+  it('DEDUP-03: isDuplicateEvent and DUPLICATE_EVENT_MESSAGE are exported', () => {
+    const mod = require('../source/api/github');
+    assert.equal(typeof mod.isDuplicateEvent, 'function');
+    assert.equal(mod.DUPLICATE_EVENT_MESSAGE, 'Den här aktiviteten finns redan i schemat.');
+  });
+});
+
+describe('02-§110.3 — app.js surfaces the duplicate synchronously (DEDUP-04)', () => {
+  const handler = slice(APP_JS, "app.post('/add-event'", "app.post('/edit-event'");
+
+  it('DEDUP-04: the handler awaits isDuplicateEvent and answers 409 before the success response', () => {
+    const checkIdx = handler.indexOf('isDuplicateEvent');
+    const successIdx = handler.indexOf('res.json({ success: true');
+    assert.ok(checkIdx > 0, 'handler must call isDuplicateEvent');
+    assert.ok(successIdx > 0, 'handler must send the success response');
+    assert.ok(checkIdx < successIdx, 'duplicate check must run BEFORE res.json(success)');
+    assert.ok(handler.includes('res.status(409)'), 'duplicate path must answer 409');
+    assert.ok(handler.includes('await isDuplicateEvent'), 'pre-check must be awaited (not fire-and-forget)');
+  });
+});
+
+describe('02-§110 — GitHub.php duplicate pre-check (DEDUP-05..07)', () => {
+  const addBody = slice(GH_PHP, 'function addEventToActiveCamp', 'function addEventsToActiveCamp');
+  const batchBody = slice(GH_PHP, 'function addEventsToActiveCamp', 'function updateEventInActiveCamp');
+
+  it('DEDUP-05: addEventToActiveCamp checks getFileMaybe before createBranch and throws DuplicateEventException', () => {
+    const guardIdx = addBody.indexOf('getFileMaybe');
+    const branchIdx = addBody.indexOf('createBranch');
+    assert.ok(guardIdx > 0 && branchIdx > 0, 'add flow must call getFileMaybe and createBranch');
+    assert.ok(guardIdx < branchIdx, 'duplicate pre-check must run BEFORE createBranch');
+    assert.ok(addBody.includes('DuplicateEventException'), 'duplicate must throw DuplicateEventException');
+  });
+
+  it('DEDUP-06: addEventsToActiveCamp checks every target before createBranch (atomic batch reject)', () => {
+    const guardIdx = batchBody.indexOf('getFileMaybe');
+    const branchIdx = batchBody.indexOf('createBranch');
+    assert.ok(guardIdx > 0 && branchIdx > 0, 'batch flow must call getFileMaybe and createBranch');
+    assert.ok(guardIdx < branchIdx, 'batch pre-check must run BEFORE createBranch');
+    assert.ok(batchBody.includes('DuplicateEventException'), 'batch duplicate must throw DuplicateEventException');
+  });
+
+  it('DEDUP-07: DuplicateEventException exists and extends RuntimeException', () => {
+    const ex = read('api', 'src', 'DuplicateEventException.php');
+    assert.ok(ex.includes('class DuplicateEventException extends \\RuntimeException'));
+    assert.ok(ex.includes('namespace SBSommar;'));
+  });
+});
+
+describe('02-§110.2/110.5 — index.php maps duplicates to 409 (DEDUP-08..09)', () => {
+  const single = slice(INDEX_PHP, 'function handleAddEvent(', 'function handleAddEvents(');
+  const batch = slice(INDEX_PHP, 'function handleAddEvents(', 'function handleEditEvent(');
+
+  it('DEDUP-08: handleAddEvent catches DuplicateEventException → 409 with the Swedish message, before the generic catch', () => {
+    const dupIdx = single.indexOf('catch (DuplicateEventException');
+    const genIdx = single.indexOf('catch (\\Throwable');
+    assert.ok(dupIdx > 0, 'must catch DuplicateEventException');
+    assert.ok(genIdx > 0, 'must keep the generic Throwable catch');
+    assert.ok(dupIdx < genIdx, 'duplicate catch must precede the generic catch');
+    assert.ok(single.includes('Den här aktiviteten finns redan i schemat.'), 'Swedish message');
+    assert.ok(single.includes('], 409)'), 'must answer 409');
+  });
+
+  it('DEDUP-09: handleAddEvents catches DuplicateEventException → 409 (atomic batch reject)', () => {
+    const dupIdx = batch.indexOf('catch (DuplicateEventException');
+    const genIdx = batch.indexOf('catch (\\Throwable');
+    assert.ok(dupIdx > 0 && genIdx > 0 && dupIdx < genIdx, 'duplicate catch must precede the generic catch');
+    assert.ok(batch.includes('för ett eller flera av de valda datumen'), 'batch Swedish message');
+    assert.ok(batch.includes('], 409)'), 'must answer 409');
+  });
+});

--- a/tests/dedup-submission.test.js
+++ b/tests/dedup-submission.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Structural checks for the duplicate-submission pre-check (02-§110.1–110.5).
+// Structural checks for the duplicate-submission pre-check (02-§111.1–111.5).
 //
 // The pre-check lives inside the network-touching add flow (github.js / GitHub.php)
 // and its entrypoints (app.js / index.php), which cannot run in Node tests. As with
@@ -10,7 +10,7 @@
 //   DEDUP-M01: submit an activity that already exists → API answers 409 with
 //     "Den här aktiviteten finns redan i schemat." and no PR is created.
 //   DEDUP-M02: submit the same activity twice concurrently → one lands; the
-//     redundant PR is auto-closed by close-redundant-event-prs (02-§110.6–110.9).
+//     redundant PR is auto-closed by close-redundant-event-prs (02-§111.6–111.9).
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
@@ -33,7 +33,7 @@ function slice(src, startNeedle, endNeedle) {
   return src.slice(start, end > start ? end : src.length);
 }
 
-describe('02-§110 — github.js duplicate pre-check (DEDUP-01..03)', () => {
+describe('02-§111 — github.js duplicate pre-check (DEDUP-01..03)', () => {
   const body = slice(GH_JS, 'async function addEventToActiveCamp', 'async function updateEventInActiveCamp');
 
   it('DEDUP-01: addEventToActiveCamp checks getFileMaybe before creating a branch', () => {
@@ -60,7 +60,7 @@ describe('02-§110 — github.js duplicate pre-check (DEDUP-01..03)', () => {
   });
 });
 
-describe('02-§110.3 — app.js surfaces the duplicate synchronously (DEDUP-04)', () => {
+describe('02-§111.3 — app.js surfaces the duplicate synchronously (DEDUP-04)', () => {
   const handler = slice(APP_JS, "app.post('/add-event'", "app.post('/edit-event'");
 
   it('DEDUP-04: the handler awaits isDuplicateEvent and answers 409 before the success response', () => {
@@ -74,7 +74,7 @@ describe('02-§110.3 — app.js surfaces the duplicate synchronously (DEDUP-04)'
   });
 });
 
-describe('02-§110 — GitHub.php duplicate pre-check (DEDUP-05..07)', () => {
+describe('02-§111 — GitHub.php duplicate pre-check (DEDUP-05..07)', () => {
   const addBody = slice(GH_PHP, 'function addEventToActiveCamp', 'function addEventsToActiveCamp');
   const batchBody = slice(GH_PHP, 'function addEventsToActiveCamp', 'function updateEventInActiveCamp');
 
@@ -101,7 +101,7 @@ describe('02-§110 — GitHub.php duplicate pre-check (DEDUP-05..07)', () => {
   });
 });
 
-describe('02-§110.2/110.5 — index.php maps duplicates to 409 (DEDUP-08..09)', () => {
+describe('02-§111.2/111.5 — index.php maps duplicates to 409 (DEDUP-08..09)', () => {
   const single = slice(INDEX_PHP, 'function handleAddEvent(', 'function handleAddEvents(');
   const batch = slice(INDEX_PHP, 'function handleAddEvents(', 'function handleEditEvent(');
 


### PR DESCRIPTION
## Sammanfattning

Dubblettsäkrar event-inskick så att samma aktivitet inte längre skapar fastnade PR:ar (#480).

**Del 1 — förkoll (synkron, före branch):**
- `add-event` och batch `add-events` (Node + PHP) slår upp målfragmentet på `main` innan någon branch skapas. Finns det redan → **HTTP 409** + "Den här aktiviteten finns redan i schemat." i stället för dagens 422 "skrivkonflikt".
- PHP-flödet är synkront; i Node await:as förkollen före `res.json` så att den fire-and-forget-skrivningen inte döljer avvisningen.
- Batch avvisas atomiskt (finns någon av datumens fragment → hela batchen avvisas).

**Del 2 — race-städning:**
- Nytt write-scopat jobb i `event-data-deploy-post-merge.yml` kör `close-redundant-event-prs.js` efter varje event-merge: stänger `event/*`-PR:ar med tom netto-diff (och raderar branchen). Samma-id/annan-body loggas för manuell koll i stället för att stängas tyst.

Id-formeln (titel + datum + start) är oförändrad — det är den medvetna dubbletthanteringen vi bygger på. Förfinar §109.8.

## Faser
Phase 0–6 enligt CLAUDE.md (krav §110 → design + traceability → tester → implementation → traceability → 5 review-passes). Lokal direction-granskning klar; merge-godkännande väntar.

## Test plan
- [x] `npm test` — 1973 gröna (18 nya: DEDUP-01..09, DEDUPCLEAN-01..09)
- [x] `npm run lint` (eslint) + `npm run lint:md`
- [x] PHPUnit — 76 gröna (PHP-syntax + paritet)
- [x] Rebasad på senaste `main`, sviten grön efter rebase
- [ ] **Manuellt (QA/prod, kräver giltig token):** DEDUP-M01 — inskick av en aktivitet som redan finns → 409 + svenska meddelandet, ingen PR skapas
- [ ] **Manuellt (riktiga repot):** DEDUP-M02 — två identiska inskick samtidigt → ett landar, den överflödiga PR:en auto-stängs

## Känd sak att validera (DEDUP-M02)
Del 2:s korrekthet vilar på att GitHubs `/pulls/{n}/files` ger en tom lista för en redundant PR efter att basen flyttats — exakt vad #473-incidenten observerade (netto-diff 0). Värt att bekräfta live innan auto-stängningen förlitas på.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
