### PR TITLE
Run stranded-PR recovery on check_suite completion (complement unreliable cron)

### DIFF
--- a/.github/workflows/event-data-deploy-post-merge.yml
+++ b/.github/workflows/event-data-deploy-post-merge.yml
@@ -263,6 +263,11 @@ jobs:
   recover-stranded-event-prs:
     name: Recover event PRs stranded in the merge queue
     runs-on: ubuntu-latest
+    # Shared with merge-queue-recovery.yml so all recovery triggers are single-flight;
+    # cancel-in-progress is false so a mid-toggle run is never cancelled (02-§112.17).
+    concurrency:
+      group: stranded-recovery
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/merge-queue-recovery.yml
+++ b/.github/workflows/merge-queue-recovery.yml
@@ -1,21 +1,32 @@
-name: Merge Queue Recovery (Scheduled)
+name: Merge Queue Recovery
 
-# Safety-net sweep for event PRs stranded in the merge-queue handoff (02-§112.8).
+# Sweep for event PRs stranded in the merge-queue handoff (02-§112).
 #
-# The post-merge sweep in event-data-deploy-post-merge.yml recovers a stranded PR
-# immediately after the next event-data merge. This scheduled run covers the case
-# where no such merge follows — e.g. the burst ends with a stranded PR. It is cheap
-# when there is nothing to do: it lists open event PRs and exits when none are
-# stranded (02-§112.9).
+# A PR strands at the moment its required checks finish and it turns mergeable, so the
+# primary trigger is check_suite: completed — recovery runs right then (02-§112.16),
+# rather than waiting for GitHub's unreliable schedule delivery. The post-merge sweep
+# in event-data-deploy-post-merge.yml covers the burst case; the schedule below is a
+# slow backstop (02-§112.8). The sweep is cheap when idle: it lists open event PRs and
+# exits when none are stranded (02-§112.9).
 
 permissions:
   contents: read
 
 on:
+  check_suite:
+    types: [completed]
   schedule:
-    # Every 15 minutes.
+    # Every 15 minutes — slow backstop; GitHub does not guarantee this cadence.
     - cron: '*/15 * * * *'
   workflow_dispatch:
+
+# All recovery triggers (here plus the post-merge job) share one group so bursts of
+# check-suite completions coalesce. cancel-in-progress is false so a run that is
+# mid-toggle (auto-merge disabled, not yet re-enabled) is never cancelled, which would
+# otherwise leave a PR with auto-merge off — worse than stranded (02-§112.17, 112.11).
+concurrency:
+  group: stranded-recovery
+  cancel-in-progress: false
 
 jobs:
   recover-stranded-event-prs:

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -977,6 +977,16 @@ stuck in the queue handoff.
 - The scheduled safety-net pass is inexpensive when there are no open event pull
   requests: it lists the open event pull requests and exits without further work when
   none are stranded. <!-- 02-§112.9 -->
+- Recovery also runs when a check suite completes (`check_suite` `completed`). A pull
+  request becomes stranded at the moment its required checks finish and it turns
+  mergeable, so running the sweep on check-suite completion recovers it then —
+  independently of the schedule, whose delivery GitHub does not guarantee at the
+  configured interval. <!-- 02-§112.16 -->
+- Recovery runs are single-flight: all recovery triggers (post-merge, scheduled,
+  check-suite, manual) share one concurrency group, and an in-progress run is never
+  cancelled. This coalesces bursts of check-suite completions into few runs and
+  guarantees a run that is mid-toggle (auto-merge disabled, not yet re-enabled) is
+  allowed to finish, so a pull request is never left with auto-merge off. <!-- 02-§112.17 -->
 - Recovery is idempotent. A pull request that is not stranded is left unchanged on
   every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -277,15 +277,31 @@ redundant-PR cleanup.
 The classifier never recovers a pull request that is not stranded, so repeated runs
 are idempotent (02-§112.10).
 
-**When it runs (02-§112.7–112.9).** The sweep runs in two places:
+**When it runs (02-§112.7–112.9, 112.16).** The sweep runs from three triggers, all
+invoking the same `recover-stranded-event-prs.js`:
 
 - A job in `event-data-deploy-post-merge.yml` (push to `main`, `source/data/**.yaml`),
   alongside `close-redundant-event-prs` — the event merge that triggers this workflow
   is exactly the base move that can strand a sibling, so recovery happens immediately
   (02-§112.7).
-- A scheduled workflow, `merge-queue-recovery.yml`, on a 15-minute cron, as a safety
-  net for strandings that no event-data merge follows (02-§112.8). The sweep lists the
+- `merge-queue-recovery.yml` on a `check_suite` `completed` trigger — a pull request
+  becomes stranded the instant its required checks finish and it turns mergeable, so
+  the sweep runs at that moment instead of waiting (02-§112.16). This is the primary
+  fast path: GitHub does not reliably deliver scheduled runs at the configured 15-minute
+  interval, so the schedule alone leaves a stranded pull request waiting until the next
+  (sporadic) cron delivery.
+- The same `merge-queue-recovery.yml` on a 15-minute `schedule` cron (plus
+  `workflow_dispatch`), as a slow backstop for strandings that neither an event-data
+  merge nor a check-suite completion happens to cover (02-§112.8). The sweep lists the
   open event pull requests first and exits cheaply when none are stranded (02-§112.9).
+
+**Single-flight (02-§112.17).** `merge-queue-recovery.yml` (workflow-level) and the
+post-merge `recover-stranded-event-prs` job both declare the same
+`concurrency: stranded-recovery` group with `cancel-in-progress: false`. Check-suite
+completions arrive in bursts, so the group coalesces them — at most one run executes
+while one waits, and superseded pending runs are dropped. `cancel-in-progress: false`
+is deliberate: a run that has disabled auto-merge but not yet re-enabled it must finish,
+or the pull request would be left with auto-merge off — worse than stranded (02-§112.11).
 
 **Authentication (02-§112.12, 112.14, 112.15).** The default Actions workflow token
 (`secrets.GITHUB_TOKEN`) cannot run the `enablePullRequestAutoMerge` /

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1744,6 +1744,8 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.13` | covered | STRAND-16/-17 (`processPr` returns `'failed'` on fetch/recover error), STRAND-18/-19 (`runSweep` counts failures and keeps going); `main()` throws when the count is non-zero |
 | `02-§112.14` | implemented | `EVENT_AUTOMERGE_TOKEN` documented as a repository-level secret in 08-ENVIRONMENTS; recovery jobs declare no `environment:` so only repo-level secrets resolve |
 | `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
+| `02-§112.16` | gap | `merge-queue-recovery.yml` adds a `check_suite: [completed]` trigger so the sweep runs when a PR's checks finish |
+| `02-§112.17` | gap | Shared `concurrency: stranded-recovery` group with `cancel-in-progress: false` on the scheduled workflow and the post-merge job |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1744,8 +1744,8 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.13` | covered | STRAND-16/-17 (`processPr` returns `'failed'` on fetch/recover error), STRAND-18/-19 (`runSweep` counts failures and keeps going); `main()` throws when the count is non-zero |
 | `02-§112.14` | implemented | `EVENT_AUTOMERGE_TOKEN` documented as a repository-level secret in 08-ENVIRONMENTS; recovery jobs declare no `environment:` so only repo-level secrets resolve |
 | `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
-| `02-§112.16` | gap | `merge-queue-recovery.yml` adds a `check_suite: [completed]` trigger so the sweep runs when a PR's checks finish |
-| `02-§112.17` | gap | Shared `concurrency: stranded-recovery` group with `cancel-in-progress: false` on the scheduled workflow and the post-merge job |
+| `02-§112.16` | covered | RECTRIG-02: `merge-queue-recovery.yml` declares a `check_suite: [completed]` trigger (schedule + workflow_dispatch retained, RECTRIG-01) |
+| `02-§112.17` | covered | RECTRIG-03/-04: scheduled workflow and post-merge job share `concurrency: stranded-recovery` with `cancel-in-progress: false` |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered; stranded-recovery auth + fail-loud 02-§112.12–112.15: 1 covered, 3 implemented).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered; stranded-recovery auth + fail-loud 02-§112.12–112.15: 1 covered, 3 implemented; stranded-recovery check-suite trigger + single-flight 02-§112.16–112.17 covered).
 
 ---
 
@@ -138,8 +138,8 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1422
-Covered (implemented + tested): 763
+Total requirements:            1424
+Covered (implemented + tested): 765
 Implemented, not tested:        659
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
@@ -159,12 +159,16 @@ Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
   submission time (and thus whether the latency goal is actually met) must be
   confirmed against production (#481).
 
-Note: §112 (Stranded Auto-Merge Recovery) adds 15 requirements
-  (02-§112.1–112.15): 6 covered (STRAND-01..19,
-  tests/stranded-recovery.test.js) and 9 implemented (the GraphQL
+Note: §112 (Stranded Auto-Merge Recovery) adds 17 requirements
+  (02-§112.1–112.17): 8 covered (STRAND-01..19 and RECTRIG-01..05 in
+  tests/stranded-recovery.test.js and tests/recovery-trigger-workflow.test.js)
+  and 9 implemented (the GraphQL
   disable→enable toggle, the per-PR isolation and early-exit in main(), the two
   workflow entry points, the EVENT_AUTOMERGE_TOKEN auth, and the deploy-trigger
-  identity, STRAND-M01 manual). Event PRs merge through a
+  identity, STRAND-M01 manual). A third trigger runs the sweep on check_suite
+  completion — the moment a PR turns mergeable — so recovery no longer depends on
+  GitHub's unreliable schedule delivery; all triggers share one single-flight
+  concurrency group (02-§112.16–112.17). Event PRs merge through a
   required merge queue; when main advances between auto-merge enablement and
   queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
   CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js

--- a/tests/recovery-trigger-workflow.test.js
+++ b/tests/recovery-trigger-workflow.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// Workflow-config checks for the stranded-recovery triggers (02-§112.16, 112.17).
+// These assert the YAML wiring; the live recovery behaviour is manual checkpoint
+// STRAND-M01.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const load = (rel) =>
+  yaml.load(fs.readFileSync(path.resolve(__dirname, '..', rel), 'utf8'));
+
+const recovery = load('.github/workflows/merge-queue-recovery.yml');
+const postMerge = load('.github/workflows/event-data-deploy-post-merge.yml');
+
+// `on:` is a YAML 1.1 boolean, so some parsers key it as `true`. Accept either.
+const triggersOf = (wf) => wf.on ?? wf[true];
+
+const CONCURRENCY_GROUP = 'stranded-recovery';
+
+describe('merge-queue-recovery triggers (02-§112.16)', () => {
+  const on = triggersOf(recovery);
+
+  it('RECTRIG-01: keeps schedule and workflow_dispatch triggers', () => {
+    assert.ok(on.schedule, 'schedule trigger must remain as the backstop');
+    assert.ok('workflow_dispatch' in on, 'workflow_dispatch must remain');
+  });
+
+  it('RECTRIG-02: runs on check_suite completed', () => {
+    assert.ok(on.check_suite, 'check_suite trigger must be present');
+    assert.deepEqual(on.check_suite.types, ['completed']);
+  });
+});
+
+describe('single-flight concurrency (02-§112.17)', () => {
+  it('RECTRIG-03: scheduled workflow uses the shared group, no cancel-in-progress', () => {
+    assert.equal(recovery.concurrency.group, CONCURRENCY_GROUP);
+    assert.equal(recovery.concurrency['cancel-in-progress'], false);
+  });
+
+  it('RECTRIG-04: post-merge recover job shares the same group, no cancel-in-progress', () => {
+    const job = postMerge.jobs['recover-stranded-event-prs'];
+    assert.ok(job, 'post-merge recover job must exist');
+    assert.equal(job.concurrency.group, CONCURRENCY_GROUP);
+    assert.equal(job.concurrency['cancel-in-progress'], false);
+  });
+});
+
+describe('recovery auth wiring stays intact (02-§112.12)', () => {
+  const tokenOf = (job) => {
+    const step = job.steps.find((s) => s.run && s.run.includes('recover-stranded-event-prs.js'));
+    return step && step.env && step.env.GITHUB_TOKEN;
+  };
+
+  it('RECTRIG-05: both recovery entry points pass EVENT_AUTOMERGE_TOKEN', () => {
+    const expected = '${{ secrets.EVENT_AUTOMERGE_TOKEN }}';
+    assert.equal(tokenOf(recovery.jobs['recover-stranded-event-prs']), expected);
+    assert.equal(tokenOf(postMerge.jobs['recover-stranded-event-prs']), expected);
+  });
+});


### PR DESCRIPTION
## Summary

The stranded-PR recovery sweep (§112) relied on a 15-minute `schedule` cron as its safety net, but GitHub does not deliver scheduled runs reliably — in practice they fire only a few times a day, not every 15 minutes. A PR that becomes mergeable (`CLEAN`) just after a burst's post-merge sweeps then sits stranded until the next sporadic cron delivery. Observed live with #577 (recovered only by a manual dispatch).

This adds an event-driven trigger so recovery runs **at the moment a PR turns mergeable**, instead of waiting on the clock.

### Changes
- **`check_suite: completed` trigger** on `merge-queue-recovery.yml`: a PR strands the instant its required checks finish, so the sweep runs then (02-§112.16). The 15-minute schedule and `workflow_dispatch` are retained as a slow backstop; the post-merge job is unchanged.
- **Single-flight concurrency** (02-§112.17): `merge-queue-recovery.yml` (workflow-level) and the post-merge `recover-stranded-event-prs` job share `concurrency: stranded-recovery` with `cancel-in-progress: false`. Bursts of check-suite completions coalesce into few runs, and `cancel-in-progress: false` guarantees a run that is mid-toggle (auto-merge disabled, not yet re-enabled) is never cancelled — which would otherwise leave a PR with auto-merge off (§112.11).
- No change to `recover-stranded-event-prs.js`; reuses the same script and `EVENT_AUTOMERGE_TOKEN`.
- Requirements 02-§112.16–112.17, architecture notes, and traceability updates.

## Test plan
- [x] `npm test` — 2039 tests pass (incl. new RECTRIG-01..05 in `tests/recovery-trigger-workflow.test.js`)
- [x] `npm run lint` (ESLint) clean
- [x] `npm run lint:md` clean
- [ ] After merge (trigger lives on the default branch): confirm a `check_suite` completion fires a `Merge Queue Recovery` run, and a freshly-stranded event PR is recovered without waiting for the cron (STRAND-M01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYBN9uGWQwQ7x6MaSbzc3G)_