### PR TITLE
docs: event-data deploy embeds current prod version in footer

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          fetch-tags: true
 
       - name: Detect changed event data file
         id: gate
@@ -48,6 +49,31 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "Detected changed file: $CHANGED"
           fi
+
+      # Compute the version string to embed in the footer so event-data pages
+      # (schema.html, idag.html, kalender.html, per-event pages) show the same
+      # version as every other page on QA. Mirrors deploy-qa.yml: full semver
+      # from the latest tag plus the QA PR suffix (02-§62.9, 02-§62.20).
+      - name: Compute version string
+        id: version
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          BASE=$(cat VERSION | tr -d '[:space:]')
+          LATEST=$(git tag --list "v${BASE}.*" --sort=-version:refname | head -1)
+          if [ -n "$LATEST" ]; then
+            FULL_VER=$(echo "$LATEST" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          else
+            FULL_VER="${BASE}.0"
+          fi
+          PR_NUM=$(git log -1 --pretty=format:"%s" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          if [ -n "$PR_NUM" ]; then
+            VERSION_STR="${FULL_VER} – QA PR${PR_NUM}"
+          else
+            SHA=$(git rev-parse --short HEAD)
+            VERSION_STR="${FULL_VER} – QA ${SHA}"
+          fi
+          echo "build_version=${VERSION_STR}" >> $GITHUB_OUTPUT
+          echo "QA version: ${VERSION_STR}"
 
       - uses: actions/setup-node@v6
         if: steps.gate.outputs.skip != 'true'
@@ -66,6 +92,7 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           SITE_URL: ${{ secrets.SITE_URL }}
           BUILD_ENV: qa
+          BUILD_VERSION: ${{ steps.version.outputs.build_version }}
           COOKIE_DOMAIN: ${{ secrets.COOKIE_DOMAIN }}
           GOATCOUNTER_SITE_CODE: ${{ secrets.GOATCOUNTER_SITE_CODE }}
 
@@ -108,6 +135,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          fetch-tags: true
 
       - uses: actions/setup-node@v6
         with:
@@ -146,6 +174,24 @@ jobs:
             fi
           fi
 
+      # Compute the version string to embed in the footer so event-data pages
+      # (schema.html, idag.html, kalender.html, per-event pages) show the same
+      # version as every other page on production: the full semver from the
+      # latest tag, e.g. 1.0.4 (02-§62.9, 02-§62.20).
+      - name: Compute version string
+        id: version
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          BASE=$(cat VERSION | tr -d '[:space:]')
+          LATEST=$(git tag --list "v${BASE}.*" --sort=-version:refname | head -1)
+          if [ -n "$LATEST" ]; then
+            FULL_VER=$(echo "$LATEST" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          else
+            FULL_VER="${BASE}.0"
+          fi
+          echo "build_version=${FULL_VER}" >> $GITHUB_OUTPUT
+          echo "Production version: ${FULL_VER}"
+
       - name: Build site
         if: steps.gate.outputs.skip != 'true'
         run: node source/build/build.js
@@ -153,6 +199,7 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           SITE_URL: ${{ secrets.SITE_URL }}
           BUILD_ENV: production
+          BUILD_VERSION: ${{ steps.version.outputs.build_version }}
           COOKIE_DOMAIN: ${{ secrets.COOKIE_DOMAIN }}
           GOATCOUNTER_SITE_CODE: ${{ secrets.GOATCOUNTER_SITE_CODE }}
 

--- a/docs/02-requirements/build-deploy.md
+++ b/docs/02-requirements/build-deploy.md
@@ -655,9 +655,21 @@ the footer solves this with minimal visual impact.
 - **Local**: The version string must include the base version and a
   Stockholm-timezone timestamp, e.g.
   `v1.0 – Lokal 2026-03-02 14:30`. <!-- 02-§62.8 -->
-- **Event-data deploys**: When `BUILD_ENV` is set but `BUILD_VERSION` is
-  not (event-data deploys), no version string is rendered in the
-  footer. <!-- 02-§62.9 -->
+- **Event-data deploys**: The post-merge event-data deploy workflow
+  computes the current production version from the latest `v{base}.*`
+  git tag and passes it to the build as `BUILD_VERSION`. The event-data
+  pages it rebuilds (`schema.html`, `idag.html`, `kalender.html`, the
+  per-event pages and feeds) therefore show the same footer version
+  string as every other page on the same environment. On production the
+  string is the full semver (e.g. `v1.0.4`); on QA it additionally
+  carries the QA PR suffix (e.g. `v1.0.4 – QA PR547`), matching a full QA
+  deploy. <!-- 02-§62.9 -->
+- The event-data deploy workflow checks out with tags fetched
+  (`fetch-tags: true`) so the latest tag is available for this
+  computation. <!-- 02-§62.20 -->
+- When `BUILD_VERSION` is unset in a CI build — a defensive fallback, not
+  the normal path — the build renders no version string rather than a
+  misleading one. <!-- 02-§62.21 -->
 
 ### 62.4 Automatic production tagging
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -777,7 +777,7 @@ Part of [the traceability index](./index.md).
 | `02-§62.6` | Production: full semver from tags | — | — | `.github/workflows/deploy-prod.yml` | implemented |
 | `02-§62.7` | QA: full semver + PR number | — | — | `.github/workflows/deploy-qa.yml` | implemented |
 | `02-§62.8` | Local: base version + timestamp | — | VER-03..04, VER-07 | `source/build/version.js` | covered |
-| `02-§62.9` | Event-data deploy: no version shown | — | VER-06, VER-09 | `source/build/version.js` | covered |
+| `02-§62.9` | Event-data deploy embeds current prod version | — | EDW-33..36 | `.github/workflows/event-data-deploy-post-merge.yml` | covered |
 | `02-§62.10` | Annotated git tag per prod deploy | — | — | `.github/workflows/deploy-prod.yml` | implemented |
 | `02-§62.11` | Tag created after successful deploy | — | — | `.github/workflows/deploy-prod.yml` | implemented |
 | `02-§62.12` | Tag skip if already exists | — | — | `.github/workflows/deploy-prod.yml` | implemented |
@@ -788,6 +788,8 @@ Part of [the traceability index](./index.md).
 | `02-§62.17` | Version logic in separate testable module | — | VER-01..09 | `source/build/version.js` | covered |
 | `02-§62.18` | QA redeploy triggered after prod deploy | 09-RELEASING.md | manual: trigger prod deploy and verify QA workflow runs | `.github/workflows/deploy-prod.yml` | implemented |
 | `02-§62.19` | QA redeploy uses exact prod version string | 09-RELEASING.md | manual: verify QA footer shows exact prod version after redeploy | `.github/workflows/deploy-prod.yml` | implemented |
+| `02-§62.20` | Event-data deploy checks out with tags fetched | — | EDW-33..34 | `.github/workflows/event-data-deploy-post-merge.yml` | covered |
+| `02-§62.21` | Defensive fallback: no version when BUILD_VERSION unset in CI | — | VER-06, VER-09 | `source/build/version.js` | covered |
 | `02-§62.20` | Normal QA deploy restores QA-suffixed version | — | manual: merge PR and verify QA footer shows QA suffix | `.github/workflows/deploy-qa.yml` | implemented |
 | | | **§63 — Site Analytics** | | | |
 | `02-§63.1` | GoatCounter as analytics tool | 03-architecture/pages-and-content.md §23 | — | `source/build/analytics.js` | implemented |

--- a/source/build/version.js
+++ b/source/build/version.js
@@ -63,9 +63,14 @@ function buildLocalVersion(baseVersion) {
  * should be shown.
  *
  * Logic:
- *   - If BUILD_VERSION is set: use it directly (set by CI for prod/QA).
+ *   - If BUILD_VERSION is set: use it directly. All deploy workflows set
+ *     it — full prod/QA deploys and the post-merge event-data deploy,
+ *     which computes the current production version from the latest git
+ *     tag (02-§62.9).
  *   - If running in CI (GITHUB_ACTIONS is set) without BUILD_VERSION:
- *     return null (event-data deploy — no misleading version).
+ *     return null. This is a defensive fallback (02-§62.21) — a CI build
+ *     that forgot to pass BUILD_VERSION renders no version rather than a
+ *     misleading local timestamp.
  *   - Otherwise (local dev): build a local timestamp version.
  *     Local .env may set BUILD_ENV for testing, but that should not
  *     suppress the version — only real CI runs should.

--- a/tests/event-deploy-workflow.test.js
+++ b/tests/event-deploy-workflow.test.js
@@ -299,3 +299,74 @@ describe('02-§109.25 — Event-data workflows trigger on fragment paths (EDW-31
     );
   });
 });
+
+// ── 02-§62.9 / 62.20  Event-data deploy embeds the current prod version ──────
+// The post-merge deploy rebuilds schema.html, idag.html, kalender.html and the
+// per-event pages. It must pass BUILD_VERSION so those pages show the same
+// footer version as every other page (issue #574 — otherwise they alone showed
+// no version after an event merge). The version is the latest git tag, so the
+// checkout must fetch tags.
+
+describe('02-§62.20 — Event-data deploy checks out with tags fetched (EDW-33..34)', () => {
+  for (const name of ['deploy-qa', 'deploy-prod']) {
+    it(`EDW-33/34: ${name} checkout sets fetch-tags: true`, () => {
+      const steps = workflow.jobs[name].steps || [];
+      const checkout = steps.find(
+        (s) => s.uses && s.uses.startsWith('actions/checkout')
+      );
+      assert.ok(checkout, `${name} must have a checkout step`);
+      assert.strictEqual(
+        checkout.with?.['fetch-tags'],
+        true,
+        `${name} checkout must set fetch-tags: true so git tags are available`
+      );
+    });
+  }
+});
+
+describe('02-§62.9 — Event-data deploy passes BUILD_VERSION to the build (EDW-35..36)', () => {
+  for (const name of ['deploy-qa', 'deploy-prod']) {
+    it(`EDW-35/36: ${name} computes a version and feeds it into the build as BUILD_VERSION`, () => {
+      const steps = workflow.jobs[name].steps || [];
+
+      // A version step, gated on the same detection output as the build.
+      const version = steps.find((s) => s.id === 'version');
+      assert.ok(version, `${name} must have a step with id "version"`);
+      assert.ok(
+        version.if && version.if.includes('gate'),
+        `${name} version step must be gated on detection output`
+      );
+      assert.ok(
+        version.run && version.run.includes('git tag --list'),
+        `${name} version step must resolve the latest git tag`
+      );
+
+      // The build step must pass that version through as BUILD_VERSION.
+      const build = steps.find(
+        (s) => s.run && s.run.includes('node source/build/build.js')
+      );
+      assert.ok(build, `${name} must have a build step`);
+      assert.ok(
+        build.env && build.env.BUILD_VERSION
+          && build.env.BUILD_VERSION.includes('steps.version.outputs.build_version'),
+        `${name} build step must set BUILD_VERSION from the version step output`
+      );
+    });
+  }
+
+  it('EDW-35: deploy-qa version carries the QA PR suffix', () => {
+    const version = (workflow.jobs['deploy-qa'].steps || []).find((s) => s.id === 'version');
+    assert.ok(
+      version.run.includes('QA PR'),
+      'deploy-qa version string must include the QA PR suffix (matching a full QA deploy)'
+    );
+  });
+
+  it('EDW-36: deploy-prod version is a bare semver with no QA suffix', () => {
+    const version = (workflow.jobs['deploy-prod'].steps || []).find((s) => s.id === 'version');
+    assert.ok(
+      !version.run.includes('QA'),
+      'deploy-prod version string must not include a QA suffix'
+    );
+  });
+});

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Tests for source/build/version.js — 02-§62.8, 02-§62.9, 02-§62.15, 02-§62.16, 02-§62.17.
+// Tests for source/build/version.js — 02-§62.8, 02-§62.15, 02-§62.16, 02-§62.17, 02-§62.21.
 //
 // These verify:
 //   - readVersionFile reads the VERSION file or falls back to '0.0' (VER-01..02)
@@ -71,7 +71,7 @@ describe('buildLocalVersion (02-§62.8)', () => {
 
 // ── resolveVersionString ────────────────────────────────────────────────────
 
-describe('resolveVersionString (02-§62.9, 02-§62.15, 02-§62.16)', () => {
+describe('resolveVersionString (02-§62.15, 02-§62.16, 02-§62.21)', () => {
   it('VER-05: returns BUILD_VERSION directly when set', () => {
     const dir = makeTmpDir();
     const env = { BUILD_VERSION: '1.0.4' };
@@ -79,7 +79,7 @@ describe('resolveVersionString (02-§62.9, 02-§62.15, 02-§62.16)', () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  it('VER-06: returns null in CI without BUILD_VERSION (event-data deploy)', () => {
+  it('VER-06: returns null in CI without BUILD_VERSION (defensive fallback)', () => {
     const dir = makeTmpDir();
     const env = { GITHUB_ACTIONS: 'true', BUILD_ENV: 'production' };
     assert.strictEqual(resolveVersionString(env, dir), null);


### PR DESCRIPTION
Reword 02-§62.9 to the desired state: the post-merge event-data deploy
computes the current production version from the latest git tag and
passes it to the build, so schema.html, idag.html and kalender.html show
the same footer version as every other page. Add 02-§62.20 (checkout
fetches tags) and 02-§62.21 (defensive no-version fallback). Update the
traceability matrix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018uxYpwPn1Dt4qPFZaGSo4A