### PR TITLE
Clarify schedule delay and add cache-reload tip on success

### DIFF
--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -207,9 +207,11 @@ progress modal → result.
 ### 19.4 Success state
 
 - On a successful response, the modal content changes to show: the submitted
-  activity title, the text "Aktiviteten är tillagd! Den syns i schemat om ungefär
-  en minut.", a primary link "Gå till schemat →" to `schema.html`, and a secondary
-  button "Lägg till en till". <!-- 02-§19.10 -->
+  activity title, the text "Aktiviteten är tillagd! Den syns i schemat inom någon
+  minut, men ibland kan det ta upp till 15 minuter.", a tip note "Dyker den inte
+  upp? Ladda om sidan – webbläsaren kan visa en sparad version.", a primary link
+  "Gå till schemat →" to `schema.html`, and a secondary button "Lägg till en till".
+  <!-- 02-§19.10 -->
 - If the user declined cookie consent, the success state also shows a Swedish note
   explaining they cannot edit the activity from this browser, and that they can
   resubmit with consent next time. <!-- 02-§19.11 -->
@@ -265,8 +267,10 @@ and actions appropriate for an edit rather than a new submission.
 ### 20.3 Success state
 
 - On a successful response, the modal shows: the edited activity title, the text
-  "Aktiviteten är uppdaterad! Den syns i schemat om ungefär en minut.", and a
-  primary link "Gå till schemat →" to `schema.html`. <!-- 02-§20.8 -->
+  "Aktiviteten är uppdaterad! Den syns i schemat inom någon minut, men ibland kan
+  det ta upp till 15 minuter.", a tip note "Dyker den inte upp? Ladda om sidan –
+  webbläsaren kan visa en sparad version.", and a primary link "Gå till schemat →"
+  to `schema.html`. <!-- 02-§20.8 -->
 
 ### 20.4 Error state
 

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -306,7 +306,7 @@ element inside `.modal-box`. Tab and Shift+Tab wrap within the modal.
 | State | Heading | Content |
 | --- | --- | --- |
 | Loading | "Skickar…" | Spinner + "Skickar till GitHub…" |
-| Success | "Aktiviteten är tillagd!" | Title, "Den syns i schemat om ungefär en minut.", optional no-edit note, two action buttons |
+| Success | "Aktiviteten är tillagd!" | Title, "Den syns i schemat inom någon minut, men ibland kan det ta upp till 15 minuter.", cache-reload tip note, optional no-edit note, two action buttons |
 | Error | "Något gick fel" | Error message + "Försök igen" button |
 
 ### "Försök igen" and "Lägg till en till"
@@ -362,7 +362,7 @@ trapping, and `body.modal-open { overflow: hidden }`.
 | State | Heading | Content |
 | --- | --- | --- |
 | Loading | "Sparar…" | Spinner + "Sparar till GitHub…" |
-| Success | "Aktiviteten är uppdaterad!" | Title, "Den syns i schemat om ungefär en minut.", "Gå till schemat →" link |
+| Success | "Aktiviteten är uppdaterad!" | Title, "Den syns i schemat inom någon minut, men ibland kan det ta upp till 15 minuter.", cache-reload tip note, "Gå till schemat →" link |
 | Error | "Något gick fel" | Error message + "Försök igen" button |
 
 ### Edit "Försök igen"

--- a/source/assets/js/client/lagg-till.js
+++ b/source/assets/js/client/lagg-till.js
@@ -621,7 +621,9 @@
       ' en ny aktivitet och välj <em>Ja, det är okej</em> när vi frågar.</p>';
     modalContent.innerHTML =
       '<p class="intro"><strong>' + escHtml(title) + '</strong>' +
-      ' syns i schemat om ungefär en minut.</p>' +
+      ' syns i schemat inom någon minut, men ibland kan det ta upp till 15 minuter.</p>' +
+      '<p class="result-note">Dyker den inte upp? Ladda om sidan –' +
+      ' webbläsaren kan visa en sparad version.</p>' +
       noEditNote +
       '<div class="success-actions">' +
         '<a href="schema.html" class="btn-primary">Gå till schemat →</a>' +
@@ -647,7 +649,10 @@
       ' redigeras från den här webbläsaren.</p>';
     modalContent.innerHTML =
       '<p class="intro"><strong>' + escHtml(title) + '</strong>' +
-      ' på ' + count + ' dagar – syns i schemat om ungefär en minut.</p>' +
+      ' på ' + count + ' dagar – syns i schemat inom någon minut,' +
+      ' men ibland kan det ta upp till 15 minuter.</p>' +
+      '<p class="result-note">Dyker de inte upp? Ladda om sidan –' +
+      ' webbläsaren kan visa en sparad version.</p>' +
       noEditNote +
       '<div class="success-actions">' +
         '<a href="schema.html" class="btn-primary">Gå till schemat →</a>' +

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -157,7 +157,9 @@
     modalHeading.textContent = 'Aktiviteten är uppdaterad!';
     modalContent.innerHTML =
       '<p class="intro"><strong>' + escHtml(title) + '</strong>' +
-      ' syns i schemat om ungefär en minut.</p>' +
+      ' syns i schemat inom någon minut, men ibland kan det ta upp till 15 minuter.</p>' +
+      '<p class="result-note">Dyker den inte upp? Ladda om sidan –' +
+      ' webbläsaren kan visa en sparad version.</p>' +
       '<div class="success-actions">' +
         '<a href="schema.html" class="btn-primary">Gå till schemat →</a>' +
       '</div>';


### PR DESCRIPTION
## Sammanfattning

- Bekräftelsetexten efter att en aktivitet lagts till eller redigerats säger nu att den syns i schemat **inom någon minut, men ibland kan det ta upp till 15 minuter** — istället för "om ungefär en minut", som satte en förväntan som inte alltid stämmer.
- En lugnare tips-rad uppmanar användaren att **ladda om sidan** om aktiviteten ändå inte dyker upp, eftersom webbläsarens cache är den vanligaste orsaken.
- Gäller alla tre success-vyer: lägg-till (enkel), lägg-till (flerdags-batch) och redigera. Flerdags-varianten säger "Dyker de inte upp?" eftersom det rör flera aktiviteter.

## Ändrade filer

- `source/assets/js/client/lagg-till.js` — enkel + batch success
- `source/assets/js/client/redigera.js` — edit success
- `docs/02-requirements/add-edit-forms.md` — krav `02-§19.10`, `02-§20.8`
- `docs/03-architecture/forms-and-api.md` — states-tabellerna

## Test

- [x] `npm run lint`
- [x] `npm run lint:md`
- [x] `npm test` (2011 tester gröna)
- [ ] Manuell webbläsarkoll av modalen — kunde inte köras i denna miljö (ingen dev-server/browser)

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K72DARkVGaEymtnma2BhM1)_