### PR TITLE
Recover stranded PRs on checks-passed, not the laggy mergeable state

### DIFF
--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -936,8 +936,18 @@ stuck in the queue handoff.
 
 - A stranded event pull request is one that is open, whose head branch is named
   `event/*`, `event-edit/*`, or `event-delete/*`, that has auto-merge enabled, whose
-  required status checks all pass, whose mergeable state is clean, and that has no
-  merge-queue entry. <!-- 02-§112.1 -->
+  required status checks have all passed, and that has no merge-queue entry. Its
+  mergeable state may already report clean, or may still be catching up
+  (see §112.18). <!-- 02-§112.1 -->
+- Recovery keys off the status-check rollup, not the mergeable-state status. After a
+  check suite completes, GitHub can take minutes to recompute a pull request's
+  mergeable state to clean, and no further check-suite event follows to re-trigger
+  recovery in that window. Recovery therefore treats an event pull request whose
+  checks have all passed and that is not in the queue as stranded even while its
+  mergeable state still reports `BLOCKED` or `UNKNOWN`; a mergeable state of clean
+  also qualifies. A pull request whose mergeable state reports a real conflict
+  (`DIRTY`) is not recovered, because re-enabling auto-merge cannot resolve a
+  conflict. <!-- 02-§112.18 -->
 - A stranded event pull request is recovered by disabling and then re-enabling
   auto-merge, which registers a fresh merge-queue entry against the current `main`
   so the pull request merges. Re-enabling auto-merge without first disabling it is a

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -251,19 +251,24 @@ when it fails — typically because the required checks are still running — th
 request falls back to auto-merge, and this recovery sweep remains the safety net for
 any pull request that ends up stranded.
 
-**Recovery sweep (02-§112.1–112.6).** `source/scripts/recover-stranded-event-prs.js`
+**Recovery sweep (02-§112.1–112.6, 112.18).** `source/scripts/recover-stranded-event-prs.js`
 is a sibling to `close-redundant-event-prs.js`. It lists the open pull requests on
-`event/*`, `event-edit/*`, and `event-delete/*` branches and, for each, reads three
+`event/*`, `event-edit/*`, and `event-delete/*` branches and, for each, reads four
 GraphQL fields via `gh api graphql`: whether auto-merge is enabled
-(`autoMergeRequest`), the mergeable state (`mergeStateStatus`), and whether it is in
-the queue (`mergeQueueEntry`). A pure, unit-tested classifier
-(`classifyStrandedPr`) decides:
+(`autoMergeRequest`), the mergeable state (`mergeStateStatus`), whether it is in the
+queue (`mergeQueueEntry`), and the head commit's status-check rollup
+(`statusCheckRollup.state`, surfaced as `checksPassed === 'SUCCESS'`). A pure,
+unit-tested classifier (`classifyStrandedPr`) decides:
 
-- `recover` — auto-merge enabled, `mergeStateStatus` is `CLEAN`, and no
-  `mergeQueueEntry`: the pull request is stranded (02-§112.1).
-- `skip` — already has a `mergeQueueEntry` (progressing, 02-§112.4); checks pending
-  or failing so `mergeStateStatus` is not `CLEAN` (02-§112.5); or auto-merge is not
-  enabled.
+- `recover` — auto-merge enabled, not in the queue, and either `mergeStateStatus` is
+  `CLEAN`, or the checks have passed (`checksPassed`) while `mergeStateStatus` is still
+  `BLOCKED`/`UNKNOWN`: the pull request is stranded (02-§112.1, 112.18). Keying off the
+  check rollup rather than `mergeStateStatus` matters because GitHub takes minutes to
+  recompute the mergeable state to `CLEAN` after checks finish, and no further
+  check-suite event fires in that window.
+- `skip` — already has a `mergeQueueEntry` (progressing, 02-§112.4); checks still
+  pending or failing (02-§112.5); a real conflict (`mergeStateStatus` `DIRTY`); or
+  auto-merge is not enabled.
 
 For a `recover` verdict the script calls `disablePullRequestAutoMerge` then
 `enablePullRequestAutoMerge` (mergeMethod `SQUASH`, matching the form API, 02-§112.3).

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1746,7 +1746,7 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
 | `02-§112.16` | covered | RECTRIG-02: `merge-queue-recovery.yml` declares a `check_suite: [completed]` trigger (schedule + workflow_dispatch retained, RECTRIG-01) |
 | `02-§112.17` | covered | RECTRIG-03/-04: scheduled workflow and post-merge job share `concurrency: stranded-recovery` with `cancel-in-progress: false` |
-| `02-§112.18` | gap | `classifyStrandedPr` recovers on `checksPassed` while `mergeStateStatus` is `BLOCKED`/`UNKNOWN`; skips `DIRTY`; `fetchPrState` reads `statusCheckRollup` |
+| `02-§112.18` | covered | STRAND-20/-21 (recover on checksPassed + BLOCKED/UNKNOWN), STRAND-22/-23 (skip pending and DIRTY), STRAND-25 (CLEAN still recovers); `fetchPrState` reads `statusCheckRollup.state` |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1746,6 +1746,7 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
 | `02-§112.16` | covered | RECTRIG-02: `merge-queue-recovery.yml` declares a `check_suite: [completed]` trigger (schedule + workflow_dispatch retained, RECTRIG-01) |
 | `02-§112.17` | covered | RECTRIG-03/-04: scheduled workflow and post-merge job share `concurrency: stranded-recovery` with `cancel-in-progress: false` |
+| `02-§112.18` | gap | `classifyStrandedPr` recovers on `checksPassed` while `mergeStateStatus` is `BLOCKED`/`UNKNOWN`; skips `DIRTY`; `fetchPrState` reads `statusCheckRollup` |
 
 ### §113 — Proactive Merge-Queue Enqueue
 

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -116,7 +116,7 @@ ID ranges.
 
 ---
 
-Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered; stranded-recovery auth + fail-loud 02-§112.12–112.15: 1 covered, 3 implemented; stranded-recovery check-suite trigger + single-flight 02-§112.16–112.17 covered).
+Audit date: 2026-02-24. Last updated: 2026-06-21 (duplicate submission hardening delivered, #480: 02-§111.1–111.9: 7 covered, 2 implemented; split-on-open delivered, #470: 02-§110.1–110.8 covered; fragment-only edit/delete delivered, #467: 02-§109.1–109.26: 22 covered, 4 implemented; config-file QA deploy trigger 02-§108.1–108.4 covered; location availability 02-§107.1–107.8 covered; countdown hidden during ongoing camp delivered, #521: 02-§30.26 covered; stranded-recovery auth + fail-loud 02-§112.12–112.15: 1 covered, 3 implemented; stranded-recovery check-suite trigger + single-flight 02-§112.16–112.17 covered; stranded-recovery rollup-based detection 02-§112.18 covered).
 
 ---
 
@@ -138,8 +138,8 @@ Test IDs referenced in the `Test(s)` column are defined in the
 ## Summary
 
 ```text
-Total requirements:            1424
-Covered (implemented + tested): 765
+Total requirements:            1425
+Covered (implemented + tested): 766
 Implemented, not tested:        659
 Gap (no implementation):          0
 Orphan tests (no requirement):    0
@@ -159,8 +159,8 @@ Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
   submission time (and thus whether the latency goal is actually met) must be
   confirmed against production (#481).
 
-Note: §112 (Stranded Auto-Merge Recovery) adds 17 requirements
-  (02-§112.1–112.17): 8 covered (STRAND-01..19 and RECTRIG-01..05 in
+Note: §112 (Stranded Auto-Merge Recovery) adds 18 requirements
+  (02-§112.1–112.18): 9 covered (STRAND-01..25 and RECTRIG-01..05 in
   tests/stranded-recovery.test.js and tests/recovery-trigger-workflow.test.js)
   and 9 implemented (the GraphQL
   disable→enable toggle, the per-PR isolation and early-exit in main(), the two
@@ -168,7 +168,10 @@ Note: §112 (Stranded Auto-Merge Recovery) adds 17 requirements
   identity, STRAND-M01 manual). A third trigger runs the sweep on check_suite
   completion — the moment a PR turns mergeable — so recovery no longer depends on
   GitHub's unreliable schedule delivery; all triggers share one single-flight
-  concurrency group (02-§112.16–112.17). Event PRs merge through a
+  concurrency group (02-§112.16–112.17). Recovery keys off the status-check rollup
+  rather than the mergeable-state status, which GitHub recomputes minutes later, so a
+  checks-passed PR is recovered at check-suite time even while its mergeable state
+  still reads BLOCKED (02-§112.18). Event PRs merge through a
   required merge queue; when main advances between auto-merge enablement and
   queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
   CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -33,18 +33,30 @@ function isEventBranch(branch) {
  *   mergeStateStatus  – GitHub mergeStateStatus enum (CLEAN, BLOCKED, BEHIND,
  *                       UNSTABLE, DIRTY, DRAFT, HAS_HOOKS, UNKNOWN)
  *   inMergeQueue      – true when the PR has a mergeQueueEntry
+ *   checksPassed      – true when the head commit's status-check rollup is SUCCESS
+ *
+ * Recovery keys off the check rollup, not mergeStateStatus, because GitHub takes
+ * minutes to recompute mergeStateStatus to CLEAN after checks finish and fires no
+ * further check-suite event in that window (02-§112.18). So a checks-passed PR that
+ * is not queued is treated as stranded even while mergeStateStatus still reads
+ * BLOCKED/UNKNOWN. A real conflict (DIRTY) is left alone — re-enabling auto-merge
+ * cannot resolve it.
  *
  * Returns:
  *   'ignore'  – not an event-submission PR
- *   'recover' – stranded: auto-merge on, CLEAN, and not in the queue
- *   'skip'    – event PR that is not stranded (queued, not CLEAN, or auto-merge off)
+ *   'recover' – stranded: auto-merge on, not in the queue, and mergeable (CLEAN) or
+ *               checks-passed while the mergeable state is still catching up
+ *   'skip'    – event PR that is not stranded (queued, checks pending/failing,
+ *               conflicting, or auto-merge off)
  */
-function classifyStrandedPr({ branch, autoMergeEnabled, mergeStateStatus, inMergeQueue } = {}) {
+function classifyStrandedPr({ branch, autoMergeEnabled, mergeStateStatus, inMergeQueue, checksPassed } = {}) {
   if (!isEventBranch(branch)) return 'ignore';
   if (!autoMergeEnabled) return 'skip';      // nothing to recover
   if (inMergeQueue) return 'skip';           // already progressing through the queue
-  if (mergeStateStatus !== 'CLEAN') return 'skip'; // checks pending/failing or not mergeable
-  return 'recover';
+  if (mergeStateStatus === 'CLEAN') return 'recover'; // GitHub already considers it mergeable
+  // Checks are green but the mergeable state has not converged yet (02-§112.18).
+  if (checksPassed && (mergeStateStatus === 'BLOCKED' || mergeStateStatus === 'UNKNOWN')) return 'recover';
+  return 'skip'; // checks pending/failing, conflicting, or otherwise not eligible
 }
 
 function gh(args) {
@@ -85,6 +97,7 @@ function fetchPrState(owner, repo, number) {
           autoMergeRequest { enabledAt }
           mergeStateStatus
           mergeQueueEntry { id }
+          commits(last:1){ nodes { commit { statusCheckRollup { state } } } }
         }
       }
     }`;
@@ -96,11 +109,13 @@ function fetchPrState(owner, repo, number) {
     '-F', `num=${number}`,
   ]);
   const pr = JSON.parse(out).data.repository.pullRequest;
+  const rollup = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state;
   return {
     nodeId: pr.id,
     autoMergeEnabled: pr.autoMergeRequest != null,
     mergeStateStatus: pr.mergeStateStatus,
     inMergeQueue: pr.mergeQueueEntry != null,
+    checksPassed: rollup === 'SUCCESS',
   };
 }
 

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -87,6 +87,54 @@ describe('classifyStrandedPr — stranded auto-merge recovery (02-§112.1–112.
   });
 });
 
+describe('classifyStrandedPr — recover on checks-passed despite laggy mergeable state (02-§112.18)', () => {
+  // GitHub takes minutes to recompute mergeStateStatus to CLEAN after checks finish,
+  // so recovery keys off the check rollup, not the laggy mergeable state.
+  const base = { branch: 'event/2026-06-26-x-1', autoMergeEnabled: true, inMergeQueue: false };
+
+  it('STRAND-20: checks passed, mergeStateStatus still BLOCKED, not queued → recover (the #585 case)', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, mergeStateStatus: 'BLOCKED', checksPassed: true }),
+      'recover',
+    );
+  });
+
+  it('STRAND-21: checks passed, mergeStateStatus still UNKNOWN → recover', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, mergeStateStatus: 'UNKNOWN', checksPassed: true }),
+      'recover',
+    );
+  });
+
+  it('STRAND-22: checks NOT passed and BLOCKED → skip (genuinely pending/failing, 02-§112.5)', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, mergeStateStatus: 'BLOCKED', checksPassed: false }),
+      'skip',
+    );
+  });
+
+  it('STRAND-23: real conflict (DIRTY) is never recovered even with checks passed', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, mergeStateStatus: 'DIRTY', checksPassed: true }),
+      'skip',
+    );
+  });
+
+  it('STRAND-24: checks passed but already in the queue → skip (progressing)', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, inMergeQueue: true, mergeStateStatus: 'BLOCKED', checksPassed: true }),
+      'skip',
+    );
+  });
+
+  it('STRAND-25: CLEAN still recovers without an explicit rollup (backward compatible)', () => {
+    assert.equal(
+      classifyStrandedPr({ ...base, mergeStateStatus: 'CLEAN' }),
+      'recover',
+    );
+  });
+});
+
 describe('withRetry — enable-step resilience (02-§112.11)', () => {
   it('STRAND-11: returns the result on first success without retrying', () => {
     let calls = 0;


### PR DESCRIPTION
## Summary

Live testing of the `check_suite` recovery trigger (#583) surfaced a residual race, reproduced with #585: the trigger fired reliably (four runs), but **all four saw the PR as `mergeStateStatus=BLOCKED`** and skipped. GitHub takes minutes to recompute a PR's mergeable state to `CLEAN` after its checks finish, and no further `check_suite` event fires in that window — so the sweep, which required `mergeStateStatus == CLEAN`, never acted. #585 only merged when recovered manually ~24 min later.

### Timeline (#585)
- 16:32:55 PR opened
- 16:32:57–16:34:19 four `check_suite` recovery runs — all see `BLOCKED` → skip
- ~16:54 mergeable state finally flips to `CLEAN`
- 16:58 recovered by a manual dispatch

### Fix
Key the stranded decision off the **status-check rollup**, not the laggy mergeable state. `classifyStrandedPr` now returns `recover` when auto-merge is on, the PR is not in the queue, and either:
- `mergeStateStatus == CLEAN` (unchanged), or
- the checks have passed (`statusCheckRollup.state == SUCCESS`) while `mergeStateStatus` is still `BLOCKED`/`UNKNOWN`.

A real conflict (`DIRTY`) is still skipped — re-enabling auto-merge cannot resolve it. `fetchPrState` now reads `statusCheckRollup.state`. No change to the toggle, retry, single-flight, or auth logic.

This is what makes the `check_suite` trigger actually bite: the rollup is `SUCCESS` the instant the last suite completes, so recovery acts then instead of waiting on the mergeable state.

## Test plan
- [x] `npm test` — 2045 tests pass (incl. new STRAND-20..25 covering the lag case, conflict skip, and CLEAN backward-compat)
- [x] `npm run lint` (ESLint) clean
- [x] `npm run lint:md` clean
- [ ] After merge: submit an event that strands and confirm the `check_suite` run now recovers it without waiting for cron (STRAND-M01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYBN9uGWQwQ7x6MaSbzc3G)_