### PR TITLE
Lägg tältens färgmarkering i lokalbeskrivningarna

### DIFF
--- a/source/content/locations.md
+++ b/source/content/locations.md
@@ -19,3 +19,17 @@ Kvistbergskolan; Kom ihåg, det tar cirka 15-20 minuter att gå till skolan och 
 ## Lokaler
 
 Alla lokaler och all information om dem är baserat på senaste års läger. Varje år brukar en del justeringar ske. Hur det blir detta året bestäms på plats. Om någon/några har andra förslag på vad olika ytor kan användas till då kan denna information behöva uppdateras. Allt baseras på behov och engagemang det finns detta året. Se nedan som inspiration, och en inblick i vilka faciliteter som finns och hur de ser ut.
+
+### Tältens färger
+
+För att det ska vara lätt att hitta rätt är tälten färgmarkerade:
+
+| Tält | Färg |
+|------|------|
+| Kaffepaviljongen | Blå |
+| Servicetält | Rosa |
+| Heliga Birgittas kapell | Röd |
+| Tält 1 | Gul |
+| Tält 2 | Orange |
+| Rollspelstält 1 | Grön |
+| Rollspelstält 2 | Svart |

--- a/source/content/locations.md
+++ b/source/content/locations.md
@@ -27,8 +27,8 @@ För att det ska vara lätt att hitta rätt är tälten färgmarkerade:
 | Tält | Färg |
 |------|------|
 | Kaffepaviljongen | Blå |
-| Servicetält | Rosa |
-| Heliga Birgittas kapell | Röd |
+| Andreastältet | Rosa |
+| Kaffetältet | Röd |
 | Tält 1 | Gul |
 | Tält 2 | Orange |
 | Rollspelstält 1 | Grön |

--- a/source/content/locations.md
+++ b/source/content/locations.md
@@ -19,17 +19,3 @@ Kvistbergskolan; Kom ihåg, det tar cirka 15-20 minuter att gå till skolan och 
 ## Lokaler
 
 Alla lokaler och all information om dem är baserat på senaste års läger. Varje år brukar en del justeringar ske. Hur det blir detta året bestäms på plats. Om någon/några har andra förslag på vad olika ytor kan användas till då kan denna information behöva uppdateras. Allt baseras på behov och engagemang det finns detta året. Se nedan som inspiration, och en inblick i vilka faciliteter som finns och hur de ser ut.
-
-### Tältens färger
-
-För att det ska vara lätt att hitta rätt är tälten färgmarkerade:
-
-| Tält | Färg |
-|------|------|
-| Kaffepaviljongen | Blå |
-| Andreastältet | Rosa |
-| Kaffetältet | Röd |
-| Tält 1 | Gul |
-| Tält 2 | Orange |
-| Rollspelstält 1 | Grön |
-| Rollspelstält 2 | Svart |

--- a/source/data/local.yaml
+++ b/source/data/local.yaml
@@ -8,7 +8,7 @@
 locations:
   - id: andreas-taltet
     name: AndreasTältet
-    information: ""
+    information: "Ett tips vid uppbyggnad, detta tält är markerat med rosa färg."
     image_path: ""
   - id: annat
     name: Annat
@@ -87,7 +87,7 @@ locations:
       - "images/camping-badplats.webp"
   - id: kaffe-paviljongen
     name: KaffePaviljongen
-    information: "Placerat framför stuga 6, där kaffe och te finns dygnet runt."
+    information: "Placerat framför stuga 6, där kaffe och te finns dygnet runt. Ett tips vid uppbyggnad, denna paviljong är markerad med blå färg."
     image_path: ""
   - id: kaffetalt
     name: Kaffetält
@@ -95,7 +95,7 @@ locations:
       Placerat i gaveln på simhallen. Kaffe och te finns här. Ofta en plats
       för föräldrar att sitta på och prata lite, centralt och tillgängligt.
       Förslagsvis används detta tältet för “föräldrafika” med olika känsliga
-      ämnen.
+      ämnen. Ett tips vid uppbyggnad, detta tält är markerat med röd färg.
     image_path: "images/kaffetalt.webp"
   - id: nerf-arena
     name: Nerf-arena
@@ -107,14 +107,14 @@ locations:
     information: >
       Det finns en hel del rollspel under lägret och för dessa finns det två
       tält. De som spelar rollspel brukar ansvara för att sätta upp och ta ner
-      tälten.
+      tälten. Ett tips vid uppbyggnad, detta tält är markerat med grön färg.
     image_path: "images/rollspelstalt.webp"
   - id: rollspelstalt-2
     name: Rollspelstält2
     information: >
       Det finns en hel del rollspel under lägret och för dessa finns det två
       tält. De som spelar rollspel brukar ansvara för att sätta upp och ta ner
-      tälten.
+      tälten. Ett tips vid uppbyggnad, detta tält är markerat med svart färg.
     image_path: "images/rollspelstalt.webp"
   - id: servicehus
     name: Servicehus
@@ -145,11 +145,11 @@ locations:
       - "images/hemkunskap-2.webp"
   - id: talt-1
     name: Tält1
-    information: "Tält 1 är närmast väggen."
+    information: "Tält 1 är närmast väggen. Ett tips vid uppbyggnad, detta tält är markerat med gul färg."
     image_path: "images/talt-1-och-2.webp"
   - id: talt-2
     name: Tält2
-    information: "Tält 2 är det vi ser mest av på bilden. I mitten."
+    information: "Tält 2 är det vi ser mest av på bilden. I mitten. Ett tips vid uppbyggnad, detta tält är markerat med orange färg."
     image_path: "images/talt-1-och-2.webp"
   - id: talt-3
     name: Tält3

--- a/source/data/local.yaml
+++ b/source/data/local.yaml
@@ -8,7 +8,7 @@
 locations:
   - id: andreas-taltet
     name: AndreasTältet
-    information: "Ett tips vid uppbyggnad, detta tält är markerat med rosa färg."
+    information: "Känns igen på sin rosa färgmarkering."
     image_path: ""
   - id: annat
     name: Annat
@@ -87,7 +87,7 @@ locations:
       - "images/camping-badplats.webp"
   - id: kaffe-paviljongen
     name: KaffePaviljongen
-    information: "Placerat framför stuga 6, där kaffe och te finns dygnet runt. Ett tips vid uppbyggnad, denna paviljong är markerad med blå färg."
+    information: "Placerat framför stuga 6, där kaffe och te finns dygnet runt. Känns igen på sin blå färgmarkering."
     image_path: ""
   - id: kaffetalt
     name: Kaffetält
@@ -95,7 +95,7 @@ locations:
       Placerat i gaveln på simhallen. Kaffe och te finns här. Ofta en plats
       för föräldrar att sitta på och prata lite, centralt och tillgängligt.
       Förslagsvis används detta tältet för “föräldrafika” med olika känsliga
-      ämnen. Ett tips vid uppbyggnad, detta tält är markerat med röd färg.
+      ämnen. Känns igen på sin röda färgmarkering.
     image_path: "images/kaffetalt.webp"
   - id: nerf-arena
     name: Nerf-arena
@@ -107,14 +107,14 @@ locations:
     information: >
       Det finns en hel del rollspel under lägret och för dessa finns det två
       tält. De som spelar rollspel brukar ansvara för att sätta upp och ta ner
-      tälten. Ett tips vid uppbyggnad, detta tält är markerat med grön färg.
+      tälten. Känns igen på sin gröna färgmarkering.
     image_path: "images/rollspelstalt.webp"
   - id: rollspelstalt-2
     name: Rollspelstält2
     information: >
       Det finns en hel del rollspel under lägret och för dessa finns det två
       tält. De som spelar rollspel brukar ansvara för att sätta upp och ta ner
-      tälten. Ett tips vid uppbyggnad, detta tält är markerat med svart färg.
+      tälten. Känns igen på sin svarta färgmarkering.
     image_path: "images/rollspelstalt.webp"
   - id: servicehus
     name: Servicehus
@@ -145,11 +145,11 @@ locations:
       - "images/hemkunskap-2.webp"
   - id: talt-1
     name: Tält1
-    information: "Tält 1 är närmast väggen. Ett tips vid uppbyggnad, detta tält är markerat med gul färg."
+    information: "Tält 1 är närmast väggen. Känns igen på sin gula färgmarkering."
     image_path: "images/talt-1-och-2.webp"
   - id: talt-2
     name: Tält2
-    information: "Tält 2 är det vi ser mest av på bilden. I mitten. Ett tips vid uppbyggnad, detta tält är markerat med orange färg."
+    information: "Tält 2 är det vi ser mest av på bilden. I mitten. Känns igen på sin orange färgmarkering."
     image_path: "images/talt-1-och-2.webp"
   - id: talt-3
     name: Tält3


### PR DESCRIPTION
## Sammanfattning

Issue #520 var ett förslag (från Christina Johansson via feedback-formuläret) om att para ihop tälten med färger. Efter alignment landade vi på en **innehållsändring**: färgmarkeringen står enkom i varje lokals beskrivning i `source/data/local.yaml`, så den visas i tältets eget dragspel under `#lokaler` (och i lokalöversikten). Ingen ny datamodell, ingen färgkodning i schemat.

Varje lokal beskrivs med *"Känns igen på sin [färg] färgmarkering."*:

| Lokal (i local.yaml) | Färg |
|----------------------|------|
| KaffePaviljongen | blå |
| AndreasTältet | rosa |
| Kaffetält | röd |
| Tält1 | gul |
| Tält2 | orange |
| Rollspelstält1 | grön |
| Rollspelstält2 | svart |

Två av Christinas namn mappades till de namn som används i schemat: *Servicetält → AndreasTältet* och *Heliga Birgittas kapell → Kaffetält*. `AndreasTältet` hade tidigare tom beskrivning och har nu fått sin enda mening.

## Testplan

- [x] `local.yaml` parsar som giltig YAML
- [x] `npm test` — alla 2045 tester passerar
- [x] Lint rent
- [ ] Manuell koll i webbläsare: `/index.html#lokaler` — varje tälts dragspel visar färgmeningen

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131TE7Q7njeL6i3gVNKYxR2)_