### PR TITLE
Recover event PRs stranded in the merge queue

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -11,6 +11,8 @@ name: Event Data Deploy (Post-Merge)
 #   2. deploy-prod    – detect inline + QA check + build + SCP to Production
 #   3. close-redundant-event-prs – close duplicate event PRs made redundant by
 #                                  this merge (02-§111.6–111.9)
+#   4. recover-stranded-event-prs – re-enqueue event PRs stranded in the merge
+#                                   queue by this merge's base move (02-§112.7)
 
 permissions:
   contents: read

--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -210,3 +210,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+
+  recover-stranded-event-prs:
+    name: Recover event PRs stranded in the merge queue
+    runs-on: ubuntu-latest
+    # Needs write access to disable→enable auto-merge; the default workflow token
+    # is read-only here (02-§112.7).
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # This merge just advanced main, which is exactly the base move that can
+      # strand a sibling event PR's auto-merge. Re-enqueue any stranded event PR
+      # by toggling auto-merge off then on (02-§112.7). Uses the pre-installed gh
+      # CLI; no dependency install needed.
+      - name: Recover stranded event PRs
+        run: node source/scripts/recover-stranded-event-prs.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/merge-queue-recovery.yml
+++ b/.github/workflows/merge-queue-recovery.yml
@@ -1,0 +1,40 @@
+name: Merge Queue Recovery (Scheduled)
+
+# Safety-net sweep for event PRs stranded in the merge-queue handoff (02-§112.8).
+#
+# The post-merge sweep in event-data-deploy-post-merge.yml recovers a stranded PR
+# immediately after the next event-data merge. This scheduled run covers the case
+# where no such merge follows — e.g. the burst ends with a stranded PR. It is cheap
+# when there is nothing to do: it lists open event PRs and exits when none are
+# stranded (02-§112.9).
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Every 15 minutes.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  recover-stranded-event-prs:
+    name: Recover event PRs stranded in the merge queue
+    runs-on: ubuntu-latest
+    # Needs write access to disable→enable auto-merge (02-§112.8).
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Recover stranded event PRs
+        run: node source/scripts/recover-stranded-event-prs.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -901,3 +901,71 @@ error.
   (so its net diff against `main` is not empty) is outside this automatic cleanup;
   it is logged for manual attention rather than closed silently, so the residual
   edge stays visible. <!-- 02-§111.9 -->
+
+## 112. Stranded Auto-Merge Recovery
+
+### 112.1 Context
+
+Event pull requests opened by the form API (add, edit, delete) have auto-merge
+enabled at creation (§109, §110, §111). All pull requests to `main` merge through
+a merge queue required by the `main` branch ruleset: when a pull request's required
+checks pass and auto-merge is enabled, GitHub places it in the queue, which re-tests
+each entry on a temporary `gh-readonly-queue/main/*` branch and merges entries one at
+a time.
+
+Event submissions arrive in bursts (§109.1), so several event pull requests often
+compete for the queue at once. When one pull request merges, `main` advances. A
+sibling pull request whose auto-merge was enabled against the previous `main` tip
+can then be left **stranded**: it has auto-merge enabled, all required checks green,
+and a clean mergeable state, yet it never reaches the queue and never merges. GitHub
+treats auto-merge as already enabled, so a second enable request changes nothing; the
+pull request only re-enters the queue when auto-merge is disabled and then enabled
+again, which registers a fresh queue entry against the current `main`.
+
+The observable signature of a stranded pull request is precise: auto-merge enabled,
+required checks passing, mergeable state clean, and **no merge-queue entry**. A
+pull request that is genuinely progressing through the queue has a merge-queue entry
+and is not stranded. (Issue #495; observed as #486, an edit pull request that was
+stranded when #482 merged ahead of it on 2026-06-21.)
+
+This failure mode is independent of the duplicate-submission handling in §111: a
+stranded pull request has a valid, non-empty diff and should merge — it is simply
+stuck in the queue handoff.
+
+### 112.2 Stranded pull request recovery (site requirements)
+
+- A stranded event pull request is one that is open, whose head branch is named
+  `event/*`, `event-edit/*`, or `event-delete/*`, that has auto-merge enabled, whose
+  required status checks all pass, whose mergeable state is clean, and that has no
+  merge-queue entry. <!-- 02-§112.1 -->
+- A stranded event pull request is recovered by disabling and then re-enabling
+  auto-merge, which registers a fresh merge-queue entry against the current `main`
+  so the pull request merges. Re-enabling auto-merge without first disabling it is a
+  no-op and does not recover the pull request. <!-- 02-§112.2 -->
+- Recovery re-enables auto-merge with the squash merge method, matching how the form
+  API enables auto-merge at submission. <!-- 02-§112.3 -->
+- An event pull request that already has a merge-queue entry is left untouched: it is
+  progressing through the queue normally and disabling its auto-merge would remove it
+  from the queue. <!-- 02-§112.4 -->
+- An event pull request whose required checks are still pending, or have failed, is
+  left untouched: it is not yet eligible to merge, so there is nothing to
+  recover. <!-- 02-§112.5 -->
+- Each event pull request is evaluated in isolation, so a failure to read or recover
+  one pull request does not abort the recovery of the others. <!-- 02-§112.6 -->
+
+### 112.3 When recovery runs (site requirements)
+
+- Recovery runs after each merge of event data to `main`, in the same post-merge
+  pipeline as the concurrent-duplicate cleanup (§111.8). That merge is what advances
+  the base and can strand a sibling pull request, so recovery happens immediately
+  when stranding is most likely. <!-- 02-§112.7 -->
+- Recovery also runs on a fixed schedule, every 15 minutes, as a safety net. A
+  pull request can be stranded by a merge that is not itself an event-data merge, or
+  by a stranding that no subsequent event merge follows to trigger the post-merge
+  pass; the scheduled pass bounds how long such a pull request waits before it is
+  recovered. <!-- 02-§112.8 -->
+- The scheduled safety-net pass is inexpensive when there are no open event pull
+  requests: it lists the open event pull requests and exits without further work when
+  none are stranded. <!-- 02-§112.9 -->
+- Recovery is idempotent. A pull request that is not stranded is left unchanged on
+  every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -950,6 +950,12 @@ stuck in the queue handoff.
 - An event pull request whose required checks are still pending, or have failed, is
   left untouched: it is not yet eligible to merge, so there is nothing to
   recover. <!-- 02-§112.5 -->
+- The re-enable step is retried with backoff. Once auto-merge has been disabled, a
+  transient failure to re-enable it would leave the pull request with auto-merge off
+  — worse than stranded — so re-enabling is retried until it succeeds or the
+  attempts are exhausted, in which case the failure is logged. The disable step is
+  not retried: if it fails the pull request is unchanged and the next recovery pass
+  retries the whole recovery. <!-- 02-§112.11 -->
 - Each event pull request is evaluated in isolation, so a failure to read or recover
   one pull request does not abort the recovery of the others. <!-- 02-§112.6 -->
 

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -21,7 +21,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
-| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111 |
+| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111, §112 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103, §108 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
 | [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105, §106 |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -102,7 +102,8 @@ their `source/data/**.yaml` path filter matches files nested one level under
 | --- | --- | --- |
 | `ci.yml` | All branches + PRs | Lint, test, build for code changes; pass-through for data-only |
 | `event-data-deploy.yml` | PRs from `event/**`, `event-edit/**` | No-op branch protection gate |
-| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus a write-scoped job that closes duplicate event PRs made redundant by the merge (02-§111.7) |
+| `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus write-scoped jobs that close duplicate event PRs made redundant by the merge (02-§111.7) and recover event PRs stranded in the merge queue by the base move (02-§112.7) |
+| `merge-queue-recovery.yml` | 15-minute `schedule` cron | Write-scoped safety-net sweep that recovers event PRs stranded in the merge queue (02-§112.8) |
 | `deploy-qa.yml` | Push to `main` (ignores per-camp event YAMLs) | Full build + SCP/SSH swap (QA) |
 | `deploy-prod.yml` | Manual `workflow_dispatch` | Full build + SCP/SSH swap (Production) |
 | `deploy-reusable.yml` | Called by `deploy-qa.yml` / `deploy-prod.yml` | Shared build-and-deploy logic |
@@ -223,6 +224,56 @@ silently (02-§111.9).
   protection for `main`.
 - No new secrets are needed beyond the existing SSH deploy secrets (scoped per
   GitHub Environment; see [08-ENVIRONMENTS.md](08-ENVIRONMENTS.md)).
+
+### 11.8 Stranded auto-merge recovery (02-§112)
+
+All pull requests to `main` merge through a merge queue required by the `main`
+branch ruleset. The form API enables auto-merge (squash) on each event pull request
+(`enableAutoMerge` in `source/api/github.js` / `GitHub::enableAutoMerge()` in PHP),
+and GitHub places the pull request in the queue once its required checks pass. The
+queue re-tests each entry on a `gh-readonly-queue/main/*` branch; `ci.yml` reaches
+those branches through its `push: '**'` trigger, so no `merge_group:` trigger is
+needed (see [04-OPERATIONS.md](../04-OPERATIONS.md) §"Merge queue").
+
+When event submissions arrive in a burst, several pull requests compete for the
+queue. If one merges and advances `main` while a sibling's auto-merge was enabled
+against the previous tip, GitHub can leave that sibling **stranded**: auto-merge
+stays enabled, the required checks are green and the mergeable state is clean, but
+the pull request never enters the queue (it has no `mergeQueueEntry`). Because
+GitHub already considers auto-merge enabled, re-enabling it is a no-op; only
+disabling and re-enabling auto-merge registers a fresh queue entry against the
+current `main` (02-§112.2).
+
+**Recovery sweep (02-§112.1–112.6).** `source/scripts/recover-stranded-event-prs.js`
+is a sibling to `close-redundant-event-prs.js`. It lists the open pull requests on
+`event/*`, `event-edit/*`, and `event-delete/*` branches and, for each, reads three
+GraphQL fields via `gh api graphql`: whether auto-merge is enabled
+(`autoMergeRequest`), the mergeable state (`mergeStateStatus`), and whether it is in
+the queue (`mergeQueueEntry`). A pure, unit-tested classifier
+(`classifyStrandedPr`) decides:
+
+- `recover` — auto-merge enabled, `mergeStateStatus` is `CLEAN`, and no
+  `mergeQueueEntry`: the pull request is stranded (02-§112.1).
+- `skip` — already has a `mergeQueueEntry` (progressing, 02-§112.4); checks pending
+  or failing so `mergeStateStatus` is not `CLEAN` (02-§112.5); or auto-merge is not
+  enabled.
+
+For a `recover` verdict the script calls `disablePullRequestAutoMerge` then
+`enablePullRequestAutoMerge` (mergeMethod `SQUASH`, matching the form API, 02-§112.3).
+Each pull request is processed inside its own `try`/`catch`, so one failed read or
+mutation does not abort the sweep (02-§112.6), mirroring the redundant-PR cleanup.
+The classifier never recovers a pull request that is not stranded, so repeated runs
+are idempotent (02-§112.10).
+
+**When it runs (02-§112.7–112.9).** The sweep runs in two places:
+
+- A job in `event-data-deploy-post-merge.yml` (push to `main`, `source/data/**.yaml`),
+  alongside `close-redundant-event-prs` — the event merge that triggers this workflow
+  is exactly the base move that can strand a sibling, so recovery happens immediately
+  (02-§112.7). The job needs `pull-requests: write` to toggle auto-merge.
+- A scheduled workflow, `merge-queue-recovery.yml`, on a 15-minute cron, as a safety
+  net for strandings that no event-data merge follows (02-§112.8). The sweep lists the
+  open event pull requests first and exits cheaply when none are stranded (02-§112.9).
 
 ---
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -260,8 +260,13 @@ the queue (`mergeQueueEntry`). A pure, unit-tested classifier
 
 For a `recover` verdict the script calls `disablePullRequestAutoMerge` then
 `enablePullRequestAutoMerge` (mergeMethod `SQUASH`, matching the form API, 02-§112.3).
-Each pull request is processed inside its own `try`/`catch`, so one failed read or
-mutation does not abort the sweep (02-§112.6), mirroring the redundant-PR cleanup.
+The re-enable is wrapped in `withRetry` (exponential backoff) because once auto-merge
+has been disabled, a transient failure to re-enable it would leave the pull request
+with auto-merge off — worse than stranded; the disable is a single attempt, since a
+failed disable leaves the pull request unchanged for the next sweep to retry
+(02-§112.11). Each pull request is processed inside its own `try`/`catch`, so one
+failed read or mutation does not abort the sweep (02-§112.6), mirroring the
+redundant-PR cleanup.
 The classifier never recovers a pull request that is not stranded, so repeated runs
 are idempotent (02-§112.10).
 

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -152,10 +152,9 @@ auto-merge is enabled, GitHub adds it to the queue instead of merging it directl
 
 The queue merges one entry at a time. Each queued PR is re-tested on a temporary
 `gh-readonly-queue/main/*` branch built on the current `main` tip, so a PR forked
-from an older `main` is rebuilt against the latest commit and merged in order.
-Concurrent form submissions therefore all reach `main` automatically: no PR is
-left stranded `behind` the branch it was forked from, and no manual
-"Update branch" step is needed.
+from an older `main` is rebuilt against the latest commit and merged in order. Once
+a PR is *in* the queue, concurrent form submissions all reach `main` automatically,
+with no manual "Update branch" step.
 
 The required `Lint, Test & Build` check reaches a queue branch because `ci.yml`
 triggers on `push` to `**`, which matches `gh-readonly-queue/main/*`. No workflow
@@ -164,6 +163,18 @@ from reporting on the queue branch: queued PRs then wait out the 60-minute
 status-check timeout, are treated as failed, and drop from the queue without
 merging. Add an explicit `merge_group:` trigger to the check-providing workflows
 before narrowing the `push` trigger.
+
+**Stranded auto-merge.** The handoff *into* the queue is not always reliable. When
+event submissions arrive in a burst and one merges, `main` advances; a sibling PR
+whose auto-merge was enabled against the previous tip can be left stranded —
+auto-merge enabled, checks green, `mergeable_state: clean`, but with **no
+merge-queue entry**, so it never merges. Re-enabling auto-merge is a no-op (GitHub
+sees it as already on); only disabling and re-enabling it registers a fresh queue
+entry. This is recovered automatically: a sweep
+(`source/scripts/recover-stranded-event-prs.js`) runs after every event-data merge
+and on a 15-minute schedule (`merge-queue-recovery.yml`), finds stranded `event/*`,
+`event-edit/*`, and `event-delete/*` PRs, and toggles their auto-merge off then on
+(02-§112, issue #495).
 
 ### Environment Variables
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1724,13 +1724,13 @@ Doc ref: `02-requirements/event-data.md §112`;
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§112.1` | gap | `classifyStrandedPr` returns `recover` only for an `event/`/`event-edit/`/`event-delete/` branch with auto-merge enabled, `mergeStateStatus === CLEAN`, and no `mergeQueueEntry` |
-| `02-§112.2` | gap | Recovery calls `disablePullRequestAutoMerge` then `enablePullRequestAutoMerge`; the live "disable→enable creates a fresh queue entry, re-enable alone is a no-op" premise is a manual checkpoint (STRAND-M01) |
-| `02-§112.3` | gap | Re-enable uses mergeMethod `SQUASH`, matching `enableAutoMerge` in the form API |
-| `02-§112.4` | gap | `classifyStrandedPr` returns `skip` when a `mergeQueueEntry` is present (already progressing) |
-| `02-§112.5` | gap | `classifyStrandedPr` returns `skip` when `mergeStateStatus` is not `CLEAN` (checks pending/failing) |
-| `02-§112.6` | gap | Per-PR `try`/`catch` in `main()` isolates a failed read or mutation from the rest of the sweep |
-| `02-§112.7` | gap | `recover-stranded-event-prs` job in `event-data-deploy-post-merge.yml` runs on push to `main` (`source/data/**`); CI/manual checkpoint (STRAND-M01) |
-| `02-§112.8` | gap | `merge-queue-recovery.yml` runs the sweep on a 15-minute `schedule` cron; CI/manual checkpoint (STRAND-M01) |
-| `02-§112.9` | gap | `main()` lists open event PRs first and returns without mutations when none classify as `recover` |
-| `02-§112.10` | gap | `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
+| `02-§112.1` | covered | STRAND-01/-02/-03: `classifyStrandedPr` returns `recover` only for an `event/`/`event-edit/`/`event-delete/` branch with auto-merge enabled, `mergeStateStatus === CLEAN`, and no `mergeQueueEntry` |
+| `02-§112.2` | implemented | `recoverPr()` calls `disablePullRequestAutoMerge` then `enablePullRequestAutoMerge`; the live "disable→enable creates a fresh queue entry, re-enable alone is a no-op" premise is manual checkpoint STRAND-M01 |
+| `02-§112.3` | implemented | `recoverPr()` re-enables with mergeMethod `SQUASH`, matching `enableAutoMerge` in the form API; live behaviour is STRAND-M01 |
+| `02-§112.4` | covered | STRAND-04, STRAND-10: `classifyStrandedPr` returns `skip` when a `mergeQueueEntry` is present (already progressing) |
+| `02-§112.5` | covered | STRAND-05, STRAND-06: `classifyStrandedPr` returns `skip` when `mergeStateStatus` is not `CLEAN` (checks pending/failing or not mergeable) |
+| `02-§112.6` | implemented | Per-PR `try`/`catch` in `main()` isolates a failed read or mutation from the rest of the sweep; exercised live (STRAND-M01) |
+| `02-§112.7` | implemented | `recover-stranded-event-prs` job in `event-data-deploy-post-merge.yml` runs on push to `main` (`source/data/**`); CI/manual checkpoint STRAND-M01 |
+| `02-§112.8` | implemented | `merge-queue-recovery.yml` runs the sweep on a 15-minute `schedule` cron (plus `workflow_dispatch`); CI/manual checkpoint STRAND-M01 |
+| `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
+| `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1734,3 +1734,4 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.8` | implemented | `merge-queue-recovery.yml` runs the sweep on a 15-minute `schedule` cron (plus `workflow_dispatch`); CI/manual checkpoint STRAND-M01 |
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
+| `02-§112.11` | covered | STRAND-11/-12/-13: `recoverPr()` wraps the re-enable in `withRetry` (exponential backoff); disable is a single attempt; live toggle is STRAND-M01 |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1715,3 +1715,22 @@ Doc ref: `02-requirements/event-data.md §111`;
 | `02-§111.7` | implemented | DEDUPCLEAN-01/-02 decide `close`; `main()` runs `gh pr close --delete-branch` on an `event/*` PR — the GitHub close + branch delete is the DEDUP-M02 manual checkpoint |
 | `02-§111.8` | implemented | `close-redundant-event-prs` job in `event-data-deploy-post-merge.yml` runs the script on push to `main` (`source/data/**`); CI/manual checkpoint (DEDUP-M02) |
 | `02-§111.9` | covered | DEDUPCLEAN-04: a modified (same-id/different-body) fragment → `log-manual`, not closed |
+
+### §112 — Stranded Auto-Merge Recovery
+
+Doc ref: `02-requirements/event-data.md §112`;
+`03-architecture/ci-and-deploy.md §11.8` (Stranded auto-merge recovery);
+`04-OPERATIONS.md §Merge queue`.
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§112.1` | gap | `classifyStrandedPr` returns `recover` only for an `event/`/`event-edit/`/`event-delete/` branch with auto-merge enabled, `mergeStateStatus === CLEAN`, and no `mergeQueueEntry` |
+| `02-§112.2` | gap | Recovery calls `disablePullRequestAutoMerge` then `enablePullRequestAutoMerge`; the live "disable→enable creates a fresh queue entry, re-enable alone is a no-op" premise is a manual checkpoint (STRAND-M01) |
+| `02-§112.3` | gap | Re-enable uses mergeMethod `SQUASH`, matching `enableAutoMerge` in the form API |
+| `02-§112.4` | gap | `classifyStrandedPr` returns `skip` when a `mergeQueueEntry` is present (already progressing) |
+| `02-§112.5` | gap | `classifyStrandedPr` returns `skip` when `mergeStateStatus` is not `CLEAN` (checks pending/failing) |
+| `02-§112.6` | gap | Per-PR `try`/`catch` in `main()` isolates a failed read or mutation from the rest of the sweep |
+| `02-§112.7` | gap | `recover-stranded-event-prs` job in `event-data-deploy-post-merge.yml` runs on push to `main` (`source/data/**`); CI/manual checkpoint (STRAND-M01) |
+| `02-§112.8` | gap | `merge-queue-recovery.yml` runs the sweep on a 15-minute `schedule` cron; CI/manual checkpoint (STRAND-M01) |
+| `02-§112.9` | gap | `main()` lists open event PRs first and returns without mutations when none classify as `recover` |
+| `02-§112.10` | gap | `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -138,14 +138,14 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1407
-Covered (implemented + tested): 753
+Total requirements:            1408
+Covered (implemented + tested): 754
 Implemented, not tested:        654
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
-Note: §112 (Stranded Auto-Merge Recovery) adds 10 requirements
-  (02-§112.1–112.10): 4 covered (STRAND-01..10,
+Note: §112 (Stranded Auto-Merge Recovery) adds 11 requirements
+  (02-§112.1–112.11): 5 covered (STRAND-01..13,
   tests/stranded-recovery.test.js) and 6 implemented (the GraphQL
   disable→enable toggle, the per-PR isolation and early-exit in main(), and
   the two workflow entry points, STRAND-M01 manual). Event PRs merge through a

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -138,11 +138,23 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1397
-Covered (implemented + tested): 749
-Implemented, not tested:        648
+Total requirements:            1407
+Covered (implemented + tested): 753
+Implemented, not tested:        654
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
+
+Note: §112 (Stranded Auto-Merge Recovery) adds 10 requirements
+  (02-§112.1–112.10): 4 covered (STRAND-01..10,
+  tests/stranded-recovery.test.js) and 6 implemented (the GraphQL
+  disable→enable toggle, the per-PR isolation and early-exit in main(), and
+  the two workflow entry points, STRAND-M01 manual). Event PRs merge through a
+  required merge queue; when main advances between auto-merge enablement and
+  queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
+  CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js
+  detects that signature and toggles auto-merge off then on to register a fresh
+  queue entry, running after each event merge and on a 15-minute safety-net
+  schedule (#495).
 
 Note: §111 (Duplicate Submission Hardening) adds 9 requirements
   (02-§111.1–111.9): 7 covered (DEDUP-01..09, DEDUPCLEAN-01..09,

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -51,6 +51,29 @@ function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' });
 }
 
+// Synchronous sleep without extra dependencies (CI runs are single-threaded here).
+function sleepSync(ms) {
+  if (ms > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run `fn`, retrying on throw with exponential backoff. Pure with respect to
+ * `fn`, so it is unit-tested with a synchronous stub and baseMs 0.
+ * Returns `fn`'s value, or re-throws the last error once attempts are exhausted.
+ */
+function withRetry(fn, { attempts = 3, baseMs = 1000 } = {}) {
+  let lastErr;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      return fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) sleepSync(baseMs * 2 ** i);
+    }
+  }
+  throw lastErr;
+}
+
 // Read the merge state of one PR via GraphQL. Separated from main() so the network
 // shell stays thin; classifyStrandedPr does the deciding.
 function fetchPrState(owner, repo, number) {
@@ -82,17 +105,21 @@ function fetchPrState(owner, repo, number) {
 }
 
 // Disable then re-enable auto-merge (squash) to register a fresh queue entry.
+// Disable runs once: if it fails the PR is left untouched (auto-merge still on)
+// and the next sweep retries the whole recovery. Enable is retried, because once
+// disable has succeeded a transient enable failure would otherwise leave the PR
+// with auto-merge off — worse than stranded (02-§112.11).
 function recoverPr(nodeId) {
   gh([
     'api', 'graphql',
     '-f', 'query=mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}',
     '-f', `id=${nodeId}`,
   ]);
-  gh([
+  withRetry(() => gh([
     'api', 'graphql',
     '-f', 'query=mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}',
     '-f', `id=${nodeId}`,
-  ]);
+  ]));
 }
 
 function main() {
@@ -142,4 +169,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { classifyStrandedPr };
+module.exports = { classifyStrandedPr, withRetry };

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// Recovers event-submission pull requests that have stranded in the merge-queue
+// handoff (02-§112). Runs in event-data-deploy-post-merge.yml after each event
+// merge, and on a 15-minute schedule in merge-queue-recovery.yml.
+//
+// All pull requests to main merge through a merge queue. The form API enables
+// auto-merge (squash) on each event PR; GitHub places it in the queue once its
+// required checks pass. When event submissions arrive in a burst and one merges,
+// main advances — and a sibling whose auto-merge was enabled against the previous
+// tip can be left stranded: auto-merge enabled, checks green (mergeStateStatus
+// CLEAN), mergeable, but with no mergeQueueEntry, so it never merges. Re-enabling
+// auto-merge is a no-op; only disabling and re-enabling it registers a fresh queue
+// entry against the current main. This script detects that exact signature and
+// toggles auto-merge off then on to recover the PR.
+
+const { execFileSync } = require('node:child_process');
+
+// Event PRs opened by the form API use these head-branch prefixes (add / edit /
+// delete). Anything else is out of scope.
+const EVENT_PREFIXES = ['event/', 'event-edit/', 'event-delete/'];
+
+function isEventBranch(branch) {
+  return typeof branch === 'string' && EVENT_PREFIXES.some((p) => branch.startsWith(p));
+}
+
+/**
+ * Decide what to do with an event pull request from its observable merge state.
+ * Pure and side-effect free so it can be unit-tested.
+ *
+ *   branch            – head ref name
+ *   autoMergeEnabled  – true when auto-merge is enabled on the PR
+ *   mergeStateStatus  – GitHub mergeStateStatus enum (CLEAN, BLOCKED, BEHIND,
+ *                       UNSTABLE, DIRTY, DRAFT, HAS_HOOKS, UNKNOWN)
+ *   inMergeQueue      – true when the PR has a mergeQueueEntry
+ *
+ * Returns:
+ *   'ignore'  – not an event-submission PR
+ *   'recover' – stranded: auto-merge on, CLEAN, and not in the queue
+ *   'skip'    – event PR that is not stranded (queued, not CLEAN, or auto-merge off)
+ */
+function classifyStrandedPr({ branch, autoMergeEnabled, mergeStateStatus, inMergeQueue } = {}) {
+  if (!isEventBranch(branch)) return 'ignore';
+  if (!autoMergeEnabled) return 'skip';      // nothing to recover
+  if (inMergeQueue) return 'skip';           // already progressing through the queue
+  if (mergeStateStatus !== 'CLEAN') return 'skip'; // checks pending/failing or not mergeable
+  return 'recover';
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+// Read the merge state of one PR via GraphQL. Separated from main() so the network
+// shell stays thin; classifyStrandedPr does the deciding.
+function fetchPrState(owner, repo, number) {
+  const query = `
+    query($owner:String!,$repo:String!,$num:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$num){
+          id
+          autoMergeRequest { enabledAt }
+          mergeStateStatus
+          mergeQueueEntry { id }
+        }
+      }
+    }`;
+  const out = gh([
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-f', `owner=${owner}`,
+    '-f', `repo=${repo}`,
+    '-F', `num=${number}`,
+  ]);
+  const pr = JSON.parse(out).data.repository.pullRequest;
+  return {
+    nodeId: pr.id,
+    autoMergeEnabled: pr.autoMergeRequest != null,
+    mergeStateStatus: pr.mergeStateStatus,
+    inMergeQueue: pr.mergeQueueEntry != null,
+  };
+}
+
+// Disable then re-enable auto-merge (squash) to register a fresh queue entry.
+function recoverPr(nodeId) {
+  gh([
+    'api', 'graphql',
+    '-f', 'query=mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}',
+    '-f', `id=${nodeId}`,
+  ]);
+  gh([
+    'api', 'graphql',
+    '-f', 'query=mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}',
+    '-f', `id=${nodeId}`,
+  ]);
+}
+
+function main() {
+  const repoSlug = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
+  const [owner, repo] = repoSlug.split('/');
+  if (!owner || !repo) {
+    throw new Error('GH_REPO/GITHUB_REPOSITORY must be set to "owner/repo"');
+  }
+  const repoArgs = ['--repo', repoSlug];
+
+  const prs = JSON.parse(
+    gh(['pr', 'list', ...repoArgs, '--state', 'open', '--limit', '100', '--json', 'number,headRefName']),
+  );
+
+  // Cheap exit when there are no open event PRs (02-§112.9).
+  const eventPrs = prs.filter((pr) => isEventBranch(pr.headRefName));
+  if (eventPrs.length === 0) {
+    console.log('No open event pull requests — nothing to recover');
+    return;
+  }
+
+  for (const pr of eventPrs) {
+    // Isolate per-PR failures so one bad fetch/mutation does not abort the sweep
+    // (02-§112.6).
+    try {
+      const state = fetchPrState(owner, repo, pr.number);
+      const verdict = classifyStrandedPr({ branch: pr.headRefName, ...state });
+
+      if (verdict === 'recover') {
+        console.log(`Recovering stranded PR #${pr.number} (${pr.headRefName}) — auto-merge on, CLEAN, no queue entry; toggling auto-merge`);
+        recoverPr(state.nodeId);
+      } else {
+        console.log(`Skipping PR #${pr.number} (${pr.headRefName}) — ${verdict} (mergeStateStatus=${state.mergeStateStatus}, inQueue=${state.inMergeQueue}, autoMerge=${state.autoMergeEnabled})`);
+      }
+    } catch (err) {
+      console.log(`::warning::Could not process event PR #${pr.number} (${pr.headRefName}): ${err.message}`);
+    }
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('recover-stranded-event-prs failed:', err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { classifyStrandedPr };

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+// Unit tests for the stranded-auto-merge recovery decision (02-§112.1–112.10).
+// classifyStrandedPr is pure, so its full decision table is tested here; the
+// GitHub GraphQL wiring in the script's main() (read fields, disable→enable
+// auto-merge) is a manual/integration checkpoint (STRAND-M01).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { classifyStrandedPr } = require('../source/scripts/recover-stranded-event-prs');
+
+// A pull request that GitHub considers fully mergeable but that never reached the
+// queue: auto-merge on, checks green (CLEAN), and no queue entry.
+const STRANDED = { autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: false };
+
+describe('classifyStrandedPr — stranded auto-merge recovery (02-§112.1–112.10)', () => {
+  it('STRAND-01: add (event/) PR, auto-merge on, CLEAN, no queue entry → recover', () => {
+    assert.equal(classifyStrandedPr({ branch: 'event/2026-06-22-x-1', ...STRANDED }), 'recover');
+  });
+
+  it('STRAND-02: edit (event-edit/) PR stranded → recover (the #486 case)', () => {
+    assert.equal(classifyStrandedPr({ branch: 'event-edit/x-2026-06-22-1115-1', ...STRANDED }), 'recover');
+  });
+
+  it('STRAND-03: delete (event-delete/) PR stranded → recover', () => {
+    assert.equal(classifyStrandedPr({ branch: 'event-delete/x-1', ...STRANDED }), 'recover');
+  });
+
+  it('STRAND-04: already in the merge queue → skip (progressing, 02-§112.4)', () => {
+    assert.equal(
+      classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
+      'skip',
+    );
+  });
+
+  it('STRAND-05: mergeStateStatus not CLEAN (BLOCKED/BEHIND/UNSTABLE) → skip (02-§112.5)', () => {
+    for (const status of ['BLOCKED', 'BEHIND', 'UNSTABLE', 'DIRTY']) {
+      assert.equal(
+        classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: status, inMergeQueue: false }),
+        'skip',
+        `status ${status} should skip`,
+      );
+    }
+  });
+
+  it('STRAND-06: required checks still pending (UNKNOWN) → skip (02-§112.5)', () => {
+    assert.equal(
+      classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: 'UNKNOWN', inMergeQueue: false }),
+      'skip',
+    );
+  });
+
+  it('STRAND-07: auto-merge not enabled → skip (nothing to recover)', () => {
+    assert.equal(
+      classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: false, mergeStateStatus: 'CLEAN', inMergeQueue: false }),
+      'skip',
+    );
+  });
+
+  it('STRAND-08: non-event branch → ignore', () => {
+    assert.equal(classifyStrandedPr({ branch: 'fix/something', ...STRANDED }), 'ignore');
+    assert.equal(classifyStrandedPr({ branch: 'main', ...STRANDED }), 'ignore');
+  });
+
+  it('STRAND-09: missing/garbage input → ignore (no branch)', () => {
+    assert.equal(classifyStrandedPr({}), 'ignore');
+    assert.equal(classifyStrandedPr(), 'ignore');
+    assert.equal(classifyStrandedPr({ branch: null }), 'ignore');
+  });
+
+  it('STRAND-10: idempotent — a non-stranded event PR always classifies as skip (02-§112.10)', () => {
+    // Re-running recovery on a PR that is already queued or already merging must
+    // never re-toggle it.
+    assert.equal(
+      classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
+      'skip',
+    );
+  });
+});

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -8,7 +8,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { classifyStrandedPr } = require('../source/scripts/recover-stranded-event-prs');
+const { classifyStrandedPr, withRetry } = require('../source/scripts/recover-stranded-event-prs');
 
 // A pull request that GitHub considers fully mergeable but that never reached the
 // queue: auto-merge on, checks green (CLEAN), and no queue entry.
@@ -76,5 +76,34 @@ describe('classifyStrandedPr — stranded auto-merge recovery (02-§112.1–112.
       classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
       'skip',
     );
+  });
+});
+
+describe('withRetry — enable-step resilience (02-§112.11)', () => {
+  it('STRAND-11: returns the result on first success without retrying', () => {
+    let calls = 0;
+    const result = withRetry(() => { calls += 1; return 'ok'; }, { baseMs: 0 });
+    assert.equal(result, 'ok');
+    assert.equal(calls, 1);
+  });
+
+  it('STRAND-12: retries on throw and succeeds before attempts are exhausted', () => {
+    let calls = 0;
+    const result = withRetry(() => {
+      calls += 1;
+      if (calls < 3) throw new Error('transient');
+      return 'recovered';
+    }, { attempts: 3, baseMs: 0 });
+    assert.equal(result, 'recovered');
+    assert.equal(calls, 3);
+  });
+
+  it('STRAND-13: re-throws the last error once all attempts are exhausted', () => {
+    let calls = 0;
+    assert.throws(
+      () => withRetry(() => { calls += 1; throw new Error(`fail-${calls}`); }, { attempts: 3, baseMs: 0 }),
+      /fail-3/,
+    );
+    assert.equal(calls, 3);
   });
 });


### PR DESCRIPTION
## Summary

- Event PRs (add / edit / delete) merge through a required merge queue with auto-merge enabled. When a burst of submissions competes for the queue and one merges, `main` advances — and a sibling whose auto-merge was enabled against the previous tip can be left **stranded**: auto-merge on, checks green, `mergeable_state: clean`, but with **no merge-queue entry**, so it never merges. Re-enabling auto-merge is a no-op; only disabling then re-enabling registers a fresh queue entry. (Issue #495; observed as #486.)
- Adds `source/scripts/recover-stranded-event-prs.js`: lists open `event/*`, `event-edit/*`, `event-delete/*` PRs, reads each PR's `autoMergeRequest`, `mergeStateStatus`, and `mergeQueueEntry` via GraphQL, and a pure `classifyStrandedPr` decides `recover` / `skip` / `ignore`. A stranded PR is recovered by disabling then re-enabling auto-merge (squash). The re-enable is retried with backoff so a transient failure can't leave a PR with auto-merge off; per-PR `try`/`catch` isolates failures.
- Runs in two places: a write-scoped job in `event-data-deploy-post-merge.yml` after each event merge (immediate), and `merge-queue-recovery.yml` on a 15-minute schedule as a safety net (cheap when no event PRs are open).
- This is distinct from the duplicate-PR cleanup (#480/#485): a stranded PR has a valid, non-empty diff and *should* merge — it is just stuck in the queue handoff. It also does **not** require a `merge_group:` trigger, since `ci.yml` already reaches queue branches via its `push: '**'` trigger.

Requirements `02-§112.1–112.11`; architecture `03-architecture/ci-and-deploy.md §11.8`; merge-queue stranding documented in `04-OPERATIONS.md`.

## Test plan

- [x] `node --test tests/stranded-recovery.test.js` — 13 cases (STRAND-01..13): classifier decision table + `withRetry` resilience
- [x] `npm test` — full suite, 2001 passing
- [x] `npm run lint` (eslint) and `npm run lint:md` clean
- [x] Both workflow YAMLs validate
- [ ] **Manual (STRAND-M01):** against live GitHub, confirm the `disable→enable` toggle re-enters a stranded event PR into the merge queue (only exercisable on real GitHub; auto-merge mutations and merge-queue state are not available in unit tests)

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGfraxdshpSKuPBvseawfu)_