### PR TITLE
Hide homepage countdown while a camp is ongoing

### DIFF
--- a/docs/02-requirements/design-and-content.md
+++ b/docs/02-requirements/design-and-content.md
@@ -54,14 +54,16 @@ and connects visitors to community channels.
 - Below the social icons, a countdown displays the number of days remaining
   until the next camp starts. <!-- 02-§30.13 -->
 - The countdown target date is derived automatically from `camps.yaml`:
-  the `start_date` of the nearest future camp (or the active camp if its
-  start date is still in the future). <!-- 02-§30.14 -->
+  the `start_date` of the nearest upcoming camp. <!-- 02-§30.14 -->
 - The countdown shows two lines: the number (large, prominent) and the
   label "Dagar kvar" beneath it. <!-- 02-§30.15 -->
 - The countdown is rendered at build time as a `data-target` attribute.
   Client-side JavaScript calculates and updates the number on page
   load. <!-- 02-§30.16 -->
-- If no future camp exists, the countdown is hidden. <!-- 02-§30.17 -->
+- If no upcoming camp exists, the countdown is hidden. <!-- 02-§30.17 -->
+- While a camp is ongoing — today is on or between its `start_date` and
+  `end_date`, inclusive — the countdown is not displayed. It reappears, counting
+  toward the next camp, once the ongoing camp has ended. <!-- 02-§30.26 -->
 - The countdown area has a subtle background (cream/sand oval or rounded
   rectangle) to visually separate it from the sidebar. <!-- 02-§30.18 -->
 

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -186,9 +186,14 @@ a camp countdown.
 receives `heroSrc`, `heroAlt`, and new parameters for social links and the
 countdown target date.
 
-`build.js` computes the countdown target by finding the nearest future camp
-from `camps.yaml` (comparing `start_date` against today). This date is
-embedded as a `data-target` attribute on the countdown element.
+`build.js` computes the countdown target via `resolveCountdownTarget`
+(`source/build/utils.js`). It returns the `start_date` of the nearest upcoming
+camp, or `null` when the countdown should be hidden — while any camp is ongoing
+(today on or between its `start_date` and `end_date`, inclusive) or when no
+upcoming camp exists. Hiding it during the camp is what fixes #521: the
+countdown no longer skips ahead to the next camp mid-camp. A `null` target means
+no countdown element is rendered. The chosen date is embedded as a `data-target`
+attribute on the countdown element.
 
 Social link URLs (Discord and Facebook) are passed from `build.js` based on
 configuration.

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -333,10 +333,10 @@ Part of [the traceability index](./index.md).
 | `02-§30.11` | Facebook icon links to Facebook group | 03-architecture/pages-and-content.md §15.4 | HERO-08 | `source/build/render-index.js` – `<a href="${facebookUrl}">` | covered |
 | `02-§30.12` | Icons displayed at ~64px, vertically centered | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero-social-link img { width: 64px; height: 64px }` | implemented |
 | `02-§30.13` | Countdown shows days remaining until next camp | 03-architecture/pages-and-content.md §15.3 | HERO-10 | `source/build/render-index.js` – countdown inline script | covered |
-| `02-§30.14` | Countdown target derived from camps.yaml (nearest future camp) | 03-architecture/pages-and-content.md §15.2 | HERO-10 | `source/build/build.js` – `futureCamps` filter and sort | covered |
+| `02-§30.14` | Countdown target is the nearest upcoming camp's start_date | 03-architecture/pages-and-content.md §15.2 | CDOWN-01, CDOWN-02 | `source/build/utils.js` – `resolveCountdownTarget` | covered |
 | `02-§30.15` | Countdown shows large number + "Dagar kvar" label | 07-design/components.md §6 | HERO-11, HERO-13 | `source/build/render-index.js` – `.hero-countdown-number` + `.hero-countdown-label` | covered |
 | `02-§30.16` | Countdown target embedded as data-target; JS computes on load | 03-architecture/pages-and-content.md §15.3 | HERO-10 | `source/build/render-index.js` – `data-target="${countdownTarget}"` | covered |
-| `02-§30.17` | Countdown hidden if no future camp | 03-architecture/pages-and-content.md §15.3 | HERO-12 | `source/build/render-index.js` – no countdown HTML when `countdownTarget` is null | covered |
+| `02-§30.17` | Countdown hidden if no upcoming camp | 03-architecture/pages-and-content.md §15.3 | HERO-12, CDOWN-08 | `source/build/utils.js` – `resolveCountdownTarget` returns null | covered |
 | `02-§30.18` | Countdown has subtle cream/sand background | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero-countdown { background: var(--color-cream-light) }` | implemented |
 | `02-§30.19` | All hero styling uses CSS custom properties | 07-design/css-strategy.md §7 | — (manual: CSS review) | `style.css` – all hero rules use `var(--…)` tokens | implemented |
 | `02-§30.20` | Countdown JS is minimal, no framework | 03-architecture/pages-and-content.md §15.3 | — (manual: code review) | `source/build/render-index.js` – ~8-line inline `<script>` | implemented |
@@ -345,6 +345,7 @@ Part of [the traceability index](./index.md).
 | `02-§30.23` | Countdown background color is `#FAF7EF` (solid, not semi-transparent) | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero-countdown { background: var(--color-cream-light) }` | implemented |
 | `02-§30.24` | Discord icon uses `discord-ikon.webp` | 03-architecture/pages-and-content.md §15.4 | HERO-16 | `render-index.js` – `discord-ikon.webp` in Discord link `<img>` | covered |
 | `02-§30.25` | Sidebar vertically centered alongside hero image | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero { align-items: center }` | implemented |
+| `02-§30.26` | Countdown not displayed while a camp is ongoing (today within start..end) | 03-architecture/pages-and-content.md §15.2 | CDOWN-03..07 | `source/build/utils.js` – `resolveCountdownTarget` returns null when ongoing | covered |
 
 ### 31. Inline Camp Listing and Link Styling
 

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered).
 
 ---
 
@@ -126,7 +126,7 @@ The matrix is split by ID family. Each file carries the rows for one family.
 
 | Family | Source | Rows | File |
 | --- | --- | --- | --- |
-| `02` | `docs/02-requirements/` | 1324 | [02-requirements](./02-requirements.md) |
+| `02` | `docs/02-requirements/` | 1325 | [02-requirements](./02-requirements.md) |
 | `03` | `docs/03-architecture/` | 0 | [03-architecture](./03-architecture.md) |
 | `05` | `docs/05-DATA_CONTRACT.md` | 19 | [05-data-contract](./05-data-contract.md) |
 | `07` | `docs/07-design/` | 91 | [07-design](./07-design.md) |
@@ -138,8 +138,8 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1417
-Covered (implemented + tested): 761
+Total requirements:            1418
+Covered (implemented + tested): 762
 Implemented, not tested:        656
 Gap (no implementation):          0
 Orphan tests (no requirement):    0

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -56,6 +56,7 @@ Part of [the traceability index](./index.md).
 | HERO-10..13 | `tests/hero.test.js` | `hero section – countdown (02-§30.13–30.17)` |
 | HERO-14..15 | `tests/hero.test.js` | `hero section – links from config (02-§30.22)` |
 | HERO-16 | `tests/hero.test.js` | `hero section – Discord icon image (02-§30.24)` |
+| CDOWN-01..09 | `tests/countdown-target.test.js` | `resolveCountdownTarget (02-§30.14, 30.17, 30.26)` |
 | VLD-33..39 | `tests/validate.test.js` | `validateEventRequest – time format` |
 | VLD-40..41 | `tests/validate.test.js` | `validateEditRequest – time format` |
 | VLD-42..48 | `tests/validate.test.js` | `validateEventRequest – string length limits` |

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -24,7 +24,7 @@ const { loadCampEvents } = require('./load-events');
 const { addOneDay } = require('../api/time-gate');
 const { setFeedbackUrl } = require('./layout');
 const { resolveVersionString } = require('./version');
-const { escapeHtml, injectHtaccessCsp } = require('./utils');
+const { escapeHtml, injectHtaccessCsp, resolveCountdownTarget } = require('./utils');
 const { getImageDimensions } = require('./image-dimensions');
 const { filterAvailableLocations } = require('./locations');
 
@@ -350,12 +350,13 @@ async function main() {
   // ── Compute hero social links and countdown target ────────────────────────
   const discordUrl = 'https://discord.com/channels/992817044527534181/1390691617052037232';
 
-  // Countdown: find the nearest future camp by start_date
+  // Countdown: count down to the nearest upcoming camp, but stay hidden while a
+  // camp is ongoing so it never counts toward a later camp mid-camp (#521).
   const todayStr = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Stockholm' });
   const futureCamps = camps
     .filter((c) => toDateString(c.start_date) > todayStr)
     .sort((a, b) => toDateString(a.start_date).localeCompare(toDateString(b.start_date)));
-  const countdownTarget = futureCamps.length > 0 ? toDateString(futureCamps[0].start_date) : null;
+  const countdownTarget = resolveCountdownTarget(camps, todayStr);
 
   // Facebook link: prefer active camp, fall back to nearest future camp
   const facebookUrl = (activeCamp.link || '').trim()

--- a/source/build/utils.js
+++ b/source/build/utils.js
@@ -6,6 +6,24 @@ function toDateString(val) {
   return String(val);
 }
 
+// Determines the homepage countdown target date (YYYY-MM-DD), or null when the
+// countdown should be hidden. The countdown is hidden while any camp is ongoing
+// (today on or between its start_date and end_date, inclusive) so it never
+// counts toward a later camp mid-camp, and when no upcoming camp exists.
+// Otherwise it returns the start_date of the nearest upcoming camp.
+function resolveCountdownTarget(camps, todayStr) {
+  const ongoing = camps.some(
+    (c) => toDateString(c.start_date) <= todayStr && todayStr <= toDateString(c.end_date),
+  );
+  if (ongoing) return null;
+
+  const upcoming = camps
+    .filter((c) => toDateString(c.start_date) > todayStr)
+    .sort((a, b) => toDateString(a.start_date).localeCompare(toDateString(b.start_date)));
+
+  return upcoming.length > 0 ? toDateString(upcoming[0].start_date) : null;
+}
+
 function escapeHtml(str) {
   if (str == null) return '';
   return String(str)
@@ -92,4 +110,4 @@ function injectHtaccessCsp(template, apiUrl) {
   return template.replace(/__API_ORIGIN__ ?/g, origin ? origin + ' ' : '');
 }
 
-module.exports = { toDateString, escapeHtml, formatDate, campDayButtons, safeLinkHref, injectHtaccessCsp };
+module.exports = { toDateString, resolveCountdownTarget, escapeHtml, formatDate, campDayButtons, safeLinkHref, injectHtaccessCsp };

--- a/tests/countdown-target.test.js
+++ b/tests/countdown-target.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveCountdownTarget } = require('../source/build/utils');
+
+// ── Homepage countdown target resolution (02-§30.14, 30.17, 30.26) ──────────
+//
+// The countdown counts down to the nearest upcoming camp, but is hidden
+// (target === null) while any camp is ongoing so it never counts toward a
+// later camp mid-camp (#521), and when no upcoming camp exists.
+
+describe('resolveCountdownTarget (02-§30.14, 30.17, 30.26)', () => {
+  const camps = [
+    { id: 'june', start_date: '2026-06-21', end_date: '2026-06-28' },
+    { id: 'july', start_date: '2026-07-26', end_date: '2026-08-02' },
+  ];
+
+  it('CDOWN-01: returns the nearest upcoming camp start when none is ongoing', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-06-15'), '2026-06-21');
+  });
+
+  it('CDOWN-02: picks the closest of several upcoming camps', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-07-01'), '2026-07-26');
+  });
+
+  it('CDOWN-03: returns null on the first day of an ongoing camp (02-§30.26)', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-06-21'), null);
+  });
+
+  it('CDOWN-04: returns null in the middle of an ongoing camp (02-§30.26)', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-06-25'), null);
+  });
+
+  it('CDOWN-05: returns null on the last day of an ongoing camp (02-§30.26)', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-06-28'), null);
+  });
+
+  it('CDOWN-06: stays hidden while a camp is ongoing even if a later camp exists', () => {
+    // June camp is ongoing; the July camp must not be counted toward.
+    assert.equal(resolveCountdownTarget(camps, '2026-06-24'), null);
+  });
+
+  it('CDOWN-07: resumes counting toward the next camp once the ongoing one ends', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-06-29'), '2026-07-26');
+  });
+
+  it('CDOWN-08: returns null when no upcoming camp exists (02-§30.17)', () => {
+    assert.equal(resolveCountdownTarget(camps, '2026-09-01'), null);
+  });
+
+  it('CDOWN-09: normalises Date objects, not just strings', () => {
+    const dateCamps = [
+      { id: 'june', start_date: new Date('2026-06-21'), end_date: new Date('2026-06-28') },
+    ];
+    assert.equal(resolveCountdownTarget(dateCamps, '2026-06-15'), '2026-06-21');
+    assert.equal(resolveCountdownTarget(dateCamps, '2026-06-23'), null);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #521: the homepage countdown counted down to the *next* camp while a camp was already running.
- The countdown now stays hidden for the whole duration of an ongoing camp (today on or between a camp's `start_date` and `end_date`, inclusive). It otherwise behaves exactly as before — counting down to the nearest upcoming camp, and hidden when none exists.
- Extracted the decision into a pure, testable helper `resolveCountdownTarget(camps, todayStr)` in `source/build/utils.js`; `render-index.js` and its client script are unchanged from `main`.

## Why hide instead of showing "0"

A frozen `00` next to the label "Dagar kvar" reads as a broken counter — or as if the camp were already over. Hiding the countdown during the camp is clearer.

## Changes

- `source/build/utils.js` — new `resolveCountdownTarget` helper.
- `source/build/build.js` — uses the helper to compute the countdown target.
- Requirements `02-§30.14`, `30.17`, `30.26` and architecture §15.2 updated; traceability matrix and test-id legend updated.
- `tests/countdown-target.test.js` — CDOWN-01..09 covering before / during / after a camp and `Date` normalisation.

## Test plan

- [x] `npm test` — 2020 tests pass
- [x] `npm run lint` and `npm run lint:md` clean
- [x] Local build with today inside the active camp (2026-06-21..28) renders **no** countdown element
- [ ] Manual: open the homepage in a browser outside a camp window and confirm the countdown still counts down (not reachable in CI environment)

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuvtCgWStRRd7GVyUNSMd5)_