### PR TITLE
Fix stranded-PR recovery: use auth token that can toggle auto-merge, fail loud

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -216,11 +216,6 @@ jobs:
   recover-stranded-event-prs:
     name: Recover event PRs stranded in the merge queue
     runs-on: ubuntu-latest
-    # Needs write access to disable→enable auto-merge; the default workflow token
-    # is read-only here (02-§112.7).
-    permissions:
-      contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6
@@ -231,10 +226,13 @@ jobs:
 
       # This merge just advanced main, which is exactly the base move that can
       # strand a sibling event PR's auto-merge. Re-enqueue any stranded event PR
-      # by toggling auto-merge off then on (02-§112.7). Uses the pre-installed gh
-      # CLI; no dependency install needed.
+      # by toggling auto-merge off then on (02-§112.7). The default GITHUB_TOKEN
+      # cannot run the auto-merge GraphQL mutations ("Resource not accessible by
+      # integration"), so this uses EVENT_AUTOMERGE_TOKEN — a repo-level secret
+      # with pull-request + contents write access (02-§112.12, 112.14). Uses the
+      # pre-installed gh CLI; no dependency install needed.
       - name: Recover stranded event PRs
         run: node source/scripts/recover-stranded-event-prs.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.EVENT_AUTOMERGE_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/merge-queue-recovery.yml
+++ b/.github/workflows/merge-queue-recovery.yml
@@ -21,10 +21,6 @@ jobs:
   recover-stranded-event-prs:
     name: Recover event PRs stranded in the merge queue
     runs-on: ubuntu-latest
-    # Needs write access to disable→enable auto-merge (02-§112.8).
-    permissions:
-      contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6
@@ -33,8 +29,12 @@ jobs:
         with:
           node-version: '20'
 
+      # Auto-merge GraphQL mutations are not available to the default GITHUB_TOKEN
+      # (it returns "Resource not accessible by integration"), so the sweep uses
+      # EVENT_AUTOMERGE_TOKEN — a repo-level secret holding a token with
+      # pull-request + contents write access (02-§112.12, 112.14).
       - name: Recover stranded event PRs
         run: node source/scripts/recover-stranded-event-prs.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.EVENT_AUTOMERGE_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -958,6 +958,10 @@ stuck in the queue handoff.
   retries the whole recovery. <!-- 02-§112.11 -->
 - Each event pull request is evaluated in isolation, so a failure to read or recover
   one pull request does not abort the recovery of the others. <!-- 02-§112.6 -->
+- When one or more stranded pull requests could not be recovered during a pass, the
+  recovery job exits with a non-zero status after it has attempted every pull request.
+  A failed recovery surfaces as a failed job, not a silent warning on an otherwise
+  green run. <!-- 02-§112.13 -->
 
 ### 112.3 When recovery runs (site requirements)
 
@@ -975,6 +979,22 @@ stuck in the queue handoff.
   none are stranded. <!-- 02-§112.9 -->
 - Recovery is idempotent. A pull request that is not stranded is left unchanged on
   every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->
+
+### 112.4 Recovery job authentication (site requirements)
+
+- The recovery job authenticates to the GitHub API with a token that is permitted to
+  enable and disable auto-merge on pull requests. The default GitHub Actions workflow
+  token (`secrets.GITHUB_TOKEN`) cannot perform the auto-merge GraphQL mutations even
+  when granted `pull-requests: write`, so recovery uses a separate token. <!-- 02-§112.12 -->
+- The token is supplied through the repository-level Actions secret
+  `EVENT_AUTOMERGE_TOKEN`, which holds a credential with pull-request and contents
+  write access to the repository. The secret is repository-level (not environment
+  scoped), because the recovery jobs run without a GitHub Environment and therefore
+  resolve only repository- and organisation-level secrets. <!-- 02-§112.14 -->
+- The recovered pull request merges under the `EVENT_AUTOMERGE_TOKEN` identity rather
+  than the Actions bot, so the merge to `main` triggers the event-data post-merge
+  deploy. A merge performed under the default Actions token would not trigger that
+  push-driven workflow. <!-- 02-§112.15 -->
 
 ## 113. Proactive Merge-Queue Enqueue
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -282,10 +282,28 @@ are idempotent (02-§112.10).
 - A job in `event-data-deploy-post-merge.yml` (push to `main`, `source/data/**.yaml`),
   alongside `close-redundant-event-prs` — the event merge that triggers this workflow
   is exactly the base move that can strand a sibling, so recovery happens immediately
-  (02-§112.7). The job needs `pull-requests: write` to toggle auto-merge.
+  (02-§112.7).
 - A scheduled workflow, `merge-queue-recovery.yml`, on a 15-minute cron, as a safety
   net for strandings that no event-data merge follows (02-§112.8). The sweep lists the
   open event pull requests first and exits cheaply when none are stranded (02-§112.9).
+
+**Authentication (02-§112.12, 112.14, 112.15).** The default Actions workflow token
+(`secrets.GITHUB_TOKEN`) cannot run the `enablePullRequestAutoMerge` /
+`disablePullRequestAutoMerge` GraphQL mutations even with `pull-requests: write` — it
+fails with `Resource not accessible by integration`. Both recovery jobs therefore pass
+the repository-level secret `EVENT_AUTOMERGE_TOKEN` (a credential with pull-request and
+contents write access) to the script as `GITHUB_TOKEN`, which `gh` uses for its API
+calls. The secret is repository-level because the recovery jobs run without a GitHub
+Environment and so see only repository- and organisation-level secrets. Re-enabling
+auto-merge under this identity — rather than the Actions bot — also means the eventual
+merge to `main` triggers the push-driven `event-data-deploy-post-merge.yml` deploy
+(02-§112.15).
+
+**Failure handling (02-§112.13).** Each pull request is still processed in its own
+`try`/`catch` so one failure does not abort the sweep (02-§112.6), but `main()` counts
+the failures and throws once every pull request has been attempted, exiting non-zero.
+A recovery that cannot complete therefore fails the job loudly instead of passing as a
+green run with only a `::warning::`.
 
 ---
 

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -89,6 +89,7 @@ the secrets.
 | Secret     | Used by    | Purpose                                           |
 | ---------- | ---------- | ------------------------------------------------- |
 | `SITE_URL` | `ci.yml`   | Any valid URL — just needs to pass the build step |
+| `EVENT_AUTOMERGE_TOKEN` | `merge-queue-recovery.yml`, `event-data-deploy-post-merge.yml` (`recover-stranded-event-prs` job) | Token used by the stranded-PR recovery sweep to toggle auto-merge (§112). The default `GITHUB_TOKEN` cannot run the auto-merge GraphQL mutations, so a separate credential is required. Use a fine-grained PAT scoped to this repository with **Pull requests: Read and write** and **Contents: Read and write**, or a GitHub App installation token with the same access. Must be **repository-level** (the recovery jobs run without a GitHub Environment and cannot read environment-scoped secrets). |
 
 ### GitHub Environment: `qa` (PHP on Loopia)
 
@@ -237,7 +238,7 @@ After both secrets are generated and the `.env` files are in place on your serve
 6. Under **Environment secrets**, add each secret from the `production` table with production values.
 7. Under **Environment protection rules** for `production`, add **Required reviewers** and enter the GitHub username(s) who may approve production deploys.
 8. Optionally add a **Wait timer** (e.g. 5 minutes) for an extra safety window.
-9. Verify that `SITE_URL` also exists as a **repository-level** secret (Settings > Secrets and variables > Actions > Repository secrets).
+9. Verify that `SITE_URL` and `EVENT_AUTOMERGE_TOKEN` also exist as **repository-level** secrets (Settings > Secrets and variables > Actions > Repository secrets). `EVENT_AUTOMERGE_TOKEN` powers the stranded-PR recovery sweep (§112) — see the repository-level secrets table above for the token type and permissions it needs. After an ownership change, re-check that the token's owner still has write access to the repository, or the sweep will fail with `Resource not accessible by integration`.
 
 ---
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1738,10 +1738,10 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
 | `02-§112.11` | covered | STRAND-11/-12/-13: `recoverPr()` wraps the re-enable in `withRetry` (exponential backoff); disable is a single attempt; live toggle is STRAND-M01 |
-| `02-§112.12` | gap | Recovery jobs authenticate with `EVENT_AUTOMERGE_TOKEN` (not the default `GITHUB_TOKEN`, which cannot run auto-merge mutations) |
-| `02-§112.13` | gap | `processPr()` returns `'failed'` on a caught error; `main()` counts failures and throws after attempting every PR, exiting non-zero |
-| `02-§112.14` | gap | `EVENT_AUTOMERGE_TOKEN` is a repository-level secret; recovery jobs run without a GitHub Environment (08-ENVIRONMENTS secrets schema) |
-| `02-§112.15` | gap | Merge under the `EVENT_AUTOMERGE_TOKEN` identity triggers the push-driven post-merge deploy; manual checkpoint STRAND-M01 |
+| `02-§112.12` | implemented | Both recovery jobs pass `secrets.EVENT_AUTOMERGE_TOKEN` as `GITHUB_TOKEN` (not the default token, which fails auto-merge mutations); live behaviour is manual checkpoint STRAND-M01 |
+| `02-§112.13` | covered | STRAND-16/-17 (`processPr` returns `'failed'` on fetch/recover error), STRAND-18/-19 (`runSweep` counts failures and keeps going); `main()` throws when the count is non-zero |
+| `02-§112.14` | implemented | `EVENT_AUTOMERGE_TOKEN` documented as a repository-level secret in 08-ENVIRONMENTS; recovery jobs declare no `environment:` so only repo-level secrets resolve |
+| `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1738,6 +1738,10 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
 | `02-§112.11` | covered | STRAND-11/-12/-13: `recoverPr()` wraps the re-enable in `withRetry` (exponential backoff); disable is a single attempt; live toggle is STRAND-M01 |
+| `02-§112.12` | gap | Recovery jobs authenticate with `EVENT_AUTOMERGE_TOKEN` (not the default `GITHUB_TOKEN`, which cannot run auto-merge mutations) |
+| `02-§112.13` | gap | `processPr()` returns `'failed'` on a caught error; `main()` counts failures and throws after attempting every PR, exiting non-zero |
+| `02-§112.14` | gap | `EVENT_AUTOMERGE_TOKEN` is a repository-level secret; recovery jobs run without a GitHub Environment (08-ENVIRONMENTS secrets schema) |
+| `02-§112.15` | gap | Merge under the `EVENT_AUTOMERGE_TOKEN` identity triggers the push-driven post-merge deploy; manual checkpoint STRAND-M01 |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered; stranded-recovery auth + fail-loud 02-§112.12–112.15: 1 covered, 3 implemented).
 
 ---
 
@@ -138,9 +138,9 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1418
-Covered (implemented + tested): 762
-Implemented, not tested:        656
+Total requirements:            1422
+Covered (implemented + tested): 763
+Implemented, not tested:        659
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
 
@@ -159,17 +159,20 @@ Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
   submission time (and thus whether the latency goal is actually met) must be
   confirmed against production (#481).
 
-Note: §112 (Stranded Auto-Merge Recovery) adds 11 requirements
-  (02-§112.1–112.11): 5 covered (STRAND-01..13,
-  tests/stranded-recovery.test.js) and 6 implemented (the GraphQL
-  disable→enable toggle, the per-PR isolation and early-exit in main(), and
-  the two workflow entry points, STRAND-M01 manual). Event PRs merge through a
+Note: §112 (Stranded Auto-Merge Recovery) adds 15 requirements
+  (02-§112.1–112.15): 6 covered (STRAND-01..19,
+  tests/stranded-recovery.test.js) and 9 implemented (the GraphQL
+  disable→enable toggle, the per-PR isolation and early-exit in main(), the two
+  workflow entry points, the EVENT_AUTOMERGE_TOKEN auth, and the deploy-trigger
+  identity, STRAND-M01 manual). Event PRs merge through a
   required merge queue; when main advances between auto-merge enablement and
   queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
   CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js
   detects that signature and toggles auto-merge off then on to register a fresh
   queue entry, running after each event merge and on a 15-minute safety-net
-  schedule (#495).
+  schedule (#495). The toggle uses EVENT_AUTOMERGE_TOKEN because the default
+  GITHUB_TOKEN cannot run the auto-merge mutations, and the sweep exits non-zero
+  when any stranded PR could not be recovered (#496-followup).
 
 Note: §111 (Duplicate Submission Hardening) adds 9 requirements
   (02-§111.1–111.9): 7 covered (DEDUP-01..09, DEDUPCLEAN-01..09,

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -122,6 +122,50 @@ function recoverPr(nodeId) {
   ]));
 }
 
+/**
+ * Process one event pull request: read its state, classify it, and recover it if
+ * stranded. Side effects (network reads, auto-merge toggles) are injected via
+ * `fetchState`/`recover` so the outcome logic is unit-testable.
+ *
+ *   pr.number, pr.headRefName – the open pull request to consider
+ *   fetchState(number)        – returns { nodeId, autoMergeEnabled, mergeStateStatus, inMergeQueue }
+ *   recover(nodeId)           – toggles auto-merge off then on
+ *
+ * Per-PR errors are caught here so one bad fetch or mutation does not abort the
+ * sweep (02-§112.6). Returns one of: 'recovered', 'skipped', 'ignored', 'failed'.
+ */
+function processPr(pr, { fetchState, recover, log = console.log }) {
+  try {
+    const state = fetchState(pr.number);
+    const verdict = classifyStrandedPr({ branch: pr.headRefName, ...state });
+
+    if (verdict === 'recover') {
+      log(`Recovering stranded PR #${pr.number} (${pr.headRefName}) — auto-merge on, CLEAN, no queue entry; toggling auto-merge`);
+      recover(state.nodeId);
+      return 'recovered';
+    }
+    log(`Skipping PR #${pr.number} (${pr.headRefName}) — ${verdict} (mergeStateStatus=${state.mergeStateStatus}, inQueue=${state.inMergeQueue}, autoMerge=${state.autoMergeEnabled})`);
+    return verdict === 'ignore' ? 'ignored' : 'skipped';
+  } catch (err) {
+    log(`::warning::Could not process event PR #${pr.number} (${pr.headRefName}): ${err.message}`);
+    return 'failed';
+  }
+}
+
+/**
+ * Run `processPr` over every event pull request and return how many failed. Pure
+ * with respect to the injected deps, so the fail-loud count is unit-testable. The
+ * loop never short-circuits: a failure is counted and the remaining pull requests
+ * are still attempted (02-§112.6).
+ */
+function runSweep(eventPrs, deps) {
+  let failures = 0;
+  for (const pr of eventPrs) {
+    if (processPr(pr, deps) === 'failed') failures += 1;
+  }
+  return failures;
+}
+
 function main() {
   const repoSlug = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
   const [owner, repo] = repoSlug.split('/');
@@ -141,22 +185,15 @@ function main() {
     return;
   }
 
-  for (const pr of eventPrs) {
-    // Isolate per-PR failures so one bad fetch/mutation does not abort the sweep
-    // (02-§112.6).
-    try {
-      const state = fetchPrState(owner, repo, pr.number);
-      const verdict = classifyStrandedPr({ branch: pr.headRefName, ...state });
+  const failures = runSweep(eventPrs, {
+    fetchState: (number) => fetchPrState(owner, repo, number),
+    recover: recoverPr,
+  });
 
-      if (verdict === 'recover') {
-        console.log(`Recovering stranded PR #${pr.number} (${pr.headRefName}) — auto-merge on, CLEAN, no queue entry; toggling auto-merge`);
-        recoverPr(state.nodeId);
-      } else {
-        console.log(`Skipping PR #${pr.number} (${pr.headRefName}) — ${verdict} (mergeStateStatus=${state.mergeStateStatus}, inQueue=${state.inMergeQueue}, autoMerge=${state.autoMergeEnabled})`);
-      }
-    } catch (err) {
-      console.log(`::warning::Could not process event PR #${pr.number} (${pr.headRefName}): ${err.message}`);
-    }
+  // Fail the job loudly when any stranded PR could not be recovered, rather than
+  // passing as a green run with only a warning (02-§112.13).
+  if (failures > 0) {
+    throw new Error(`${failures} event pull request(s) could not be recovered`);
   }
 }
 
@@ -169,4 +206,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { classifyStrandedPr, withRetry };
+module.exports = { classifyStrandedPr, withRetry, processPr, runSweep };

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -8,7 +8,15 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { classifyStrandedPr, withRetry } = require('../source/scripts/recover-stranded-event-prs');
+const {
+  classifyStrandedPr,
+  withRetry,
+  processPr,
+  runSweep,
+} = require('../source/scripts/recover-stranded-event-prs');
+
+// A silent logger so the test output stays clean.
+const quiet = () => {};
 
 // A pull request that GitHub considers fully mergeable but that never reached the
 // queue: auto-merge on, checks green (CLEAN), and no queue entry.
@@ -105,5 +113,95 @@ describe('withRetry — enable-step resilience (02-§112.11)', () => {
       /fail-3/,
     );
     assert.equal(calls, 3);
+  });
+});
+
+describe('processPr — per-PR outcome (02-§112.2, 112.6, 112.13)', () => {
+  const strandedState = { nodeId: 'PR_1', ...STRANDED };
+
+  it('STRAND-14: stranded PR is recovered and reported as recovered', () => {
+    let recovered = null;
+    const outcome = processPr(
+      { number: 1, headRefName: 'event-edit/x-2026-06-22-1115-1' },
+      { fetchState: () => strandedState, recover: (id) => { recovered = id; }, log: quiet },
+    );
+    assert.equal(outcome, 'recovered');
+    assert.equal(recovered, 'PR_1');
+  });
+
+  it('STRAND-15: non-stranded event PR is skipped without toggling auto-merge', () => {
+    let recoverCalled = false;
+    const outcome = processPr(
+      { number: 2, headRefName: 'event/2026-06-22-x-1' },
+      {
+        fetchState: () => ({ nodeId: 'PR_2', autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
+        recover: () => { recoverCalled = true; },
+        log: quiet,
+      },
+    );
+    assert.equal(outcome, 'skipped');
+    assert.equal(recoverCalled, false);
+  });
+
+  it('STRAND-16: a fetch failure is caught and reported as failed (02-§112.6)', () => {
+    const outcome = processPr(
+      { number: 3, headRefName: 'event/2026-06-22-x-1' },
+      { fetchState: () => { throw new Error('boom'); }, recover: () => {}, log: quiet },
+    );
+    assert.equal(outcome, 'failed');
+  });
+
+  it('STRAND-17: a recover failure is caught and reported as failed (02-§112.13)', () => {
+    const outcome = processPr(
+      { number: 4, headRefName: 'event/2026-06-22-x-1' },
+      { fetchState: () => strandedState, recover: () => { throw new Error('Resource not accessible by integration'); }, log: quiet },
+    );
+    assert.equal(outcome, 'failed');
+  });
+});
+
+describe('runSweep — fail-loud aggregation with isolation (02-§112.6, 112.13)', () => {
+  it('STRAND-18: returns 0 when every PR recovers or skips, recovering only the stranded one', () => {
+    const recovered = [];
+    const deps = {
+      fetchState: (n) => (n === 1
+        ? { nodeId: 'PR_1', ...STRANDED }
+        : { nodeId: `PR_${n}`, autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
+      recover: (id) => recovered.push(id),
+      log: quiet,
+    };
+    const failures = runSweep(
+      [
+        { number: 1, headRefName: 'event/a-1' },
+        { number: 2, headRefName: 'event/b-1' },
+      ],
+      deps,
+    );
+    assert.equal(failures, 0);
+    assert.deepEqual(recovered, ['PR_1']);
+  });
+
+  it('STRAND-19: a failing PR is counted but does not abort the others (02-§112.6)', () => {
+    const recovered = [];
+    const deps = {
+      fetchState: () => ({ nodeId: 'PR_x', ...STRANDED }),
+      // First recover throws, the rest succeed — the sweep must keep going.
+      recover: (() => {
+        let n = 0;
+        return (id) => { n += 1; if (n === 1) throw new Error('denied'); recovered.push(id); };
+      })(),
+      log: quiet,
+    };
+    const failures = runSweep(
+      [
+        { number: 1, headRefName: 'event/a-1' },
+        { number: 2, headRefName: 'event/b-1' },
+        { number: 3, headRefName: 'event/c-1' },
+      ],
+      deps,
+    );
+    assert.equal(failures, 1);
+    // The two PRs after the failure were still attempted and recovered.
+    assert.equal(recovered.length, 2);
   });
 });


### PR DESCRIPTION
## Summary

The stranded-event-PR recovery sweep (§112) detected stranded PRs correctly but could never actually recover them: both recovery jobs used the default Actions `GITHUB_TOKEN`, which cannot run the auto-merge GraphQL mutations (`Resource not accessible by integration`) even with `pull-requests: write`. The failure was swallowed as a `::warning::`, so the job still went green — a silently broken safety net.

This was confirmed by a manual `workflow_dispatch` run of `merge-queue-recovery.yml` against the real stranded PR #510: classification was correct (`Recovering stranded PR #510 … toggling auto-merge`) but `disablePullRequestAutoMerge` failed on permissions and the run still reported success.

### Changes
- **Auth:** both recovery jobs (`merge-queue-recovery.yml` and the `recover-stranded-event-prs` job in `event-data-deploy-post-merge.yml`) now use `secrets.EVENT_AUTOMERGE_TOKEN` — a repository-level secret holding a token with pull-request + contents write access. Re-enabling auto-merge under this identity also lets the eventual merge trigger the push-driven post-merge deploy (a default-token merge would not).
- **Fail loud:** `recover-stranded-event-prs.js` now aggregates per-PR outcomes (`processPr`/`runSweep`), keeps the per-PR isolation, and exits non-zero when any stranded PR could not be recovered.
- **Docs & traceability:** new requirements 02-§112.12–112.15, architecture notes in `ci-and-deploy.md`, the `EVENT_AUTOMERGE_TOKEN` entry in `08-ENVIRONMENTS.md` (incl. an ownership-change re-check note), and matrix/summary updates.

### Required follow-up (manual, by a maintainer) — ✅ done
The secret must exist before the sweep can work:
- Settings → Secrets and variables → Actions → **Repository secrets** → `EVENT_AUTOMERGE_TOKEN`
- Fine-grained PAT scoped to `SBsommar/sbsommar` with **Pull requests: RW** + **Contents: RW** (or a GitHub App token with equivalent access).

`EVENT_AUTOMERGE_TOKEN` has been created.

## Test plan
- [x] `npm test` — 2017 tests pass (incl. new STRAND-14..19)
- [x] `npm run lint` (ESLint) clean
- [x] `npm run lint:md` clean
- [x] **End-to-end verified (STRAND-M01):** manual `workflow_dispatch` of `merge-queue-recovery.yml` on this branch recovered a real stranded PR (#573, Musikquiz) — log showed `Recovering stranded PR #573 … toggling auto-merge` with **no** `Resource not accessible by integration`, and #573 merged ~55 s later via the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYBN9uGWQwQ7x6MaSbzc3G)_