### PR TITLE
Proactively enqueue event PRs into the merge queue at submission

### DIFF
--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -91,6 +91,10 @@ final class GitHub
         $this->putFile($fragPath, $content, null, $commitMsg, $branchName);
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar add-event API.');
         $this->enableAutoMerge($pr['node_id']);
+        // Place the PR in the merge queue right away to merge in ~50 s instead of
+        // waiting for the reactive recovery sweep. Best-effort: never fails the
+        // submission (02-§113.1, §113.4).
+        $this->enqueueBestEffort($pr['node_id']);
     }
 
     /**
@@ -172,6 +176,8 @@ final class GitHub
         }
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar add-events API (batch).');
         $this->enableAutoMerge($pr['node_id']);
+        // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+        $this->enqueueBestEffort($pr['node_id']);
 
         return $eventIds;
     }
@@ -209,6 +215,8 @@ final class GitHub
         $this->putFile($fragPath, $content, $fragSha, $commitMsg, $branchName);
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar edit-event API.');
         $this->enableAutoMerge($pr['node_id']);
+        // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+        $this->enqueueBestEffort($pr['node_id']);
     }
 
     /**
@@ -235,6 +243,8 @@ final class GitHub
         $this->deleteFile($fragPath, $fragSha, $commitMsg, $branchName);
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar delete-event API.');
         $this->enableAutoMerge($pr['node_id']);
+        // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+        $this->enqueueBestEffort($pr['node_id']);
     }
 
     // ── Camp resolution ──────────────────────────────────────────────────
@@ -615,6 +625,66 @@ final class GitHub
 
         if (!empty($data['errors'])) {
             throw new \RuntimeException('GraphQL error enabling auto-merge: ' . $data['errors'][0]['message']);
+        }
+    }
+
+    /**
+     * Build the GraphQL mutation that places a pull request in the merge queue
+     * (02-§113.1). Pure (no network) so it can be unit-tested. Unlike
+     * enablePullRequestAutoMerge, enqueuePullRequest takes no merge method — the
+     * merge queue's configured method is used (02-§113.3).
+     *
+     * @return array{query:string,variables:array{id:string}}
+     */
+    public static function buildEnqueueMutation(string $nodeId): array
+    {
+        return [
+            'query' => '
+                mutation($id: ID!) {
+                    enqueuePullRequest(input: { pullRequestId: $id }) {
+                        mergeQueueEntry { id }
+                    }
+                }
+            ',
+            'variables' => ['id' => $nodeId],
+        ];
+    }
+
+    /**
+     * Place a pull request in the merge queue via the GraphQL API (02-§113.1).
+     * GraphQL errors arrive as HTTP 200 with a body-level errors array — checked
+     * explicitly, mirroring enableAutoMerge. Best-effort containment lives in the
+     * caller (enqueueBestEffort), so this stays a plain "enqueue or throw"
+     * primitive.
+     */
+    private function enqueuePullRequest(string $nodeId): void
+    {
+        ['query' => $query, 'variables' => $variables] = self::buildEnqueueMutation($nodeId);
+
+        $data = $this->githubRequest('POST', '/graphql', [
+            'query'     => $query,
+            'variables' => $variables,
+        ]);
+
+        if (!empty($data['errors'])) {
+            throw new \RuntimeException('GraphQL error enqueuing pull request: ' . $data['errors'][0]['message']);
+        }
+    }
+
+    /**
+     * Best-effort wrapper around enqueuePullRequest (02-§113.4–113.7): it must
+     * never fail the user's submission. The pull request has already been created
+     * with auto-merge enabled, so a failed enqueue — most commonly because the
+     * required checks are still running, so the queue declines an unmergeable pull
+     * request (02-§113.5) — is logged as a warning and falls back to auto-merge
+     * plus the reactive recovery in §112.
+     */
+    private function enqueueBestEffort(string $nodeId): void
+    {
+        try {
+            $this->enqueuePullRequest($nodeId);
+        } catch (\Throwable $e) {
+            error_log('Proactive enqueue failed (best-effort; falling back to auto-merge + recovery): ' . $e->getMessage());
         }
     }
 

--- a/api/tests/GitHubTest.php
+++ b/api/tests/GitHubTest.php
@@ -263,4 +263,39 @@ final class GitHubTest extends TestCase
         $this->expectException(\RuntimeException::class);
         GitHub::assertFragmentYamlValid($content, 'frukost-2026-06-22-0800');
     }
+
+    // ── buildEnqueueMutation (02-§113) ───────────────────────────────────────
+    // Mirrors the Node ENQ-01..05 tests: proactive merge-queue enqueue mutation.
+    // The network call and best-effort containment are manual checkpoints (ENQ-M01).
+
+    public function testBuildEnqueueMutationCallsEnqueuePullRequest(): void
+    {
+        ['query' => $query] = GitHub::buildEnqueueMutation('PR_node_1');
+        $this->assertStringContainsString('enqueuePullRequest', $query);
+    }
+
+    public function testBuildEnqueueMutationPassesNodeIdAsPullRequestId(): void
+    {
+        ['query' => $query] = GitHub::buildEnqueueMutation('PR_node_1');
+        $this->assertMatchesRegularExpression('/pullRequestId:\s*\$id/', $query);
+    }
+
+    public function testBuildEnqueueMutationSpecifiesNoMergeMethod(): void
+    {
+        ['query' => $query] = GitHub::buildEnqueueMutation('PR_node_1');
+        $this->assertDoesNotMatchRegularExpression('/mergeMethod/i', $query);
+    }
+
+    public function testBuildEnqueueMutationBindsNodeIdToIdVariable(): void
+    {
+        ['variables' => $variables] = GitHub::buildEnqueueMutation('PR_node_42');
+        $this->assertSame('PR_node_42', $variables['id']);
+    }
+
+    public function testBuildEnqueueMutationSelectsMergeQueueEntryNotAutoMerge(): void
+    {
+        ['query' => $query] = GitHub::buildEnqueueMutation('PR_node_1');
+        $this->assertStringContainsString('mergeQueueEntry', $query);
+        $this->assertStringNotContainsString('enablePullRequestAutoMerge', $query);
+    }
 }

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -975,3 +975,65 @@ stuck in the queue handoff.
   none are stranded. <!-- 02-§112.9 -->
 - Recovery is idempotent. A pull request that is not stranded is left unchanged on
   every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->
+
+## 113. Proactive Merge-Queue Enqueue
+
+### 113.1 Context
+
+Event pull requests opened by the form API (add, edit, delete, batch) have
+auto-merge (squash) enabled at creation (§109, §110, §111). Enabling auto-merge is
+not the same as being placed in the merge queue: GitHub only adds a pull request to
+the queue once its required checks pass, and during bursts a pull request can fail to
+enter the queue at all and hang with auto-merge enabled but no queue entry (§112).
+The reactive recovery in §112 repairs such a pull request, but it is reactive — a
+stranded pull request can in the worst case wait up to the recovery sweep's interval
+(~15 minutes) before it is detected and re-queued.
+
+To keep submission latency low, the form API places each newly opened event pull
+request in the merge queue immediately at submission, via the GraphQL
+`enqueuePullRequest` mutation, so that a submitted activity merges in roughly the
+queue's normal cycle (~50 seconds) rather than waiting for a recovery sweep. This is
+a latency optimisation layered on top of the existing safety nets, not a replacement
+for them: auto-merge stays enabled as a complement, and the reactive recovery in
+§112 remains in place for any pull request that still falls out of the queue.
+
+### 113.2 Proactive enqueue at submission (site requirements)
+
+- Immediately after the form API creates an event pull request (add, edit, delete, or
+  batch) and enables squash auto-merge on it, it places the pull request in the merge
+  queue with the GraphQL `enqueuePullRequest` mutation, using the pull request's node
+  id. <!-- 02-§113.1 -->
+- Enabling squash auto-merge with `enablePullRequestAutoMerge` is retained as a
+  complement to the enqueue call: when a pull request cannot be enqueued at submission
+  time, auto-merge places it in the queue once its required checks pass. <!-- 02-§113.2 -->
+- The merge method of an enqueued pull request is the merge queue's configured method;
+  the `enqueuePullRequest` mutation does not specify a merge method, unlike
+  `enablePullRequestAutoMerge`. <!-- 02-§113.3 -->
+
+### 113.3 Best-effort behaviour (site requirements)
+
+- The enqueue call is best-effort: a failure to enqueue never fails the user's
+  submission. The pull request has already been created with auto-merge enabled, so a
+  failed enqueue falls back to auto-merge plus the reactive recovery in §112 as the
+  safety net. <!-- 02-§113.4 -->
+- A pull request whose required checks are still running is not yet mergeable, so the
+  merge queue declines to enqueue it. This is an expected outcome of a burst
+  submission, not an error condition: the failure is logged as a warning and the
+  submission still succeeds. <!-- 02-§113.5 -->
+- A failed enqueue is logged (warning), creating no GitHub issue and no user-facing
+  error. The submission response is identical to one where enqueue succeeded; the
+  difference is only how soon the pull request reaches the queue. <!-- 02-§113.6 -->
+- A submission is never more fragile than it was before proactive enqueue: every code
+  path that could throw from the enqueue step is contained so the submission outcome
+  is unchanged whether enqueue succeeds or fails. <!-- 02-§113.7 -->
+
+### 113.4 Unchanged guarantees (site requirements)
+
+- The reactive stranded-recovery automation (§112) is unchanged and remains the safety
+  net for any event pull request that falls out of the merge queue, including one whose
+  proactive enqueue failed at submission. <!-- 02-§113.8 -->
+- The event-data validation gate is unchanged by proactive enqueue: the `event-data
+  check` (the hard `check-yaml-security.js` block and `lint-yaml.js`) and the API-layer
+  validation remain required and run exactly as before. Enqueuing a pull request places
+  it in the queue, where its required checks still run and must pass before it
+  merges. <!-- 02-§113.9 -->

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -244,6 +244,13 @@ GitHub already considers auto-merge enabled, re-enabling it is a no-op; only
 disabling and re-enabling auto-merge registers a fresh queue entry against the
 current `main` (02-§112.2).
 
+The form API also enqueues each event pull request proactively at submission
+(`enqueuePullRequest`, 02-§113, see `forms-and-api.md §30`), which puts most pull
+requests in the queue without waiting for any sweep. That enqueue is best-effort:
+when it fails — typically because the required checks are still running — the pull
+request falls back to auto-merge, and this recovery sweep remains the safety net for
+any pull request that ends up stranded.
+
 **Recovery sweep (02-§112.1–112.6).** `source/scripts/recover-stranded-event-prs.js`
 is a sibling to `close-redundant-event-prs.js`. It lists the open pull requests on
 `event/*`, `event-edit/*`, and `event-delete/*` branches and, for each, reads three

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -530,3 +530,74 @@ browser tab, closing the tab also clears the data — no expiry logic is needed.
 | `source/assets/js/client/lagg-till.js` | Add save/restore/clear logic for `sb_form_draft` |
 
 ---
+
+## 30. Proactive Merge-Queue Enqueue (02-§113)
+
+Every event mutation in the form API — add, edit, delete, and the recurring-batch
+add — finishes the same way: it opens a pull request, enables squash auto-merge on
+it, and then places it in the merge queue immediately. The enqueue step is the
+latency optimisation from 02-§113; the auto-merge step is retained as a complement,
+and the reactive stranded-recovery sweep (02-§112, documented in
+`ci-and-deploy.md §11.8`) remains the safety net.
+
+### Why enqueue proactively
+
+All pull requests to `main` merge through a required merge queue. Enabling
+auto-merge is not the same as being in the queue: GitHub only adds a pull request
+to the queue once its required checks pass, and during a burst of submissions a
+pull request can hang with auto-merge enabled but no queue entry (02-§112). The
+reactive recovery repairs that, but only on its next sweep — in the worst case
+~15 minutes. Calling `enqueuePullRequest` at submission time puts the pull request
+in the queue right away, so a submitted activity merges in roughly the queue's
+normal cycle (~50 s) instead of waiting for a sweep (02-§113.1).
+
+### The enqueue call
+
+Both API implementations (`source/api/github.js`, `api/src/GitHub.php`) expose a
+pure helper that builds the GraphQL mutation, and a thin network wrapper that runs
+it:
+
+```graphql
+mutation($id: ID!) {
+  enqueuePullRequest(input: { pullRequestId: $id }) {
+    mergeQueueEntry { id }
+  }
+}
+```
+
+The mutation takes only the pull request's node id. Unlike
+`enablePullRequestAutoMerge`, it does **not** take a merge method — an enqueued
+pull request uses the merge queue's configured method (02-§113.3). The node id is
+the same `node_id` already returned by `createPullRequest` and used for
+`enableAutoMerge`.
+
+### Best-effort contract
+
+The enqueue call is best-effort and must never fail the user's submission
+(02-§113.4–113.7). The pull request has already been created with auto-merge
+enabled before enqueue is attempted, so the order is always:
+
+```text
+createPullRequest → enableAutoMerge → enqueue (best-effort)
+```
+
+The network wrapper is invoked inside a `try`/`catch` (PHP) /
+`.catch`-equivalent (Node) at each call site. A throw from enqueue — most commonly
+because the pull request's required checks are still running, so the queue declines
+to enqueue an unmergeable pull request — is caught and logged as a warning, and the
+mutation method returns normally. No GitHub issue is created and the submission
+response is identical to the success case (02-§113.6). This is why a burst
+submission whose checks have not yet finished is not an error: it simply falls back
+to auto-merge plus reactive recovery, exactly as before proactive enqueue existed.
+
+Because GraphQL reports errors as an HTTP 200 body with an `errors` array, the
+network wrapper checks that array and throws on it (mirroring `enableAutoMerge`);
+the best-effort containment lives at the call site, so the wrapper itself stays a
+plain "run this mutation or throw" primitive.
+
+### Files changed
+
+| File | Change |
+| --- | --- |
+| `source/api/github.js` | Add `buildEnqueueMutation()` (pure) and `enqueuePullRequest()` (network); call it best-effort after `enableAutoMerge` in add/edit/delete |
+| `api/src/GitHub.php` | Mirror: `buildEnqueueMutation()`, `enqueuePullRequest()`, best-effort call in add/edit/delete/batch |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1735,3 +1735,21 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
 | `02-§112.11` | covered | STRAND-11/-12/-13: `recoverPr()` wraps the re-enable in `withRetry` (exponential backoff); disable is a single attempt; live toggle is STRAND-M01 |
+
+### §113 — Proactive Merge-Queue Enqueue
+
+Doc ref: `02-requirements/event-data.md §113`;
+`03-architecture/forms-and-api.md §30` (Proactive Merge-Queue Enqueue);
+`03-architecture/ci-and-deploy.md §11.8` (cross-reference).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§113.1` | gap | |
+| `02-§113.2` | gap | |
+| `02-§113.3` | gap | |
+| `02-§113.4` | gap | |
+| `02-§113.5` | gap | |
+| `02-§113.6` | gap | |
+| `02-§113.7` | gap | |
+| `02-§113.8` | gap | |
+| `02-§113.9` | gap | |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1744,12 +1744,12 @@ Doc ref: `02-requirements/event-data.md §113`;
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§113.1` | gap | |
-| `02-§113.2` | gap | |
-| `02-§113.3` | gap | |
-| `02-§113.4` | gap | |
-| `02-§113.5` | gap | |
-| `02-§113.6` | gap | |
-| `02-§113.7` | gap | |
-| `02-§113.8` | gap | |
-| `02-§113.9` | gap | |
+| `02-§113.1` | implemented | `enqueueBestEffort(pr.node_id)` runs after `enableAutoMerge` in add/edit/delete (Node) and add/batch/edit/delete (PHP); the mutation shape is ENQ-01/-02/-04 (Node) + PHP parity; the live "PR lands in the queue" is manual checkpoint ENQ-M01 |
+| `02-§113.2` | implemented | Each call site keeps `enableAutoMerge(pr.node_id)` immediately before the enqueue call, so a non-mergeable PR still queues via auto-merge once checks pass; code-review checkpoint, live behaviour is ENQ-M01 |
+| `02-§113.3` | covered | ENQ-03 (Node) + `testBuildEnqueueMutationSpecifiesNoMergeMethod` (PHP): the mutation contains no `mergeMethod`; ENQ-05 confirms it selects `mergeQueueEntry`, not `enablePullRequestAutoMerge` |
+| `02-§113.4` | covered | ENQ-06/-07/-10: `enqueueBestEffort` calls the impl once on success and never throws when it rejects (sync throw or rejected Promise) |
+| `02-§113.5` | covered | ENQ-09: a "checks still running" failure is swallowed and reported as not enqueued; the queue actually declining an unmergeable PR is live checkpoint ENQ-M01 |
+| `02-§113.6` | covered | ENQ-08: exactly one warning is logged on failure and nothing else; no GitHub issue is created (the best-effort wrapper only calls `log`) |
+| `02-§113.7` | covered | ENQ-07: the enqueue step is contained so the submission outcome is unchanged whether enqueue succeeds or fails |
+| `02-§113.8` | covered | Recovery (`recover-stranded-event-prs.js`, §112) is untouched; STRAND-01..13 still pass. A proactively enqueued PR has a `mergeQueueEntry`, so `classifyStrandedPr` returns `skip` (STRAND-04) and recovery still catches any PR that later falls out of the queue |
+| `02-§113.9` | covered | The event-data validation gate (`check-yaml-security.js`, `lint-yaml.js`) and API-layer validation are unchanged; YSEC/validation tests still pass. Enqueue only changes when a PR enters the queue, not whether its required checks run |

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -138,11 +138,26 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1408
-Covered (implemented + tested): 754
-Implemented, not tested:        654
+Total requirements:            1417
+Covered (implemented + tested): 761
+Implemented, not tested:        656
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
+
+Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
+  (02-§113.1–113.9): 7 covered (ENQ-01..10 in tests/github.test.js plus the
+  buildEnqueueMutation parity tests in api/tests/GitHubTest.php) and 2
+  implemented (the enqueue call after auto-merge, and keeping auto-merge as a
+  complement, both code-review/ENQ-M01 manual). After the form API creates an
+  event PR and enables squash auto-merge, it places the PR in the merge queue
+  immediately via GraphQL enqueuePullRequest so a submitted activity merges in
+  ~50 s instead of waiting for the reactive recovery sweep (~15 min worst case).
+  The call is best-effort: when the PR is not yet mergeable (checks still
+  running) the failure is logged and the PR falls back to auto-merge plus the
+  §112 reactive recovery. ENQ-M01 is the live checkpoint — enqueue cannot be
+  exercised without a real token and a real PR, so whether it succeeds at
+  submission time (and thus whether the latency goal is actually met) must be
+  confirmed against production (#481).
 
 Note: §112 (Stranded Auto-Merge Recovery) adds 11 requirements
   (02-§112.1–112.11): 5 covered (STRAND-01..13,

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -317,6 +317,55 @@ async function enableAutoMerge(nodeId) {
   }
 }
 
+// Build the GraphQL mutation that places a pull request in the merge queue
+// (02-§113.1). Pure (no network) so it can be unit-tested. Unlike
+// enablePullRequestAutoMerge, enqueuePullRequest takes no merge method — the merge
+// queue's configured method is used (02-§113.3).
+function buildEnqueueMutation(nodeId) {
+  return {
+    query: `
+      mutation($id: ID!) {
+        enqueuePullRequest(input: { pullRequestId: $id }) {
+          mergeQueueEntry { id }
+        }
+      }
+    `,
+    variables: { id: nodeId },
+  };
+}
+
+// Place a pull request in the merge queue via the GraphQL API (02-§113.1).
+// GraphQL errors arrive as HTTP 200 with a body-level errors array — checked
+// explicitly, mirroring enableAutoMerge. Best-effort containment lives in the
+// caller (enqueueBestEffort), so this stays a plain "enqueue or throw" primitive.
+async function enqueuePullRequest(nodeId) {
+  const token = env('GITHUB_TOKEN');
+  const { query, variables } = buildEnqueueMutation(nodeId);
+
+  const { data } = await githubRequest('POST', '/graphql', { query, variables }, token);
+
+  if (data && data.errors && data.errors.length > 0) {
+    throw new Error(`GraphQL error enqueuing pull request: ${data.errors[0].message}`);
+  }
+}
+
+// Best-effort wrapper around enqueue (02-§113.4–113.7): it must never fail the
+// user's submission. The pull request has already been created with auto-merge
+// enabled, so a failed enqueue — most commonly because the required checks are
+// still running, so the queue declines an unmergeable pull request (02-§113.5) —
+// is logged as a warning and falls back to auto-merge plus the reactive recovery
+// in §112. Returns true when the pull request was enqueued, false otherwise.
+// `enqueue` and `log` are injectable so the containment is unit-testable.
+async function enqueueBestEffort(nodeId, { enqueue = enqueuePullRequest, log = console.warn } = {}) {
+  try {
+    await enqueue(nodeId);
+    return true;
+  } catch (e) {
+    log(`Proactive enqueue failed (best-effort; falling back to auto-merge + recovery): ${e.message}`);
+    return false;
+  }
+}
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 // Resolve the active camp from camps.yaml on main (shared by all mutations).
@@ -399,6 +448,10 @@ async function addEventToActiveCamp(body) {
   await putFile(fragPath, content, null, commitMsg, branchName);
   const pr = await createPullRequest(commitMsg, branchName, 'Automatically created by the SB Sommar add-event API.');
   await enableAutoMerge(pr.node_id);
+  // Place the PR in the merge queue right away to merge in ~50 s instead of
+  // waiting for the reactive recovery sweep. Best-effort: never fails the
+  // submission (02-§113.1, §113.4).
+  await enqueueBestEffort(pr.node_id);
 }
 
 // Edits an event by ID. The event lives in its own fragment file, which this
@@ -425,6 +478,8 @@ async function updateEventInActiveCamp(eventId, updates) {
   await putFile(fragPath, content, frag.sha, commitMsg, branchName);
   const pr = await createPullRequest(commitMsg, branchName, 'Automatically created by the SB Sommar edit-event API.');
   await enableAutoMerge(pr.node_id);
+  // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+  await enqueueBestEffort(pr.node_id);
 }
 
 // Deletes an event by ID by removing its fragment file; the camp YAML file is
@@ -444,6 +499,8 @@ async function removeEventFromActiveCamp(eventId) {
   await deleteFile(fragPath, frag.sha, commitMsg, branchName);
   const pr = await createPullRequest(commitMsg, branchName, 'Automatically created by the SB Sommar delete-event API.');
   await enableAutoMerge(pr.node_id);
+  // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+  await enqueueBestEffort(pr.node_id);
 }
 
-module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, githubRequest, env };
+module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, buildEnqueueMutation, enqueuePullRequest, enqueueBestEffort, githubRequest, env };

--- a/tests/github.test.js
+++ b/tests/github.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { slugify, yamlScalar, buildEventYaml, detectEventIndent, assertEventYamlValid, buildFragmentYaml, fragmentPath, assertFragmentYamlValid } = require('../source/api/github');
+const { slugify, yamlScalar, buildEventYaml, detectEventIndent, assertEventYamlValid, buildFragmentYaml, fragmentPath, assertFragmentYamlValid, buildEnqueueMutation, enqueueBestEffort } = require('../source/api/github');
 
 // ── slugify ───────────────────────────────────────────────────────────────────
 
@@ -533,5 +533,80 @@ describe('fragment helpers (FRAG-30..45)', () => {
   it('FRAG-43: throws when the event id does not match the expected id', () => {
     const content = buildFragmentYaml(baseEvent({ id: 'other-2026-06-22-0800' }));
     assert.throws(() => assertFragmentYamlValid(content, 'frukost-2026-06-22-0800'), /frukost-2026-06-22-0800/);
+  });
+});
+
+// ── buildEnqueueMutation / enqueueBestEffort (02-§113) ─────────────────────────
+// Proactive merge-queue enqueue: a pure mutation builder plus a best-effort wrapper
+// that must never fail the submission. The network call itself is a manual
+// checkpoint (ENQ-M01); only the pure/isolatable logic is unit-tested here.
+
+describe('buildEnqueueMutation (ENQ-01..05)', () => {
+  it('ENQ-01 (02-§113.1): builds a mutation that calls enqueuePullRequest', () => {
+    const { query } = buildEnqueueMutation('PR_node_1');
+    assert.match(query, /enqueuePullRequest/);
+  });
+
+  it('ENQ-02 (02-§113.1): passes the node id as the pullRequestId input', () => {
+    const { query } = buildEnqueueMutation('PR_node_1');
+    assert.match(query, /pullRequestId:\s*\$id/);
+  });
+
+  it('ENQ-03 (02-§113.3): does not specify a merge method (the queue config decides)', () => {
+    const { query } = buildEnqueueMutation('PR_node_1');
+    assert.doesNotMatch(query, /mergeMethod/i);
+  });
+
+  it('ENQ-04 (02-§113.1): binds the given node id to the $id variable', () => {
+    const { variables } = buildEnqueueMutation('PR_node_42');
+    assert.strictEqual(variables.id, 'PR_node_42');
+  });
+
+  it('ENQ-05 (02-§113.1): selects mergeQueueEntry — the merge-queue mutation, not auto-merge', () => {
+    const { query } = buildEnqueueMutation('PR_node_1');
+    assert.match(query, /mergeQueueEntry/);
+    assert.doesNotMatch(query, /enablePullRequestAutoMerge/);
+  });
+});
+
+describe('enqueueBestEffort (ENQ-06..10)', () => {
+  it('ENQ-06 (02-§113.1): calls the enqueue impl once with the node id on the happy path', async () => {
+    const calls = [];
+    const ok = await enqueueBestEffort('PR_node_1', { enqueue: (id) => { calls.push(id); }, log: () => {} });
+    assert.deepStrictEqual(calls, ['PR_node_1']);
+    assert.strictEqual(ok, true);
+  });
+
+  it('ENQ-07 (02-§113.4, §113.7): never throws when enqueue rejects — submission stays intact', async () => {
+    await assert.doesNotReject(() => enqueueBestEffort('PR_node_1', {
+      enqueue: () => { throw new Error('Pull request is not in a mergeable state'); },
+      log: () => {},
+    }));
+  });
+
+  it('ENQ-08 (02-§113.6): logs a warning (and creates nothing else) when enqueue fails', async () => {
+    const logged = [];
+    await enqueueBestEffort('PR_node_1', {
+      enqueue: () => { throw new Error('checks pending'); },
+      log: (msg) => logged.push(msg),
+    });
+    assert.strictEqual(logged.length, 1, 'expected exactly one warning log');
+    assert.match(logged[0], /enqueue/i);
+  });
+
+  it('ENQ-09 (02-§113.5): a "checks still running" failure is swallowed and reported as not enqueued', async () => {
+    const result = await enqueueBestEffort('PR_node_1', {
+      enqueue: () => { throw new Error('required status checks have not yet passed'); },
+      log: () => {},
+    });
+    assert.strictEqual(result, false);
+  });
+
+  it('ENQ-10 (02-§113.4): swallows a rejected Promise (async enqueue impl) too', async () => {
+    const result = await enqueueBestEffort('PR_node_1', {
+      enqueue: () => Promise.reject(new Error('transient 502')),
+      log: () => {},
+    });
+    assert.strictEqual(result, false);
   });
 });


### PR DESCRIPTION
## Summary

Path A from #481. After the form API creates an event PR and enables squash auto-merge, it now also places the PR in the merge queue immediately via GraphQL `enqueuePullRequest`, so a submitted activity is intended to merge in the queue's normal cycle (~50 s) instead of waiting for the reactive recovery sweep (02-§112, worst case ~15 min).

- Mirrored in `source/api/github.js` (Node) and `api/src/GitHub.php` (PHP) across **add, edit, delete**, and the PHP **batch** path.
- `enablePullRequestAutoMerge` is **retained** as a complement (02-§113.2).
- The enqueue is **best-effort** (02-§113.4–113.7): if it fails — most commonly because the PR's required checks are still running, so the queue declines an unmergeable PR — the failure is logged as a warning and the PR falls back to auto-merge plus the reactive recovery. Submission is never made more fragile.
- The reactive recovery (02-§112) and the event-data validation gate (`check-yaml-security.js`, `lint-yaml.js`, API-layer validation) are **unchanged and remain required** (02-§113.8–113.9).

## ⚠️ Reviewer caveats — read before merging

This PR is deliberately opened **without `Closes #481`**, because the latency goal cannot be verified here and there is genuine doubt it is met:

1. **Possible silent no-op.** At submission the PR's checks have not started, so the merge queue may reject `enqueuePullRequest` on essentially every submission. In that case this delivers no latency benefit, and because the failure is best-effort + log-only with no metric, a permanently-broken feature would be indistinguishable from normal operation.
2. **No automated proof of the goal.** All tests are green, but they cover the mutation shape and the error-swallowing fallback — not that a submission now merges in ~50 s. That is a live-only checkpoint (ENQ-M01).
3. **The issue offers "don't build this."** #481 frames this as an optimization, not a bug, and notes recovery already runs after every event merge (so real-world latency is usually far under the 15-min worst case).

**The change is safe** (submission can never become more fragile; gate and recovery untouched), so the risk is wasted effort / false confidence, not breakage.

**Recommended path:** confirm against one live submission that enqueue actually succeeds at submission time. If it does, this is a clean win and #481 can be closed; if it is rejected pre-checks, revert rather than keep dead code. Until then, #481 stays open.

## Phases (CLAUDE.md §11)

- Phase 0 alignment + issue comment ✅
- Requirements: `docs/02-requirements/event-data.md §113` ✅
- Docs: `forms-and-api.md §30`, `ci-and-deploy.md §11.8` cross-ref ✅
- Tests: ENQ-01..10 (`tests/github.test.js`) + `buildEnqueueMutation` parity (`api/tests/GitHubTest.php`) ✅
- Traceability: §113 in `99-traceability/02-requirements.md`, counts updated ✅

## Test plan

- [x] `npm test` — 2011 pass
- [x] `npm run lint` / `lint:md` — clean
- [x] `cd api && composer test` — 81 pass
- [ ] **Manual (ENQ-M01):** submit one real activity in QA/prod; confirm the PR gains a `mergeQueueEntry` at submission (enqueue succeeded) **or** logs the best-effort warning and still merges via auto-merge. This is the check that decides whether the latency goal is met and whether #481 can close.

Relates to #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvhSwVu9rCpEhfRpTwJUo1)_