### PR TITLE
Add EDQ Hub community-app link to hero social row

### DIFF
--- a/docs/02-requirements/design-and-content.md
+++ b/docs/02-requirements/design-and-content.md
@@ -42,12 +42,18 @@ and connects visitors to community channels.
 
 ### 30.4 Social links sidebar
 
-- The sidebar contains two social link icons stacked vertically:
-  a Discord icon and a Facebook icon. <!-- 02-§30.9 -->
+- The sidebar contains three social link icons:
+  a Discord icon, a Facebook icon, and an EDQ Hub icon. <!-- 02-§30.9 -->
 - The Discord icon links to the project Discord channel. <!-- 02-§30.10 -->
 - The Facebook icon links to the camp's Facebook group. <!-- 02-§30.11 -->
 - Icons are displayed at a recognizable size (approximately 64px) and are
   vertically centered within their area of the sidebar. <!-- 02-§30.12 -->
+- The EDQ Hub icon links to the camp's EDQ Hub community app at
+  `https://edqhub.com/join/sb-sommarlager-2026`. <!-- 02-§30.27 -->
+- The EDQ Hub icon appears after the Facebook icon in the social link
+  row. <!-- 02-§30.28 -->
+- Each social link opens in a new browser tab with
+  `rel="noopener noreferrer"`. <!-- 02-§30.29 -->
 
 ### 30.5 Countdown
 
@@ -72,6 +78,8 @@ and connects visitors to community channels.
 - The countdown background color is `#FAF7EF` (a near-white cream), not
   semi-transparent. <!-- 02-§30.23 -->
 - The Discord icon uses the image `discord-ikon.webp`. <!-- 02-§30.24 -->
+- The EDQ Hub icon is an inline SVG rendered as a circular community badge,
+  with an accessible label of "EDQ Hub". <!-- 02-§30.30 -->
 - The sidebar is vertically centered alongside the hero image (not
   top-aligned). <!-- 02-§30.25 -->
 
@@ -83,8 +91,8 @@ and connects visitors to community channels.
   dependency. <!-- 02-§30.20 -->
 - Social icon images are stored in `source/content/images/` and copied
   to `public/images/` at build time. <!-- 02-§30.21 -->
-- The Facebook link and Discord link are provided at build time from
-  configuration, not hardcoded in templates. <!-- 02-§30.22 -->
+- The Facebook link, Discord link, and EDQ Hub link are provided at build
+  time from configuration, not hardcoded in templates. <!-- 02-§30.22 -->
 
 ---
 

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -195,8 +195,8 @@ countdown no longer skips ahead to the next camp mid-camp. A `null` target means
 no countdown element is rendered. The chosen date is embedded as a `data-target`
 attribute on the countdown element.
 
-Social link URLs (Discord and Facebook) are passed from `build.js` based on
-configuration.
+Social link URLs (Discord, Facebook, and EDQ Hub) are passed from `build.js`
+based on configuration.
 
 ### 15.3 Client-side countdown
 
@@ -212,9 +212,16 @@ No external dependencies.
 
 ### 15.4 Social icons
 
-Discord and Facebook SVG/WebP icons are stored in `source/content/images/`.
+Discord and Facebook WebP icons are stored in `source/content/images/`.
 They are rendered as `<a>` elements wrapping `<img>` tags with appropriate
 `alt` text and `target="_blank" rel="noopener noreferrer"`.
+
+The EDQ Hub icon is an inline SVG (a circular community-hub badge) rendered
+directly inside its `<a>` element rather than referencing an image file. Its
+`<a>` carries `aria-label="EDQ Hub"` and the `<svg>` is marked
+`aria-hidden="true"`. The same `.hero-social-link` sizing rule styles both
+`<img>` and inline `<svg>` icons as 32px circular marks. The EDQ Hub link is
+tracked with `data-goatcounter-click="click-edqhub"`.
 
 ### 15.5 CSS
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -328,7 +328,7 @@ Part of [the traceability index](./index.md).
 | `02-§30.6` | Hero image has rounded corners (--radius-lg) | 07-design/css-strategy.md §7 | — (manual: visual check) | `style.css` – `.hero-img { border-radius: var(--radius-lg) }` | implemented |
 | `02-§30.7` | Hero image uses object-fit: cover and is responsive | 07-design/components.md §6 | HERO-05, HERO-06 | `style.css` – `.hero-img { object-fit: cover; width: 100% }` | covered |
 | `02-§30.8` | Image occupies ~2/3 of hero width on desktop | 07-design/components.md §6 | HERO-01 | `style.css` – `.hero { grid-template-columns: 2fr 1fr }` | covered |
-| `02-§30.9` | Sidebar contains Discord, Facebook, and EDQ Hub icons | 03-architecture/pages-and-content.md §15.4 | HERO-09, HERO-19 | `source/build/render-index.js` – `.hero-social` with three `.hero-social-link` | gap |
+| `02-§30.9` | Sidebar contains Discord, Facebook, and EDQ Hub icons | 03-architecture/pages-and-content.md §15.4 | HERO-09, HERO-19 | `source/build/render-index.js` – `.hero-social` with three `.hero-social-link` | covered |
 | `02-§30.10` | Discord icon links to Discord channel | 03-architecture/pages-and-content.md §15.4 | HERO-07 | `source/build/render-index.js` – `<a href="${discordUrl}">` | covered |
 | `02-§30.11` | Facebook icon links to Facebook group | 03-architecture/pages-and-content.md §15.4 | HERO-08 | `source/build/render-index.js` – `<a href="${facebookUrl}">` | covered |
 | `02-§30.12` | Icons displayed at ~64px, vertically centered | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero-social-link img { width: 64px; height: 64px }` | implemented |
@@ -346,10 +346,10 @@ Part of [the traceability index](./index.md).
 | `02-§30.24` | Discord icon uses `discord-ikon.webp` | 03-architecture/pages-and-content.md §15.4 | HERO-16 | `render-index.js` – `discord-ikon.webp` in Discord link `<img>` | covered |
 | `02-§30.25` | Sidebar vertically centered alongside hero image | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero { align-items: center }` | implemented |
 | `02-§30.26` | Countdown not displayed while a camp is ongoing (today within start..end) | 03-architecture/pages-and-content.md §15.2 | CDOWN-03..07 | `source/build/utils.js` – `resolveCountdownTarget` returns null when ongoing | covered |
-| `02-§30.27` | EDQ Hub icon links to the EDQ Hub community app | 03-architecture/pages-and-content.md §15.4 | HERO-17 | `source/build/render-index.js` – `<a href="${edqhubUrl}">` | gap |
-| `02-§30.28` | EDQ Hub icon appears after the Facebook icon | 03-architecture/pages-and-content.md §15.4 | HERO-19 | `source/build/render-index.js` – EDQ Hub block follows Facebook block | gap |
-| `02-§30.29` | Each social link opens in a new tab with `rel="noopener noreferrer"` | 03-architecture/pages-and-content.md §15.4 | HERO-20 | `source/build/render-index.js` – `target="_blank" rel="noopener noreferrer"` | gap |
-| `02-§30.30` | EDQ Hub icon is an inline-SVG circular badge with accessible label | 03-architecture/pages-and-content.md §15.4 | HERO-18 | `source/build/render-index.js` – inline `<svg>` + `aria-label="EDQ Hub"` | gap |
+| `02-§30.27` | EDQ Hub icon links to the EDQ Hub community app | 03-architecture/pages-and-content.md §15.4 | HERO-17 | `source/build/render-index.js` – `<a href="${edqhubUrl}">` | covered |
+| `02-§30.28` | EDQ Hub icon appears after the Facebook icon | 03-architecture/pages-and-content.md §15.4 | HERO-19 | `source/build/render-index.js` – EDQ Hub block follows Facebook block | covered |
+| `02-§30.29` | Each social link opens in a new tab with `rel="noopener noreferrer"` | 03-architecture/pages-and-content.md §15.4 | HERO-20 | `source/build/render-index.js` – `target="_blank" rel="noopener noreferrer"` | covered |
+| `02-§30.30` | EDQ Hub icon is an inline-SVG circular badge with accessible label | 03-architecture/pages-and-content.md §15.4 | HERO-18 | `source/build/render-index.js` – inline `<svg>` + `aria-label="EDQ Hub"` | covered |
 
 ### 31. Inline Camp Listing and Link Styling
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -328,7 +328,7 @@ Part of [the traceability index](./index.md).
 | `02-§30.6` | Hero image has rounded corners (--radius-lg) | 07-design/css-strategy.md §7 | — (manual: visual check) | `style.css` – `.hero-img { border-radius: var(--radius-lg) }` | implemented |
 | `02-§30.7` | Hero image uses object-fit: cover and is responsive | 07-design/components.md §6 | HERO-05, HERO-06 | `style.css` – `.hero-img { object-fit: cover; width: 100% }` | covered |
 | `02-§30.8` | Image occupies ~2/3 of hero width on desktop | 07-design/components.md §6 | HERO-01 | `style.css` – `.hero { grid-template-columns: 2fr 1fr }` | covered |
-| `02-§30.9` | Sidebar contains Discord and Facebook icons stacked vertically | 03-architecture/pages-and-content.md §15.4 | HERO-09 | `source/build/render-index.js` – `.hero-sidebar` with two `.hero-social-link` | covered |
+| `02-§30.9` | Sidebar contains Discord, Facebook, and EDQ Hub icons | 03-architecture/pages-and-content.md §15.4 | HERO-09, HERO-19 | `source/build/render-index.js` – `.hero-social` with three `.hero-social-link` | gap |
 | `02-§30.10` | Discord icon links to Discord channel | 03-architecture/pages-and-content.md §15.4 | HERO-07 | `source/build/render-index.js` – `<a href="${discordUrl}">` | covered |
 | `02-§30.11` | Facebook icon links to Facebook group | 03-architecture/pages-and-content.md §15.4 | HERO-08 | `source/build/render-index.js` – `<a href="${facebookUrl}">` | covered |
 | `02-§30.12` | Icons displayed at ~64px, vertically centered | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero-social-link img { width: 64px; height: 64px }` | implemented |
@@ -346,6 +346,10 @@ Part of [the traceability index](./index.md).
 | `02-§30.24` | Discord icon uses `discord-ikon.webp` | 03-architecture/pages-and-content.md §15.4 | HERO-16 | `render-index.js` – `discord-ikon.webp` in Discord link `<img>` | covered |
 | `02-§30.25` | Sidebar vertically centered alongside hero image | 07-design/components.md §6 | — (manual: visual check) | `style.css` – `.hero { align-items: center }` | implemented |
 | `02-§30.26` | Countdown not displayed while a camp is ongoing (today within start..end) | 03-architecture/pages-and-content.md §15.2 | CDOWN-03..07 | `source/build/utils.js` – `resolveCountdownTarget` returns null when ongoing | covered |
+| `02-§30.27` | EDQ Hub icon links to the EDQ Hub community app | 03-architecture/pages-and-content.md §15.4 | HERO-17 | `source/build/render-index.js` – `<a href="${edqhubUrl}">` | gap |
+| `02-§30.28` | EDQ Hub icon appears after the Facebook icon | 03-architecture/pages-and-content.md §15.4 | HERO-19 | `source/build/render-index.js` – EDQ Hub block follows Facebook block | gap |
+| `02-§30.29` | Each social link opens in a new tab with `rel="noopener noreferrer"` | 03-architecture/pages-and-content.md §15.4 | HERO-20 | `source/build/render-index.js` – `target="_blank" rel="noopener noreferrer"` | gap |
+| `02-§30.30` | EDQ Hub icon is an inline-SVG circular badge with accessible label | 03-architecture/pages-and-content.md §15.4 | HERO-18 | `source/build/render-index.js` – inline `<svg>` + `aria-label="EDQ Hub"` | gap |
 
 ### 31. Inline Camp Listing and Link Styling
 
@@ -828,7 +832,7 @@ Part of [the traceability index](./index.md).
 | `02-§63.34` | No personal data collected | 03-architecture/pages-and-content.md §23.1 | — | GoatCounter built-in | implemented |
 | `02-§63.35` | No cookie consent banner needed | 03-architecture/pages-and-content.md §23.1 | — | GoatCounter built-in | implemented |
 | `02-§63.36` | No wrapper JS libraries | 03-architecture/pages-and-content.md §23.3 | — | convention | implemented |
-| `02-§63.37` | Use data-goatcounter-click attrs | 03-architecture/pages-and-content.md §23.3 | ANA-EVT-01..06 | `source/build/render-index.js`, `render.js` | covered |
+| `02-§63.37` | Use data-goatcounter-click attrs | 03-architecture/pages-and-content.md §23.3 | ANA-EVT-01..07 | `source/build/render-index.js`, `render.js` | covered |
 | `02-§63.38` | All deploy workflows pass GOATCOUNTER_SITE_CODE | 03-architecture/pages-and-content.md §23.2 | manual: add event, verify script on schema.html | `.github/workflows/event-data-deploy-post-merge.yml`, `deploy-reusable.yml` | implemented |
 
 ---

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -204,7 +204,9 @@ h3 {
   opacity: 1;
 }
 
-.hero-social-link img {
+.hero-social-link img,
+.hero-social-link svg {
+  display: block;
   width: 32px;
   height: 32px;
   border-radius: var(--radius-full);

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -349,6 +349,7 @@ async function main() {
 
   // ── Compute hero social links and countdown target ────────────────────────
   const discordUrl = 'https://discord.com/channels/992817044527534181/1390691617052037232';
+  const edqhubUrl = 'https://edqhub.com/join/sb-sommarlager-2026';
 
   // Countdown: count down to the nearest upcoming camp, but stay hidden while a
   // camp is ongoing so it never counts toward a later camp mid-camp (#521).
@@ -386,7 +387,7 @@ async function main() {
     }));
 
   const heroDims = heroSrc ? getImageDimensions(path.join(CONTENT_DIR, heroSrc)) : null;
-  const indexHtml = renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerWithVersion, navSections, GOATCOUNTER_CODE);
+  const indexHtml = renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, edqhubUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerWithVersion, navSections, GOATCOUNTER_CODE);
   fs.writeFileSync(path.join(OUTPUT_DIR, 'index.html'), indexHtml, 'utf8');
   console.log(`Built: public/index.html  (${sections.length} sections)`);
 

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -161,22 +161,35 @@ function convertMarkdown(input, headingOffset = 0, collapsible = false, contentD
  * @param {string|null} opts.heroAlt  - alt text for hero image
  * @param {string|null} opts.discordUrl  - URL for Discord link
  * @param {string|null} opts.facebookUrl - URL for Facebook link
+ * @param {string|null} opts.edqhubUrl   - URL for EDQ Hub community-app link
  * @param {string|null} opts.countdownTarget - YYYY-MM-DD date for countdown
  * @param {string|null} opts.opensForEditing - YYYY-MM-DD first editing date
  * @param {string|null} opts.editingCloses  - YYYY-MM-DD last editing date (end_date + 1)
  * @param {Array<{id: string, navLabel: string, html: string}>} opts.sections
  * @param {Array<{id: string, name: string, registrationOpens: string, registrationCloses: string}>} [opts.registrationCamps]
  */
-function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerHtml = '', navSections = [], goatcounterCode = '') {
+function renderIndexPage({ heroSrc, heroAlt, heroDims, sections, discordUrl, facebookUrl, edqhubUrl, countdownTarget, opensForEditing, editingCloses, registrationCamps }, footerHtml = '', navSections = [], goatcounterCode = '') {
   const countdownHtml = countdownTarget
     ? `<div class="hero-countdown" data-target="${countdownTarget}">\n        <span class="hero-countdown-number">00</span>\n        <span class="hero-countdown-label">Dagar kvar</span>\n      </div>`
     : '';
 
-  const socialLinks = (discordUrl || facebookUrl)
+  // EDQ Hub has no brand image asset in the repo, so its icon is an inline SVG:
+  // a circular navy badge with a white "hub" glyph (central node linked to three
+  // satellite nodes) signalling a community hub. Sized and shaped to match the
+  // raster Discord/Facebook icons beside it.
+  const edqhubIcon = '<svg viewBox="0 0 32 32" width="32" height="32" fill="none" aria-hidden="true">'
+    + '<circle cx="16" cy="16" r="16" fill="#192A3D"/>'
+    + '<g stroke="#FFFFFF" stroke-width="1.6"><line x1="16" y1="16" x2="16" y2="8"/><line x1="16" y1="16" x2="9" y2="22"/><line x1="16" y1="16" x2="23" y2="22"/></g>'
+    + '<g fill="#FFFFFF"><circle cx="16" cy="16" r="3.2"/><circle cx="16" cy="8" r="2.4"/><circle cx="9" cy="22" r="2.4"/><circle cx="23" cy="22" r="2.4"/></g>'
+    + '</svg>';
+
+  const socialLinks = (discordUrl || facebookUrl || edqhubUrl)
     ? `\n    <div class="hero-social">${
       discordUrl ? `\n      <a href="${discordUrl}" class="hero-social-link" target="_blank" rel="noopener noreferrer" data-goatcounter-click="click-discord">\n        <img src="images/discord-ikon.webp" alt="Discord" width="32" height="32">\n      </a>` : ''
     }${
       facebookUrl ? `\n      <a href="${facebookUrl}" class="hero-social-link" target="_blank" rel="noopener noreferrer" data-goatcounter-click="click-facebook">\n        <img src="images/facebook-ikon.webp" alt="Facebook" width="32" height="32">\n      </a>` : ''
+    }${
+      edqhubUrl ? `\n      <a href="${edqhubUrl}" class="hero-social-link" target="_blank" rel="noopener noreferrer" aria-label="EDQ Hub" data-goatcounter-click="click-edqhub">\n        ${edqhubIcon}\n      </a>` : ''
     }\n    </div>`
     : '';
 

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -36,6 +36,7 @@ const INDEX_PAGE = {
   heroAlt: 'Camp view',
   discordUrl: null,
   facebookUrl: null,
+  edqhubUrl: null,
   countdownTarget: null,
   sections: [{ id: 'start', navLabel: 'Start', html: '<p>Intro</p>' }],
 };
@@ -187,6 +188,14 @@ describe('02-§63.37 — Custom events use data-goatcounter-click', () => {
       '', [], GC_CODE,
     );
     assert.ok(page.includes('data-goatcounter-click="click-facebook"'), 'Facebook link tracked');
+  });
+
+  it('ANA-EVT-07: EDQ Hub link has data-goatcounter-click', () => {
+    const page = renderIndexPage(
+      { ...INDEX_PAGE, edqhubUrl: 'https://edqhub.com/join/test' },
+      '', [], GC_CODE,
+    );
+    assert.ok(page.includes('data-goatcounter-click="click-edqhub"'), 'EDQ Hub link tracked');
   });
 });
 

--- a/tests/hero.test.js
+++ b/tests/hero.test.js
@@ -16,6 +16,7 @@ function buildPage(heroOpts = {}) {
     sections: [{ id: 'start', navLabel: 'Om lägret', html: '<p>Intro</p>' }],
     discordUrl: heroOpts.discordUrl ?? 'https://discord.com/channels/123/456',
     facebookUrl: heroOpts.facebookUrl ?? 'https://www.facebook.com/groups/test',
+    edqhubUrl: heroOpts.edqhubUrl ?? 'https://edqhub.com/join/sb-sommarlager-2026',
     countdownTarget: heroOpts.countdownTarget ?? '2026-06-21',
   };
 }
@@ -148,6 +149,44 @@ describe('hero section – Discord icon image (02-§30.24)', () => {
       html.includes('src="images/discord-ikon.webp"'),
       `Expected discord-ikon.webp, got: ${html.match(/<img[^>]*Discord[^>]*>/)?.[0] || 'no match'}`,
     );
+  });
+});
+
+// ── EDQ Hub link (02-§30.9, 30.27–30.30) ────────────────────────────────────
+
+describe('hero section – EDQ Hub link (02-§30.27–30.30)', () => {
+  it('HERO-17: renders an EDQ Hub link with the provided URL', () => {
+    const html = renderIndexPage(buildPage({ edqhubUrl: 'https://edqhub.com/join/test-camp' }));
+    assert.ok(
+      html.includes('href="https://edqhub.com/join/test-camp"'),
+      'Expected EDQ Hub link href',
+    );
+  });
+
+  it('HERO-18: EDQ Hub link uses an inline SVG icon and an accessible label', () => {
+    const html = renderIndexPage(buildPage());
+    const linkMatch = html.match(/<a[^>]*data-goatcounter-click="click-edqhub"[^>]*>[\s\S]*?<\/a>/);
+    assert.ok(linkMatch, 'Expected an EDQ Hub social link');
+    assert.ok(linkMatch[0].includes('aria-label="EDQ Hub"'), `Expected aria-label, got: ${linkMatch[0]}`);
+    assert.ok(linkMatch[0].includes('<svg'), `Expected inline SVG icon, got: ${linkMatch[0]}`);
+    assert.ok(linkMatch[0].includes('aria-hidden="true"'), `Expected aria-hidden on svg, got: ${linkMatch[0]}`);
+  });
+
+  it('HERO-19: renders three social links with EDQ Hub after Facebook', () => {
+    const html = renderIndexPage(buildPage());
+    const socialLinks = html.match(/<a[^>]*class="hero-social-link"[^>]*>/g) || [];
+    assert.equal(socialLinks.length, 3, `Expected 3 social links, got ${socialLinks.length}`);
+    const fbPos = html.indexOf('click-facebook');
+    const edqPos = html.indexOf('click-edqhub');
+    assert.ok(fbPos !== -1 && edqPos !== -1 && edqPos > fbPos, 'Expected EDQ Hub link after Facebook');
+  });
+
+  it('HERO-20: EDQ Hub link opens in a new tab with noopener noreferrer', () => {
+    const html = renderIndexPage(buildPage());
+    const linkMatch = html.match(/<a[^>]*data-goatcounter-click="click-edqhub"[^>]*>/);
+    assert.ok(linkMatch, 'Expected an EDQ Hub social link');
+    assert.ok(linkMatch[0].includes('target="_blank"'), `Expected target="_blank", got: ${linkMatch[0]}`);
+    assert.ok(linkMatch[0].includes('rel="noopener noreferrer"'), `Expected rel, got: ${linkMatch[0]}`);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a third social link in the hero row — **EDQ Hub** — alongside the existing Discord and Facebook icons (issue #602: "Likt discord och facebook. Även en länk hit.").
- Links to `https://edqhub.com/join/sb-sommarlager-2026` (the `?fbclid=…` tracking param from the issue is stripped). URL is hardcoded in `build.js`, the same way the Discord URL is.
- The icon is an **inline SVG** I designed: a circular navy badge (`#192A3D`, matching the `--color-navy` token) with a white "hub" glyph (central node linked to three satellite nodes). Inline SVG was chosen because EDQ Hub has no brand image asset in the repo and this environment has no image rasterizer; it follows the repo's existing inline-SVG icon pattern (`layout.js`).
- Link opens in a new tab (`rel="noopener noreferrer"`), carries `aria-label="EDQ Hub"` with `aria-hidden` on the SVG, and is tracked via `data-goatcounter-click="click-edqhub"`.

## Changes

- **Requirements**: `docs/02-requirements/design-and-content.md` (02-§30.9, .22, .27–.30)
- **Architecture + traceability**: `docs/03-architecture/pages-and-content.md` §15.4; `docs/99-traceability/02-requirements.md`
- **Tests**: `tests/hero.test.js` (HERO-17–20), `tests/analytics.test.js` (ANA-EVT-07)
- **Implementation**: `source/build/render-index.js`, `source/build/build.js`, `source/assets/cs/style.css`

## Test plan

- [x] `npm test` — 2050/2050 pass
- [x] `npm run lint` (JS), `lint:css`, `lint:md`
- [x] `npm run lint:html` on built output (validates the inline SVG)
- [x] Built `index.html`: EDQ Hub link present, third in order, no `fbclid`, correct `aria-label` and tracking attr
- [ ] Manual: open `/` in a browser and confirm the badge sits well beside Discord/Facebook (not possible in the remote env)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019HYSGujqhZkoU7sqPR9q91)_