### PR TITLE
Add quick-add activity button to sticky navigation

### DIFF
--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -18,7 +18,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 
 | File | Topic | Sections |
 | ---- | ----- | -------- |
-| [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79 |
+| [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79, §114 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111, §112 |

--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -460,3 +460,42 @@ the `<section id="…">` attribute and the `href="#…"` in navigation links.
 
 - The navigation link for "Röster" must point to `#roster`. <!-- 02-§79.3 -->
 - The navigation link for "Kostnader" must point to `#kostnader`. <!-- 02-§79.4 -->
+
+---
+
+---
+
+## 114. Quick-Add Activity Button in Sticky Navigation
+
+### Context
+
+On long pages such as the schedule, reaching "Lägg till aktivitet" requires
+opening the hamburger menu and scrolling within it. A one-tap quick-add button
+in the always-visible sticky navigation lets a participant start adding an
+activity from anywhere on the site without opening the menu.
+
+### 114.1 User requirements
+
+- A visitor on a mobile viewport sees a "+" button in the sticky top
+  navigation that takes them directly to the add-activity page. <!-- 02-§114.1 -->
+- The button is reachable without opening the hamburger menu, on every page
+  except the add-activity page itself. <!-- 02-§114.2 -->
+
+### 114.2 Site requirements
+
+- The shared navigation renders a quick-add button as an `<a>` element linking
+  to `lagg-till.html`, with `aria-label="Lägg till aktivitet"`. <!-- 02-§114.3 -->
+- The quick-add button appears on every page except `lagg-till.html`, where it
+  is omitted. <!-- 02-§114.4 -->
+- The quick-add button is visible only on mobile viewports (≤ 767 px). On
+  desktop it is not displayed, because the "Lägg till" page link is always
+  visible in the navigation bar. <!-- 02-§114.5 -->
+- The quick-add button is a child of `<nav class="page-nav">`, positioned in
+  the row of floating action buttons between the centred scroll-to-top button
+  and the feedback button. <!-- 02-§114.6 -->
+- The quick-add button matches the other floating action buttons in size
+  (42 × 42 px), terracotta background, white icon, and
+  `var(--radius-md)` border-radius. <!-- 02-§114.7 -->
+- The quick-add button displays a plus (+) icon. <!-- 02-§114.8 -->
+- The PWA-install button is positioned to the left of the quick-add button so
+  the two buttons never overlap. <!-- 02-§114.9 -->

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -97,6 +97,29 @@ mode — no visible jump. The background pseudo-element covers the full area.
 `html` has `scroll-padding-top` set to the approximate nav height so that
 anchor targets are not obscured by the sticky bar.
 
+### 12.7 Quick-add activity button (02-§114)
+
+`pageNav()` renders a quick-add button as an `<a class="quick-add-btn"
+href="lagg-till.html" aria-label="Lägg till aktivitet">` element containing an
+inline SVG plus icon. The button is a direct child of `<nav class="page-nav">`,
+rendered alongside the feedback, install, and scroll-to-top buttons.
+
+`pageNav(activeHref, …)` omits the button entirely when `activeHref ===
+'lagg-till.html'`, so it never appears on the add-activity page itself.
+
+The button is mobile-only. Its `display` is `none` by default and `flex` inside
+the `@media (max-width: 767px)` block — the same pattern as `.scroll-top` and
+`.pwa-install-btn`. On desktop the "Lägg till" page link is always visible in
+the nav bar, so no desktop button is needed.
+
+It shares the 42 × 42 px terracotta pill styling of the other floating action
+buttons and is positioned with `position: fixed; top: var(--space-xs)` in the
+slot between the centred scroll-to-top button and the right-aligned feedback
+button (`right: calc(var(--space-sm) + 42px + var(--space-xs))`). The
+`.pwa-install-btn` moves one slot further left
+(`right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`) so the two
+never overlap. The button needs no client-side script — it is a plain link.
+
 ---
 
 ## 14. Upcoming Camps Section on Homepage

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -120,6 +120,13 @@ button (`right: calc(var(--space-sm) + 42px + var(--space-xs))`). The
 (`right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`) so the two
 never overlap. The button needs no client-side script — it is a plain link.
 
+The install button keeps that fixed slot on `lagg-till.html` even though the
+quick-add button is absent there, so an empty slot can sit between it and the
+feedback button. This is intentional: the install button is hidden unless the
+browser fires `beforeinstallprompt`, so the gap is only ever visible in the
+rare case the app is installable while the user is on the add page — not worth
+page-specific positioning rules.
+
 ---
 
 ## 14. Upcoming Camps Section on Homepage

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -44,6 +44,18 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
 - `html` has `scroll-padding-top` set to account for the sticky navigation
   height, so anchor-link targets are not hidden behind the bar. <!-- 07-§6.25-impl -->
 
+### Quick-add activity button (mobile)
+
+- A `+` quick-add button (`.quick-add-btn`) sits in the row of floating
+  action buttons in the sticky navigation, linking to the add-activity
+  page. <!-- 07-§6.125 -->
+- Mobile only (`≤ 767px`): `42 × 42px`, `background: var(--color-terracotta)`,
+  white plus icon, `border-radius: var(--radius-md)` — matching the
+  scroll-to-top and PWA-install buttons. Hidden on desktop. <!-- 07-§6.126 -->
+- Positioned between the centred scroll-to-top button and the right-aligned
+  feedback button; the PWA-install button shifts one slot left so the
+  buttons never overlap. <!-- 07-§6.127 -->
+
 ### Hero Section
 
 - Two-column layout on desktop: image area (~2/3) and sidebar panel (~1/3).

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1778,12 +1778,12 @@ Doc ref: `02-requirements/pages-navigation.md §114`;
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§114.1` | gap | Mobile sticky nav shows a `+` link to the add-activity page |
-| `02-§114.2` | gap | Reachable without opening the hamburger menu; omitted only on `lagg-till.html` |
-| `02-§114.3` | gap | `pageNav()` renders `<a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">` |
-| `02-§114.4` | gap | Button omitted when `activeHref === 'lagg-till.html'` |
-| `02-§114.5` | gap | Mobile-only: `display: none` by default, `flex` inside `@media (max-width: 767px)` |
-| `02-§114.6` | gap | Child of `.page-nav`, positioned between scroll-to-top and feedback buttons |
-| `02-§114.7` | gap | 42 × 42 px, terracotta background, white icon, `var(--radius-md)` border-radius |
-| `02-§114.8` | gap | Inline SVG plus (+) icon |
-| `02-§114.9` | gap | `.pwa-install-btn` shifts one slot left so the buttons never overlap |
+| `02-§114.1` | covered | QADD-05/-08 confirm the button (a `lagg-till.html` link) renders on every non-add page; `layout.js` `pageNav()`. Mobile-only visibility is manual checkpoint (open schema.html at ≤767 px) |
+| `02-§114.2` | covered | QADD-07: the button is rendered before (outside) `.nav-menu`, so it is reachable without opening the hamburger; `layout.js` `pageNav()` |
+| `02-§114.3` | covered | QADD-01/-02/-03: `<a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">`; `source/build/layout.js` |
+| `02-§114.4` | covered | QADD-06/-09: omitted when `activeHref === 'lagg-till.html'`; `source/build/layout.js` |
+| `02-§114.5` | covered | QADD-10/-11: `.quick-add-btn { display: none }` by default, `display: flex` inside `@media (max-width: 767px)`; `source/assets/cs/style.css`. Desktop absence is manual checkpoint |
+| `02-§114.6` | covered | QADD-12: `right: calc(var(--space-sm) + 42px + var(--space-xs))` between scroll-top and feedback; `source/assets/cs/style.css`. Visual placement is manual checkpoint |
+| `02-§114.7` | covered | QADD-11: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
+| `02-§114.8` | covered | QADD-04: inline SVG plus icon inside the anchor; `source/build/layout.js` |
+| `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`; `source/assets/cs/style.css` |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1769,3 +1769,21 @@ Doc ref: `02-requirements/event-data.md §113`;
 | `02-§113.7` | covered | ENQ-07: the enqueue step is contained so the submission outcome is unchanged whether enqueue succeeds or fails |
 | `02-§113.8` | covered | Recovery (`recover-stranded-event-prs.js`, §112) is untouched; STRAND-01..13 still pass. A proactively enqueued PR has a `mergeQueueEntry`, so `classifyStrandedPr` returns `skip` (STRAND-04) and recovery still catches any PR that later falls out of the queue |
 | `02-§113.9` | covered | The event-data validation gate (`check-yaml-security.js`, `lint-yaml.js`) and API-layer validation are unchanged; YSEC/validation tests still pass. Enqueue only changes when a PR enters the queue, not whether its required checks run |
+
+### §114 — Quick-Add Activity Button in Sticky Navigation
+
+Doc ref: `02-requirements/pages-navigation.md §114`;
+`03-architecture/pages-and-content.md §12.7` (Quick-add activity button);
+`07-design/components.md §6.125–6.127` (Quick-add activity button design).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§114.1` | gap | Mobile sticky nav shows a `+` link to the add-activity page |
+| `02-§114.2` | gap | Reachable without opening the hamburger menu; omitted only on `lagg-till.html` |
+| `02-§114.3` | gap | `pageNav()` renders `<a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">` |
+| `02-§114.4` | gap | Button omitted when `activeHref === 'lagg-till.html'` |
+| `02-§114.5` | gap | Mobile-only: `display: none` by default, `flex` inside `@media (max-width: 767px)` |
+| `02-§114.6` | gap | Child of `.page-nav`, positioned between scroll-to-top and feedback buttons |
+| `02-§114.7` | gap | 42 × 42 px, terracotta background, white icon, `var(--radius-md)` border-radius |
+| `02-§114.8` | gap | Inline SVG plus (+) icon |
+| `02-§114.9` | gap | `.pwa-install-btn` shifts one slot left so the buttons never overlap |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2656,7 +2656,7 @@ body.modal-open {
     justify-content: center;
     position: fixed;
     top: var(--space-xs);
-    right: calc(var(--space-sm) + 42px + var(--space-xs));
+    right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)));
     width: 42px;
     height: 42px;
     background: var(--color-terracotta);
@@ -2705,6 +2705,39 @@ body.modal-open {
 
   .pwa-install-btn:focus-visible {
     outline: 2px solid var(--color-terracotta);
+    outline-offset: 2px;
+  }
+}
+
+/* ── Quick-add activity button (02-§114) ── */
+
+.quick-add-btn {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .quick-add-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: var(--space-xs);
+    right: calc(var(--space-sm) + 42px + var(--space-xs));
+    width: 42px;
+    height: 42px;
+    background: var(--color-terracotta);
+    color: var(--color-white);
+    border-radius: var(--radius-md);
+    line-height: 0;
+    z-index: 201;
+  }
+
+  .quick-add-btn:hover {
+    background: var(--color-sage-hover);
+  }
+
+  .quick-add-btn:focus-visible {
+    outline: 2px solid var(--color-white);
     outline-offset: 2px;
   }
 }

--- a/source/build/layout.js
+++ b/source/build/layout.js
@@ -55,6 +55,17 @@ function pageNav(activeHref, navSections = []) {
       </svg>
     </button>`;
 
+  // Quick-add activity button — a one-tap link to the add-activity page in the
+  // sticky nav. Omitted on the add page itself, where it would be redundant.
+  const quickAddBtn = activeHref === 'lagg-till.html'
+    ? ''
+    : `    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet" data-goatcounter-click="quick-add-aktivitet">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+        <line x1="12" y1="5" x2="12" y2="19"/>
+        <line x1="5" y1="12" x2="19" y2="12"/>
+      </svg>
+    </a>\n`;
+
   const installBtn = `    <button type="button" class="pwa-install-btn" aria-label="Installera appen" hidden>
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -71,7 +82,7 @@ function pageNav(activeHref, navSections = []) {
       <span class="nav-toggle-bar"></span>
     </button>
     <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
-${installBtn}
+${quickAddBtn}${installBtn}
 ${feedbackBtn}
     <div class="nav-menu" id="nav-menu">
       <div class="nav-pages">

--- a/source/build/layout.js
+++ b/source/build/layout.js
@@ -59,7 +59,7 @@ function pageNav(activeHref, navSections = []) {
   // sticky nav. Omitted on the add page itself, where it would be redundant.
   const quickAddBtn = activeHref === 'lagg-till.html'
     ? ''
-    : `    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet" data-goatcounter-click="quick-add-aktivitet">
+    : `    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
         <line x1="12" y1="5" x2="12" y2="19"/>
         <line x1="5" y1="12" x2="19" y2="12"/>

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -22,6 +22,12 @@
       <span class="nav-toggle-bar"></span>
     </button>
     <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
+    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet" data-goatcounter-click="quick-add-aktivitet">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+        <line x1="12" y1="5" x2="12" y2="19"/>
+        <line x1="5" y1="12" x2="19" y2="12"/>
+      </svg>
+    </a>
     <button type="button" class="pwa-install-btn" aria-label="Installera appen" hidden>
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -22,7 +22,7 @@
       <span class="nav-toggle-bar"></span>
     </button>
     <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
-    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet" data-goatcounter-click="quick-add-aktivitet">
+    <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
         <line x1="12" y1="5" x2="12" y2="19"/>
         <line x1="5" y1="12" x2="19" y2="12"/>

--- a/tests/quick-add-button.test.js
+++ b/tests/quick-add-button.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+// Tests for the quick-add activity button in the sticky navigation – 02-§114.
+//
+// The button's mobile-only visibility and exact on-screen placement
+// (CSS media queries, fixed positioning) cannot be fully verified in
+// Node.js. The string-level CSS checks below confirm the rules exist;
+// the visual result is a manual checkpoint:
+//   Manual checkpoint (02-§114.1, §114.5, §114.6): open any page other than
+//   lagg-till.html on a ≤767 px viewport and confirm the "+" button appears
+//   in the top bar, between the centred up-arrow and the feedback button,
+//   and tapping it opens the add-activity page. On a ≥768 px viewport the
+//   "+" button is absent.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { pageNav } = require('../source/build/layout');
+const { renderSchedulePage } = require('../source/build/render');
+const { renderAddPage } = require('../source/build/render-add');
+const { renderIdagPage } = require('../source/build/render-idag');
+const { renderIndexPage } = require('../source/build/render-index');
+const { renderArkivPage } = require('../source/build/render-arkiv');
+
+const CSS = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'assets', 'cs', 'style.css'),
+  'utf8',
+);
+
+const CAMP = { name: 'SB Sommar 2026', start_date: '2026-06-28', end_date: '2026-07-05' };
+const EVENTS = [];
+const LOCATIONS = ['Servicehus', 'Annat'];
+const API_URL = 'https://api.example.com/add-event';
+const SECTIONS = [{ id: 'start', navLabel: 'Om lägret' }];
+
+// Extract the quick-add button element from pageNav output for focused checks.
+function quickAddEl(html) {
+  return html.match(/<a class="quick-add-btn"[\s\S]*?<\/a>/)?.[0] || '';
+}
+
+// ── pageNav – structure (02-§114.3, §114.8) ───────────────────────────────────
+
+describe('quick-add button – structure (02-§114.3, §114.8)', () => {
+  it('QADD-01: renders an <a class="quick-add-btn"> element', () => {
+    const html = pageNav('schema.html', SECTIONS);
+    assert.ok(html.includes('<a class="quick-add-btn"'), `Got: ${html}`);
+  });
+
+  it('QADD-02: the button links to lagg-till.html', () => {
+    const el = quickAddEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('href="lagg-till.html"'), `Got: ${el}`);
+  });
+
+  it('QADD-03: the button has aria-label="Lägg till aktivitet"', () => {
+    const el = quickAddEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('aria-label="Lägg till aktivitet"'), `Got: ${el}`);
+  });
+
+  it('QADD-04: the button contains an inline SVG plus icon', () => {
+    const el = quickAddEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('<svg'), `Expected an inline SVG. Got: ${el}`);
+  });
+});
+
+// ── pageNav – omitted on the add page (02-§114.4) ─────────────────────────────
+
+describe('quick-add button – omitted on add page (02-§114.4)', () => {
+  it('QADD-05: present on non-add pages', () => {
+    for (const href of ['index.html', 'schema.html', 'idag.html', 'arkiv.html']) {
+      assert.ok(
+        pageNav(href, SECTIONS).includes('quick-add-btn'),
+        `Expected quick-add button on ${href}`,
+      );
+    }
+  });
+
+  it('QADD-06: absent on lagg-till.html', () => {
+    assert.ok(
+      !pageNav('lagg-till.html', SECTIONS).includes('quick-add-btn'),
+      'Quick-add button must be omitted on the add-activity page',
+    );
+  });
+});
+
+// ── reachable without the hamburger menu (02-§114.2) ──────────────────────────
+
+describe('quick-add button – outside the hamburger menu (02-§114.2)', () => {
+  it('QADD-07: the button is not nested inside the nav-menu container', () => {
+    const html = pageNav('schema.html', SECTIONS);
+    const menuStart = html.indexOf('<div class="nav-menu"');
+    const btnStart = html.indexOf('quick-add-btn');
+    assert.ok(btnStart !== -1 && menuStart !== -1, 'Both button and nav-menu must exist');
+    assert.ok(
+      btnStart < menuStart,
+      'Quick-add button must be rendered before (outside) the nav-menu so it is reachable without opening the hamburger',
+    );
+  });
+});
+
+// ── rendered pages carry the button except the add page (02-§114.1, §114.4) ───
+
+describe('quick-add button – across rendered pages (02-§114.1, §114.4)', () => {
+  it('QADD-08: schema, idag, index and arkiv pages include the button', () => {
+    assert.ok(renderSchedulePage(CAMP, EVENTS, '', SECTIONS).includes('quick-add-btn'));
+    assert.ok(renderIdagPage(CAMP, EVENTS, '', SECTIONS).includes('quick-add-btn'));
+    assert.ok(
+      renderIndexPage({ heroSrc: null, heroAlt: null, sections: [] }, '', SECTIONS)
+        .includes('quick-add-btn'),
+    );
+    assert.ok(renderArkivPage([], '', SECTIONS).includes('quick-add-btn'));
+  });
+
+  it('QADD-09: the add-activity page itself omits the button', () => {
+    assert.ok(
+      !renderAddPage(CAMP, LOCATIONS, API_URL, '', SECTIONS).includes('quick-add-btn'),
+    );
+  });
+});
+
+// ── CSS – mobile-only visibility and styling (02-§114.5, §114.7) ──────────────
+
+describe('quick-add button – CSS rules (02-§114.5, §114.6, §114.7, §114.9)', () => {
+  it('QADD-10: hidden by default (display: none)', () => {
+    assert.match(
+      CSS,
+      /\.quick-add-btn\s*\{[^}]*display:\s*none/,
+      'Expected a default `.quick-add-btn { display: none }` rule',
+    );
+  });
+
+  it('QADD-11: shown as a 42×42 terracotta button inside the ≤767 px media query', () => {
+    // The mobile rule carries the terracotta background and 42 px sizing.
+    const mobileRule = CSS.match(/\.quick-add-btn\s*\{[^}]*var\(--color-terracotta\)[^}]*\}/);
+    assert.ok(mobileRule, 'Expected a `.quick-add-btn` rule using --color-terracotta');
+    assert.ok(/display:\s*flex/.test(mobileRule[0]), 'Mobile rule should display: flex');
+    assert.ok(/42px/.test(mobileRule[0]), 'Mobile rule should size the button at 42px');
+    assert.ok(
+      /border-radius:\s*var\(--radius-md\)/.test(mobileRule[0]),
+      'Mobile rule should use --radius-md border-radius',
+    );
+  });
+
+  it('QADD-12: positioned between the up-arrow and the feedback button', () => {
+    assert.ok(
+      CSS.includes('right: calc(var(--space-sm) + 42px + var(--space-xs))'),
+      'Quick-add button should occupy the slot left of the feedback button',
+    );
+  });
+
+  it('QADD-13: PWA-install button shifts one slot left so they never overlap', () => {
+    assert.ok(
+      CSS.includes('right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))'),
+      'PWA-install button should move one slot further left',
+    );
+  });
+});


### PR DESCRIPTION
## Sammanfattning

Lägger till en **+**-knapp i den klibbiga toppnavigeringen så att en deltagare kan börja lägga till en aktivitet från var som helst på sidan — utan att öppna hamburgermenyn. Löser önskemålet i #654.

- `pageNav()` renderar en `<a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">` med en inline-SVG plusikon.
- Knappen visas **endast på mobil** (≤ 767 px). På desktop syns "Lägg till" redan i navigeringsraden.
- Knappen sitter i raden av flytande knappar, **mellan den centrerade upp-pilen och feedback-knappen**. PWA-installationsknappen flyttas ett steg vänster så att de aldrig överlappar.
- Knappen **utelämnas på `lagg-till.html`** (man är redan där).
- Samma terracotta-pill-stil (42 × 42 px, `var(--radius-md)`) som syskonknapparna; ingen klient-JS behövs.

## Test plan

- [x] `npm test` — 2063/2063 passerar (inkl. 13 nya QADD-tester och uppdaterad nav-snapshot)
- [x] `npm run lint` (eslint), `stylelint`, `npm run lint:md`, `html-validate` — alla rena
- [x] Manuell mobilkontroll (411 × 922): **+** syns på schema/idag/index/arkiv, mellan upp-pil och feedback; klick → `lagg-till.html`
- [x] Manuell kontroll: **+** saknas på `lagg-till.html` och på desktop (≥ 768 px)

## Spårbarhet

- Krav: `02-§114` (`docs/02-requirements/pages-navigation.md`)
- Arkitektur: `docs/03-architecture/pages-and-content.md §12.7`
- Design: `docs/07-design/components.md §6.125–6.127`
- Matris: `02-§114.1–114.9` (covered)

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWWPoYHvSqSUrx4Jvbf4Wt)_