### PR TITLE
Add per-event iCal link to today view (idag.html)

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -332,6 +332,15 @@ and does not disrupt the existing row layout. <!-- 02-§46.7 -->
 The link uses the `download` attribute so the browser saves the file
 rather than navigating. <!-- 02-§46.8 -->
 
+### 46.6 Per-event iCal link in today view
+
+Every event row on the today view (`/idag.html`) includes a download link
+to its `.ics` file, identical in appearance and behaviour to the per-event
+iCal link on the weekly schedule. <!-- 02-§46.16 -->
+
+The display view (`/live.html`) shows no per-event iCal link, since it is a
+passive, non-interactive screen viewed at a distance. <!-- 02-§46.17 -->
+
 ### 46.3 Calendar tips page discoverability
 
 The weekly schedule page includes a visible link to `kalender.html` near

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -400,6 +400,16 @@ the end of the row. The link downloads the per-event `.ics` file directly
 A text link to `kalender.html` also appears near the intro text so users
 can discover subscription instructions.
 
+### 22.5a Today view integration
+
+The today view (`idag.html`) renders its event rows client-side in
+`source/assets/js/client/events-today.js`. When `window.__SHOW_ICAL__` is
+true, each row gets the same small "iCal" download link as the weekly
+schedule, pointing at `schema/<id>/event.ics`. `render-idag.js` sets the
+flag; `render-today.js` (the display view, `live.html`) leaves it unset, so
+the passive screen shows no clickable link. The link is only emitted for
+events that carry an `id`.
+
 ### 22.6 Event detail page
 
 The per-event detail page adds a calendar download link as a third line

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -634,6 +634,8 @@ Part of [the traceability index](./index.md).
 | `02-§46.13` | Webcal URL in copy-friendly code block | 07-design/ | KAL-15 | `source/build/render-kalender.js` – `.ical-url-block` | covered |
 | `02-§46.14` | Every VEVENT includes DTSTAMP (RFC 5545 §3.6.1) | 03-architecture/pages-and-content.md §22 | ICAL-29, ICAL-31 | `source/build/render-ical.js` – `buildDtstamp()` | covered |
 | `02-§46.15` | DTSTAMP is UTC build-time timestamp (YYYYMMDDTHHMMSSZ) | 03-architecture/pages-and-content.md §22 | ICAL-30 | `source/build/render-ical.js` – `buildDtstamp()` | covered |
+| `02-§46.16` | Every today-view event row has per-event iCal download link | 03-architecture/pages-and-content.md §22.5a | IDAG-20; manual: browser check | `source/build/render-idag.js` – `__SHOW_ICAL__` flag; `source/assets/js/client/events-today.js` – `icalLink()` | covered |
+| `02-§46.17` | Display view (`live.html`) shows no per-event iCal link | 03-architecture/pages-and-content.md §22.5a | IDAG-21 | `source/build/render-today.js` – flag unset | covered |
 | `02-§47.1` | All headings (h1–h6) use terracotta color | 07-design/index.md §3 | HDC-01..03 | `source/assets/cs/style.css` – h1, h2, h3 rules | covered |
 | `02-§47.2` | Content links have permanent underline | 07-design/components.md §6 | HDC-04 | `source/assets/cs/style.css` – `.content a` rule | covered |
 | `02-§47.3` | Nav/back-links retain existing styles | 07-design/components.md §6 | manual: visual check | no change to `.nav-link` or `.back-link` rules | implemented |

--- a/source/assets/js/client/events-today.js
+++ b/source/assets/js/client/events-today.js
@@ -16,6 +16,8 @@
   var headingPrefix = window.__HEADING_PREFIX__ || '';
   var emptyClass = window.__EMPTY_CLASS__ || 'intro';
   var showFooter = window.__SHOW_FOOTER__ || false;
+  // idag.html opts in; the passive display view (live.html) leaves this unset.
+  var showIcal = window.__SHOW_ICAL__ || false;
 
   function pad(n) { return String(n).padStart(2, '0'); }
 
@@ -54,10 +56,19 @@
     return /^https?:\/\//i.test(s) ? s : '';
   }
 
+  // Per-event iCal download link, matching icalDownloadLink() in render.js.
+  // Only emitted on idag.html (showIcal) and only when the event has an id.
+  function icalLink(e) {
+    if (!showIcal || !e.id) return '';
+    return '<a href="schema/' + esc(e.id) + '/event.ics" class="ev-ical" download ' +
+      'title="Ladda ner iCal" data-goatcounter-click="download-ical">iCal</a>';
+  }
+
   var rows = todayEvents.map(function (e) {
     var timeStr = e.end ? esc(e.start) + '–' + esc(e.end) : esc(e.start);
     var metaParts = [e.location, e.responsible].filter(Boolean).map(esc);
     var metaEl = metaParts.length ? '<span class="ev-meta"> · ' + metaParts.join(' · ') + '</span>' : '';
+    var icalEl = icalLink(e);
     var safeLink = safeHttp(e.link);
     var hasExtra = e.description || e.descriptionHtml || safeLink;
     var idAttr = e.id ? ' data-event-id="' + esc(e.id) + '"' : '';
@@ -76,14 +87,14 @@
       return '<details class="event-row"' + idAttr + dateAttr + '><summary>' +
         '<span class="ev-time">' + timeStr + '</span>' +
         '<span class="ev-title">' + esc(e.title) + '</span>' +
-        metaEl + '</summary>' +
+        metaEl + icalEl + '</summary>' +
         '<div class="event-extra">' + extraParts.join('') + '</div>' +
         '</details>';
     } else {
       return '<div class="event-row plain"' + idAttr + dateAttr + '>' +
         '<span class="ev-time">' + timeStr + '</span>' +
         '<span class="ev-title">' + esc(e.title) + '</span>' +
-        metaEl + '</div>';
+        metaEl + icalEl + '</div>';
     }
   });
 

--- a/source/build/render-idag.js
+++ b/source/build/render-idag.js
@@ -47,7 +47,7 @@ ${pageNav('idag.html', navSections)}
 
   <div id="today-events"></div>
 </main>
-  <script>window.__EVENTS__ = ${eventsJson}; window.__HEADING_PREFIX__ = 'Dagens aktiviteter'; window.__EMPTY_CLASS__ = 'intro'; window.__SHOW_FOOTER__ = false;</script>
+  <script>window.__EVENTS__ = ${eventsJson}; window.__HEADING_PREFIX__ = 'Dagens aktiviteter'; window.__EMPTY_CLASS__ = 'intro'; window.__SHOW_FOOTER__ = false; window.__SHOW_ICAL__ = true;</script>
   <script src="events-today.js"></script>
   <script src="session.js"></script>
   <script src="nav.js" defer></script>

--- a/tests/render-idag.test.js
+++ b/tests/render-idag.test.js
@@ -20,6 +20,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
 const { renderIdagPage } = require('../source/build/render-idag');
+const { renderTodayPage } = require('../source/build/render-today');
 
 const CAMP = { name: 'Test Camp' };
 const EVENTS = [
@@ -92,6 +93,37 @@ describe('renderIdagPage – session.js script tag (02-§18.42)', () => {
     assert.ok(
       posSession > posToday,
       'session.js must come after events-today.js so rows exist when links are injected',
+    );
+  });
+});
+
+// ── 02-§46.16 / 02-§46.17: per-event iCal link in today view ─────────────────
+//
+// The iCal link itself is injected client-side by events-today.js, which only
+// runs in a real DOM. Here we verify the structural trigger: idag.html opts in
+// via window.__SHOW_ICAL__, and the display view (live.html) does not.
+//
+// Manual verification checkpoint for 02-§46.16:
+//   1. Build the site and open idag.html in a browser on a day with events.
+//   2. Confirm each event row ends with a small "iCal" link.
+//   3. Click it and confirm the per-event .ics file downloads.
+
+describe('renderIdagPage – per-event iCal opt-in (02-§46.16)', () => {
+  it('IDAG-20: rendered HTML sets window.__SHOW_ICAL__ = true', () => { // IDAG-20
+    const html = renderIdagPage(CAMP, EVENTS);
+    assert.ok(
+      /window\.__SHOW_ICAL__\s*=\s*true/.test(html),
+      'Expected window.__SHOW_ICAL__ = true in rendered idag.html',
+    );
+  });
+});
+
+describe('renderTodayPage – display view has no iCal opt-in (02-§46.17)', () => {
+  it('IDAG-21: rendered display HTML does not set window.__SHOW_ICAL__', () => { // IDAG-21
+    const html = renderTodayPage(CAMP, EVENTS, '<svg></svg>');
+    assert.ok(
+      !/__SHOW_ICAL__/.test(html),
+      'Display view (live.html) must not opt in to per-event iCal links',
     );
   });
 });


### PR DESCRIPTION
## Sammanfattning

- På dagsvyn (`idag.html`) får varje aktivitet nu en liten **"iCal"-länk** i raden — samma som veckoschemat redan har — så att en enskild aktivitet kan laddas ner (`schema/<id>/event.ics`) till kalendern.
- `render-idag.js` sätter `window.__SHOW_ICAL__ = true`; `events-today.js` ritar ut länken klient-sidan (efter plats/ansvarig, inuti `<summary>` för detaljrader) endast när flaggan är satt och aktiviteten har ett `id`.
- Storbilds-/TV-läget (`live.html`) lämnar flaggan osatt → ingen klickbar länk där, i linje med att skärmen är passiv.

Följer projektets lifecycle (Phase 0–7): requirements (§46.6), arkitektur (§22.5a) + spårbarhet, tester, implementation.

## Testplan

- [x] `npm test` — 2022/2022 passerar
- [x] `npm run lint` / `npm run lint:md` — rent
- [x] `SITE_URL=… npm run build` — bygget går igenom
- [x] DOM-simulering av `events-today.js`: idag-läget ger iCal-länk i både enkla rader och detaljrader; display-läget ger 0 länkar
- [ ] Manuell browser-koll: öppna `idag.html` en dag med aktiviteter och bekräfta att varje rad slutar med en "iCal"-länk som laddar ner rätt `.ics`

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRhF1eUGFkPKinZyEmN1iw)_