### PR TITLE
Revert "/dagens-schema/ display-page alias"

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -87,13 +87,6 @@ jobs:
               echo "Staged: $REL"
             done
           fi
-          # Directory-style /dagens-schema/ alias embeds the day's events, so it
-          # must redeploy alongside live.html or it would show stale events.
-          if [ -f "public/dagens-schema/index.html" ]; then
-            mkdir -p staging/dagens-schema
-            cp public/dagens-schema/index.html staging/dagens-schema/index.html
-            echo "Staged: dagens-schema/index.html"
-          fi
 
       - name: Upload event data pages via rsync
         if: steps.gate.outputs.skip != 'true'
@@ -180,13 +173,6 @@ jobs:
               cp "$PAGE" "staging/$REL"
               echo "Staged: $REL"
             done
-          fi
-          # Directory-style /dagens-schema/ alias embeds the day's events, so it
-          # must redeploy alongside live.html or it would show stale events.
-          if [ -f "public/dagens-schema/index.html" ]; then
-            mkdir -p staging/dagens-schema
-            cp public/dagens-schema/index.html staging/dagens-schema/index.html
-            echo "Staged: dagens-schema/index.html"
           fi
 
       - name: Upload event data pages via SCP

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -249,8 +249,8 @@ secrets to manage. Production remains on FTP until QA is validated.
   secret the full site deploy uses), with `/public_html/` appended,
   instead of requiring a separate `FTP_TARGET_DIR` secret. <!-- 02-§43.3 -->
 - The upload must include the same files as today: `schema.html`,
-  `idag.html`, `live.html`, `dagens-schema.html`, `dagens-schema/index.html`,
-  `events.json`, `schema.rss`, and per-event detail pages under `schema/`. <!-- 02-§43.4 -->
+  `idag.html`, `live.html`, `dagens-schema.html`, `events.json`,
+  `schema.rss`, and per-event detail pages under `schema/`. <!-- 02-§43.4 -->
 - The `FTP_TARGET_DIR` validation step must be removed from the QA
   job. <!-- 02-§43.5 -->
 
@@ -456,9 +456,8 @@ workflow builds and deploys event-data files.
   [Archived (superseded)](./archive.md).
 - The workflow must build the site using `node source/build/build.js`. <!-- 02-§50.15 -->
 - The workflow must stage only event-data-derived files for upload: `schema.html`,
-  `idag.html`, `live.html`, `dagens-schema.html`, `dagens-schema/index.html`,
-  `events.json`, `schema.rss`, `schema.ics`, `kalender.html`, and per-event pages
-  under `schema/`. <!-- 02-§50.16 -->
+  `idag.html`, `live.html`, `dagens-schema.html`, `events.json`, `schema.rss`,
+  `schema.ics`, `kalender.html`, and per-event pages under `schema/`. <!-- 02-§50.16 -->
 - The workflow must deploy to QA via rsync in a parallel job. <!-- 02-§50.17 -->
 - The workflow must deploy to Production via SCP, skipped when the changed
   file belongs to a QA camp. <!-- 02-§50.18 -->

--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -38,7 +38,6 @@ Part of [the requirements index](./index.md). Section IDs (`02-§N.M`) are stabl
 - The heading is positioned inside the sidebar, not above the event list, so events use the full available height. <!-- 02-§4.20 -->
 - The layout is optimised for portrait-orientation screens; event rows are compact to maximise the number of visible events. <!-- 02-§4.21 -->
 - The old URL `/dagens-schema.html` serves a redirect page that sends the visitor to `/live.html` via `<meta http-equiv="refresh">` and a JavaScript fallback. <!-- 02-§76.1 -->
-- The directory-style URL `/dagens-schema/` is served by `/dagens-schema/index.html`, which is the same display page as `/live.html` with a `<base href="/">` tag so its relative assets and the `version.json` poll resolve against the site root. It is a true content alias, not a redirect: the page renders directly with no intermediate navigation, so kiosk screens that reload that URL on a timer never flash through a redirect page. Because it embeds the day's events, it is deployed together with `/live.html` on every deploy, including data-only event deploys, so it never shows stale events. <!-- 02-§76.2 -->
 
 ### All schedule views
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -79,9 +79,7 @@ Each deploy job:
    earlier basename-only lookup so QA-camp fragments never deploy to production.
 4. Runs `node source/build/build.js`.
 5. Stages only event-data-derived files: `schema.html`, `idag.html`,
-   `live.html`, `dagens-schema/index.html` (the display-page alias, which
-   embeds the day's events and so must redeploy with `live.html`),
-   `events.json`, `schema.rss`, `schema.ics`,
+   `live.html`, `events.json`, `schema.rss`, `schema.ics`,
    `kalender.html`, and per-event pages under `schema/`.
 6. Uploads the staged files via SCP to the target environment.
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -42,7 +42,6 @@ Part of [the traceability index](./index.md).
 | `02-§4.20` | Display view heading is positioned inside the sidebar, not above the event list | 02-requirements/schedule-and-detail.md §4; 07-design/components.md §6.44 | DIS-24, DIS-25 | `source/build/render-today.js` – `<h1 id="today-heading" class="sidebar-heading">` inside `<aside class="dagens-sidebar">` | covered |
 | `02-§4.21` | Display view is optimised for portrait screens; event rows are compact | 02-requirements/schedule-and-detail.md §4; 07-design/components.md §6.45, §6.48 | — (manual: open `/live.html` in a portrait viewport ~1080×1920 and confirm event rows are compact and the sidebar is narrow) | `source/assets/cs/style.css` – `.dagens-events { flex: 3 }`, `.dagens-sidebar { flex: 1 }`, `body.display-mode .event-row { font-size: 13px; padding: 6px }` | implemented |
 | `02-§76.1` | Old `/dagens-schema.html` URL redirects to `/live.html` | 02-requirements/schedule-and-detail.md §4 | RDR-01..04 | `source/build/render-today.js` – `renderRedirectPage()`; `source/build/build.js` → `public/dagens-schema.html` | covered |
-| `02-§76.2` | `/dagens-schema/` is a true content alias of `/live.html` (display page + `<base href="/">`), deployed alongside `live.html` on every deploy | 02-requirements/schedule-and-detail.md §4; 03-architecture/ci-and-deploy.md §11.3 | ALIAS-01..03, EDW-DS-01..02 | `source/build/render-today.js` – `renderDisplayAlias()`; `source/build/build.js` → `public/dagens-schema/index.html`; `.github/workflows/event-data-deploy-post-merge.yml` – staging step | covered |
 | `02-§77.1` | Build computes MD5 hash of each JS file referenced by `<script>` tags | 03-architecture/ci-and-deploy.md §27 | CACHE-10 | `source/build/build.js` – JS cache-busting post-processing | covered |
 | `02-§77.2` | Build replaces `src="<file>.js"` with `src="<file>.js?v=<hash>"` in all HTML | 03-architecture/ci-and-deploy.md §27 | CACHE-11 | `source/build/build.js` – JS cache-busting post-processing | covered |
 | `02-§77.3` | JS hash is deterministic: identical content → identical hash | 03-architecture/ci-and-deploy.md §27 | CACHE-12 | `source/build/build.js` – `crypto.createHash('md5')` | covered |
@@ -1017,7 +1016,6 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§75.11` | covered | NL-03: each nav link has both short and long label spans; `layout.js` |
 | | | **§76 — Redirect from old display view URL** |
 | `02-§76.1` | covered | RDR-01..04: `renderRedirectPage()` produces redirect; `build.js` writes `public/dagens-schema.html` |
-| `02-§76.2` | covered | ALIAS-01..03: `renderDisplayAlias()` injects `<base href="/">` into the display page; `build.js` writes `public/dagens-schema/index.html`. EDW-DS-01..02: both deploy jobs stage `dagens-schema/index.html` |
 | | | **§77 — JavaScript Cache-Busting** |
 | `02-§77.1` | covered | CACHE-10: build.js computes MD5 hash for JS files |
 | `02-§77.2` | covered | CACHE-11: build.js replaces JS src with ?v=hash |

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -8,7 +8,7 @@ const QRCode = require('qrcode');
 const { renderSchedulePage, toDateString } = require('./render');
 const { renderAddPage } = require('./render-add');
 const { renderEditPage, editApiUrl } = require('./render-edit');
-const { renderTodayPage, renderRedirectPage, renderDisplayAlias } = require('./render-today');
+const { renderTodayPage, renderRedirectPage } = require('./render-today');
 const { renderIdagPage } = require('./render-idag');
 const { renderLokalerPage } = require('./render-lokaler');
 const { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, formatLongSvDate } = require('./render-index');
@@ -208,15 +208,6 @@ async function main() {
 
   fs.writeFileSync(path.join(OUTPUT_DIR, 'dagens-schema.html'), renderRedirectPage(), 'utf8');
   console.log('Built: public/dagens-schema.html  (redirect → live.html)');
-
-  // Directory-style alias /dagens-schema/ serves the live display page directly,
-  // so kiosk screens that reload that URL on a timer never flash through a
-  // redirect. Asset/version.json paths resolve from root via the injected
-  // <base href="/">. (02-§76.2)
-  const dagensSchemaDir = path.join(OUTPUT_DIR, 'dagens-schema');
-  fs.mkdirSync(dagensSchemaDir, { recursive: true });
-  fs.writeFileSync(path.join(dagensSchemaDir, 'index.html'), renderDisplayAlias(todayHtml), 'utf8');
-  console.log('Built: public/dagens-schema/index.html  (display-page alias)');
 
   // ── Write version.json — polled by live.html for live reload ─────────────────
   fs.writeFileSync(path.join(OUTPUT_DIR, 'version.json'), JSON.stringify({ version: buildTime }), 'utf8');

--- a/source/build/render-today.js
+++ b/source/build/render-today.js
@@ -76,19 +76,6 @@ ${pwaHeadTags()}
 }
 
 /**
- * Wraps the display-page HTML for the `/dagens-schema/` directory alias.
- *
- * The alias serves the live display page directly (no redirect) so kiosk
- * screens that reload that URL on a timer never flash through an intermediate
- * page. A `<base href="/">` tag is injected so relative asset URLs
- * (`style.css`, `events-today.js`) and the `version.json` poll resolve against
- * the site root instead of `/dagens-schema/`. (02-§76.2)
- */
-function renderDisplayAlias(todayHtml) {
-  return todayHtml.replace('<head>', '<head>\n  <base href="/">');
-}
-
-/**
  * Renders a lightweight redirect page from the old dagens-schema.html URL
  * to the new live.html URL.
  */
@@ -108,4 +95,4 @@ function renderRedirectPage() {
 `;
 }
 
-module.exports = { renderTodayPage, renderRedirectPage, renderDisplayAlias };
+module.exports = { renderTodayPage, renderRedirectPage };

--- a/tests/coverage-today.test.js
+++ b/tests/coverage-today.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { renderTodayPage, renderRedirectPage, renderDisplayAlias } = require('../source/build/render-today');
+const { renderTodayPage, renderRedirectPage } = require('../source/build/render-today');
 
 // ── Shared fixtures ─────────────────────────────────────────────────────────
 
@@ -258,34 +258,5 @@ describe('02-§76.1 — Redirect page from dagens-schema.html to live.html', () 
 
   it('RDR-04: has a visible link to live.html', () => {
     assert.ok(html.includes('href="live.html"'), 'link to live.html present');
-  });
-});
-
-// ── 02-§76.2  Directory-style /dagens-schema/ display-page alias ─────────────
-
-describe('02-§76.2 — /dagens-schema/ alias serves the display page directly', () => {
-  const todayHtml = renderTodayPage(CAMP, EVENTS, QR_SVG, 'https://sbsommar.se', '2099-07-01T08:00:00.000Z');
-  const aliasHtml = renderDisplayAlias(todayHtml);
-
-  it('ALIAS-01: injects <base href="/"> so relative assets resolve from root', () => {
-    assert.ok(aliasHtml.includes('<base href="/">'), 'base href present');
-    assert.ok(
-      aliasHtml.includes('<head>\n  <base href="/">'),
-      'base href is the first element inside <head>',
-    );
-  });
-
-  it('ALIAS-02: is not a redirect — it keeps the full display layout and event payload', () => {
-    assert.ok(aliasHtml.includes('class="dagens-layout"'), 'display layout present');
-    assert.ok(!aliasHtml.includes('http-equiv="refresh"'), 'no meta refresh');
-    assert.ok(aliasHtml.includes('window.__EVENTS__'), 'embedded events present');
-  });
-
-  it('ALIAS-03: differs from the live.html page only by the injected <base> tag', () => {
-    assert.strictEqual(
-      aliasHtml.replace('\n  <base href="/">', ''),
-      todayHtml,
-      'removing the base tag yields the identical live.html source',
-    );
   });
 });

--- a/tests/event-deploy-workflow.test.js
+++ b/tests/event-deploy-workflow.test.js
@@ -299,25 +299,3 @@ describe('02-§109.25 — Event-data workflows trigger on fragment paths (EDW-31
     );
   });
 });
-
-// ── 02-§76.2  /dagens-schema/ alias redeploys with live.html on data-only deploys ──
-// The alias embeds the day's events, so it must be staged alongside live.html in
-// every deploy job or it would diverge from live.html after a data-only deploy.
-
-describe('02-§76.2 — Both deploy jobs stage the /dagens-schema/ alias (EDW-DS-01..02)', () => {
-  const deployJobs = jobNames.filter((n) => n.startsWith('deploy'));
-
-  for (const name of deployJobs) {
-    it(`EDW-DS-01: ${name} staging step copies dagens-schema/index.html`, () => {
-      const steps = workflow.jobs[name].steps || [];
-      const stage = steps.find(
-        (s) => s.run && s.run.includes('mkdir -p staging')
-      );
-      assert.ok(stage, `${name} must have a staging step`);
-      assert.ok(
-        stage.run.includes('dagens-schema/index.html'),
-        `${name} staging step must stage dagens-schema/index.html`
-      );
-    });
-  }
-});


### PR DESCRIPTION
Reverts the `/dagens-schema/` display-page alias (PR #548) in full — the feature is not needed.

This restores the state before the alias: the pre-existing `/dagens-schema.html` → `/live.html` redirect (`02-§76.1`) is untouched; only the new directory alias, its `<base href="/">` injection, the deploy-staging entry, requirement `02-§76.2`, and the associated tests/traceability are removed.

## What this reverts
- `source/build/render-today.js` — `renderDisplayAlias()`
- `source/build/build.js` — `public/dagens-schema/index.html` output
- `.github/workflows/event-data-deploy-post-merge.yml` — alias staging in both deploy jobs
- Requirement `02-§76.2` + traceability rows + deploy-list doc updates
- Tests `ALIAS-01..03`, `EDW-DS-01..02`

## Verification
- [x] `npm test` — 2022 passing, 0 failing
- [x] `npx eslint .` — clean
- [x] `node source/build/build.js` — builds; no `dagens-schema/` directory emitted; `dagens-schema.html` redirect still present

Merging this redeploys QA without the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZeDR3ZazugJFzay3xL9B3)_