### PR TITLE
Add edit-shortcut button to sticky navigation

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD025": false,
   "MD029": false,
   "MD033": false,

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -18,7 +18,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 
 | File | Topic | Sections |
 | ---- | ----- | -------- |
-| [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79, §114 |
+| [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79, §114, §115 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
 | [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111, §112 |

--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -499,3 +499,46 @@ activity from anywhere on the site without opening the menu.
 - The quick-add button displays a plus (+) icon. <!-- 02-§114.8 -->
 - The PWA-install button is positioned to the left of the quick-add button so
   the two buttons never overlap. <!-- 02-§114.9 -->
+
+---
+
+## 115. Edit-Shortcut Button in Sticky Navigation
+
+### Context
+
+A participant who has added activities needs a fast way back to them to make
+edits. Without a shortcut, the only route is to open the schedule and locate
+each owned row. A button beside the menu button in the always-visible sticky
+navigation — shown only to people who actually own an upcoming activity — takes
+them straight to the edit page, which lists their own activities. Holding an
+admin token is irrelevant here: the shortcut is about *my* activities, not
+administration.
+
+### 115.1 User requirements
+
+- A participant who owns at least one upcoming activity sees an edit-shortcut
+  button beside the menu button in the sticky top navigation, taking them
+  directly to the edit page. <!-- 02-§115.1 -->
+- A visitor who owns no upcoming activity sees no edit-shortcut button. <!-- 02-§115.2 -->
+- Holding an admin token does not by itself reveal the button; visibility
+  depends only on the visitor's own activities. <!-- 02-§115.3 -->
+
+### 115.2 Site requirements
+
+- The shared navigation renders the edit-shortcut button as an `<a>` element
+  linking to `redigera.html`, with `aria-label="Redigera mina aktiviteter"`. <!-- 02-§115.4 -->
+- The edit-shortcut button appears on every page except `redigera.html`, where
+  it is omitted. <!-- 02-§115.5 -->
+- The edit-shortcut button is hidden by default and is revealed by client-side
+  JavaScript only when the `sb_session` cookie holds valid signed ownership for
+  at least one activity whose date has not passed. <!-- 02-§115.6 -->
+- The presence of an admin token in `localStorage` never reveals the
+  edit-shortcut button; only own-activity ownership does. <!-- 02-§115.7 -->
+- The edit-shortcut button is visible only on mobile viewports (≤ 767 px). On
+  desktop it is never displayed. <!-- 02-§115.8 -->
+- The edit-shortcut button is a child of `<nav class="page-nav">`, positioned
+  beside the hamburger menu button. <!-- 02-§115.9 -->
+- The edit-shortcut button matches the menu and floating action buttons in size
+  (42 × 42 px), terracotta background, white icon, and `var(--radius-md)`
+  border-radius. <!-- 02-§115.10 -->
+- The edit-shortcut button displays a pencil (edit) icon. <!-- 02-§115.11 -->

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -127,6 +127,46 @@ browser fires `beforeinstallprompt`, so the gap is only ever visible in the
 rare case the app is installable while the user is on the add page — not worth
 page-specific positioning rules.
 
+### 12.8 Edit-shortcut button (02-§115)
+
+`pageNav()` renders an edit-shortcut button as an `<a class="edit-shortcut-btn"
+href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>` element
+containing an inline SVG pencil icon. It is a direct child of `<nav
+class="page-nav">`, rendered immediately after the hamburger menu button so it
+sits beside it.
+
+`pageNav(activeHref, …)` omits the button entirely when `activeHref ===
+'redigera.html'`, so it never appears on the edit page itself.
+
+Unlike the quick-add button, the edit-shortcut button is **conditional**: it is
+rendered with the `hidden` attribute and revealed only for visitors who own an
+upcoming activity. The reveal is handled by a small IIFE in `nav.js` (the only
+client script loaded on every page with navigation), so no new per-page script
+tag is needed:
+
+1. It reads the `sb_session` cookie and keeps only valid signed ownership
+   entries (`{ id, exp, sig }` with a non-expired `exp`). If there are none it
+   returns immediately — non-owners never trigger a fetch.
+2. Otherwise it fetches `/events.json` and reveals the button (`btn.hidden =
+   false`) when at least one owned ID maps to an event whose `date` is today or
+   later. On a fetch error the button stays hidden.
+
+An admin token is deliberately **not** consulted — visibility depends only on
+the visitor's own activities (02-§115.7). This is the opposite of
+`injectEditLinks()`, where a valid admin token lights up edit links on every
+row.
+
+The button is mobile-only. Its `display` is `none` by default and `flex` inside
+the `@media (max-width: 767px)` block, with an `.edit-shortcut-btn[hidden] {
+display: none }` rule so the `hidden` attribute keeps it hidden until JS clears
+it — the same pattern as `.scroll-top`. On desktop the bare `display: none`
+applies regardless of the `hidden` attribute, so the button never appears there.
+
+It shares the 42 × 42 px terracotta pill styling and is positioned with
+`position: absolute; top: var(--space-xs)` beside the hamburger menu button
+(`left: calc(var(--space-sm) + 42px + var(--space-xs))`), matching the menu
+button's positioning model.
+
 ---
 
 ## 14. Upcoming Camps Section on Homepage

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -56,6 +56,17 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
   feedback button; the PWA-install button shifts one slot left so the
   buttons never overlap. <!-- 07-§6.127 -->
 
+### Edit-shortcut button (mobile)
+
+- A pencil edit-shortcut button (`.edit-shortcut-btn`) sits beside the
+  hamburger menu button in the sticky navigation, linking to the edit
+  page. <!-- 07-§6.128 -->
+- Mobile only (`≤ 767px`): `42 × 42px`, `background: var(--color-terracotta)`,
+  white pencil icon, `border-radius: var(--radius-md)` — matching the menu and
+  floating action buttons. Hidden on desktop. <!-- 07-§6.129 -->
+- Hidden by default; revealed by `nav.js` only for visitors who own an upcoming
+  activity. An admin token does not reveal it. <!-- 07-§6.130 -->
+
 ### Hero Section
 
 - Two-column layout on desktop: image area (~2/3) and sidebar panel (~1/3).

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1796,14 +1796,14 @@ Doc ref: `02-requirements/pages-navigation.md §115`;
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§115.1` | gap | Owner-only edit-shortcut button linking to the edit page |
-| `02-§115.2` | gap | Hidden when the visitor owns no upcoming activity |
-| `02-§115.3` | gap | Admin token alone does not reveal the button |
-| `02-§115.4` | gap | `<a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter">` |
-| `02-§115.5` | gap | Omitted when `activeHref === 'redigera.html'` |
-| `02-§115.6` | gap | Revealed by `nav.js` only for ≥1 owned, non-past activity in `sb_session` |
-| `02-§115.7` | gap | `nav.js` reveal ignores the admin token entirely |
-| `02-§115.8` | gap | Mobile-only (`display: none` default, `flex` ≤767 px) |
-| `02-§115.9` | gap | Child of `<nav class="page-nav">`, beside the hamburger menu button |
-| `02-§115.10` | gap | 42 × 42 px, terracotta, white icon, `var(--radius-md)` |
-| `02-§115.11` | gap | Inline SVG pencil icon |
+| `02-§115.1` | covered | ESHORT-01/-09: `.edit-shortcut-btn` link to `redigera.html` renders on non-edit pages; `layout.js` `pageNav()`. Browser-verified reveal for an owner is a manual checkpoint |
+| `02-§115.2` | covered | ESHORT-11/-13: hidden by default; revealed only on a positive ownership check in `nav.js`. Manual checkpoint: no cookie → no button |
+| `02-§115.3` | covered | ESHORT-18: `nav.js` never references `sb_admin`. Manual checkpoint: admin token only → button stays hidden |
+| `02-§115.4` | covered | ESHORT-01/-02/-03: `<a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>`; `source/build/layout.js` |
+| `02-§115.5` | covered | ESHORT-07/-10: omitted when `activeHref === 'redigera.html'`; `source/build/layout.js` |
+| `02-§115.6` | covered | ESHORT-15/-16/-17: `nav.js` reads `sb_session` signed entries, fetches `events.json`, sets `btn.hidden = false` for an owned event with `date >= today`; `source/assets/js/client/nav.js` |
+| `02-§115.7` | covered | ESHORT-18: the `nav.js` reveal IIFE never consults the admin token; `source/assets/js/client/nav.js` |
+| `02-§115.8` | covered | ESHORT-11/-12/-13: `.edit-shortcut-btn { display: none }` default, `flex` inside `@media (max-width: 767px)`, `[hidden]` re-hide; `source/assets/cs/style.css`. Desktop absence is a manual checkpoint |
+| `02-§115.9` | covered | ESHORT-08/-14: rendered after the toggle, before `.nav-menu`; positioned `left: calc(var(--space-sm) + 42px + var(--space-xs))` beside the hamburger; `layout.js` / `style.css` |
+| `02-§115.10` | covered | ESHORT-12: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
+| `02-§115.11` | covered | ESHORT-05: inline SVG pencil icon inside the anchor; `source/build/layout.js` |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1787,3 +1787,23 @@ Doc ref: `02-requirements/pages-navigation.md §114`;
 | `02-§114.7` | covered | QADD-11: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
 | `02-§114.8` | covered | QADD-04: inline SVG plus icon inside the anchor; `source/build/layout.js` |
 | `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`; `source/assets/cs/style.css` |
+
+### §115 — Edit-Shortcut Button in Sticky Navigation
+
+Doc ref: `02-requirements/pages-navigation.md §115`;
+`03-architecture/pages-and-content.md §12.8` (Edit-shortcut button);
+`07-design/components.md §6.128–6.130` (Edit-shortcut button design).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§115.1` | gap | Owner-only edit-shortcut button linking to the edit page |
+| `02-§115.2` | gap | Hidden when the visitor owns no upcoming activity |
+| `02-§115.3` | gap | Admin token alone does not reveal the button |
+| `02-§115.4` | gap | `<a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter">` |
+| `02-§115.5` | gap | Omitted when `activeHref === 'redigera.html'` |
+| `02-§115.6` | gap | Revealed by `nav.js` only for ≥1 owned, non-past activity in `sb_session` |
+| `02-§115.7` | gap | `nav.js` reveal ignores the admin token entirely |
+| `02-§115.8` | gap | Mobile-only (`display: none` default, `flex` ≤767 px) |
+| `02-§115.9` | gap | Child of `<nav class="page-nav">`, beside the hamburger menu button |
+| `02-§115.10` | gap | 42 × 42 px, terracotta, white icon, `var(--radius-md)` |
+| `02-§115.11` | gap | Inline SVG pencil icon |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2709,6 +2709,45 @@ body.modal-open {
   }
 }
 
+/* ── Edit-shortcut button (02-§115) ── */
+
+.edit-shortcut-btn {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .edit-shortcut-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: var(--space-xs);
+    left: calc(var(--space-sm) + 42px + var(--space-xs));
+    width: 42px;
+    height: 42px;
+    background: var(--color-terracotta);
+    color: var(--color-white);
+    border-radius: var(--radius-md);
+    line-height: 0;
+    z-index: 201;
+  }
+
+  /* The hidden attribute (set until nav.js reveals the button) must win over
+     the mobile display: flex above. */
+  .edit-shortcut-btn[hidden] {
+    display: none;
+  }
+
+  .edit-shortcut-btn:hover {
+    background: var(--color-sage-hover);
+  }
+
+  .edit-shortcut-btn:focus-visible {
+    outline: 2px solid var(--color-white);
+    outline-offset: 2px;
+  }
+}
+
 /* ── Quick-add activity button (02-§114) ── */
 
 .quick-add-btn {

--- a/source/assets/js/client/nav.js
+++ b/source/assets/js/client/nav.js
@@ -53,3 +53,58 @@
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });
 }());
+
+/* Edit-shortcut button – reveal for participants who own an upcoming activity.
+   Visibility depends only on the visitor's own sb_session ownership; the admin
+   token is deliberately ignored (02-§115.6, 02-§115.7). */
+(function () {
+  var btn = document.querySelector('.edit-shortcut-btn');
+  if (!btn) return;
+
+  var COOKIE_NAME = 'sb_session';
+
+  // Read sb_session and keep only valid, non-expired signed ownership IDs.
+  function readSignedIds() {
+    var pairs = document.cookie.split(';');
+    for (var i = 0; i < pairs.length; i++) {
+      var pair = pairs[i].trim();
+      if (pair.indexOf(COOKIE_NAME + '=') !== 0) continue;
+      try {
+        var parsed = JSON.parse(decodeURIComponent(pair.slice(COOKIE_NAME.length + 1)));
+        if (!Array.isArray(parsed)) return [];
+        var now = Math.floor(Date.now() / 1000);
+        return parsed
+          .filter(function (e) {
+            return e && typeof e === 'object' &&
+              typeof e.id === 'string' && e.id.length > 0 &&
+              typeof e.exp === 'number' && isFinite(e.exp) && e.exp >= now &&
+              typeof e.sig === 'string' && e.sig.length > 0;
+          })
+          .map(function (e) { return e.id; });
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }
+
+  var ids = readSignedIds();
+  if (!ids.length) return; // no ownership → no shortcut (no fetch for non-owners)
+
+  fetch('/events.json')
+    .then(function (r) { return r.json(); })
+    .then(function (events) {
+      if (!Array.isArray(events)) return;
+      var today = new Date().toISOString().slice(0, 10);
+      var owned = {};
+      for (var i = 0; i < ids.length; i++) owned[ids[i]] = true;
+      for (var j = 0; j < events.length; j++) {
+        var ev = events[j];
+        if (ev && owned[ev.id] && ev.date >= today) {
+          btn.hidden = false;
+          return;
+        }
+      }
+    })
+    .catch(function () { /* leave the button hidden on error */ });
+}());

--- a/source/build/layout.js
+++ b/source/build/layout.js
@@ -66,6 +66,19 @@ function pageNav(activeHref, navSections = []) {
       </svg>
     </a>\n`;
 
+  // Edit-shortcut button — a one-tap link to the edit page, shown beside the
+  // hamburger menu button. Rendered hidden; nav.js reveals it only for visitors
+  // who own an upcoming activity (admin token is deliberately ignored).
+  // Omitted on the edit page itself, where it would be redundant.
+  const editShortcutBtn = activeHref === 'redigera.html'
+    ? ''
+    : `    <a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 20h9"/>
+        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/>
+      </svg>
+    </a>\n`;
+
   const installBtn = `    <button type="button" class="pwa-install-btn" aria-label="Installera appen" hidden>
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -81,7 +94,7 @@ function pageNav(activeHref, navSections = []) {
       <span class="nav-toggle-bar"></span>
       <span class="nav-toggle-bar"></span>
     </button>
-    <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
+${editShortcutBtn}    <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
 ${quickAddBtn}${installBtn}
 ${feedbackBtn}
     <div class="nav-menu" id="nav-menu">

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -21,6 +21,12 @@
       <span class="nav-toggle-bar"></span>
       <span class="nav-toggle-bar"></span>
     </button>
+    <a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 20h9"/>
+        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/>
+      </svg>
+    </a>
     <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
     <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">

--- a/tests/edit-shortcut-button.test.js
+++ b/tests/edit-shortcut-button.test.js
@@ -1,0 +1,199 @@
+'use strict';
+
+// Tests for the edit-shortcut button in the sticky navigation – 02-§115.
+//
+// The button's mobile-only visibility, exact on-screen placement, and the
+// client-side reveal (cookie read + events.json fetch) cannot be fully
+// verified in Node.js. The string-level checks below confirm the markup, the
+// CSS rules, and the nav.js reveal logic exist; the visual/behavioural result
+// is a manual checkpoint:
+//   Manual checkpoint (02-§115.1, §115.6, §115.8): on a ≤767 px viewport with
+//   an sb_session cookie owning at least one upcoming activity, open any page
+//   other than redigera.html and confirm a pencil button appears beside the
+//   hamburger menu button and opens redigera.html. With no such cookie, or on
+//   a ≥768 px viewport, the button is absent. An admin token alone does NOT
+//   reveal it.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { pageNav } = require('../source/build/layout');
+const { renderSchedulePage } = require('../source/build/render');
+const { renderEditPage } = require('../source/build/render-edit');
+const { renderIdagPage } = require('../source/build/render-idag');
+const { renderIndexPage } = require('../source/build/render-index');
+const { renderArkivPage } = require('../source/build/render-arkiv');
+
+const CSS = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'assets', 'cs', 'style.css'),
+  'utf8',
+);
+const NAVJS = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'assets', 'js', 'client', 'nav.js'),
+  'utf8',
+);
+
+const CAMP = { name: 'SB Sommar 2026', start_date: '2026-06-28', end_date: '2026-07-05' };
+const EVENTS = [];
+const LOCATIONS = ['Servicehus', 'Annat'];
+const API_URL = 'https://api.example.com/edit-event';
+const SECTIONS = [{ id: 'start', navLabel: 'Om lägret' }];
+
+// Extract the edit-shortcut element from pageNav output for focused checks.
+function editEl(html) {
+  return html.match(/<a class="edit-shortcut-btn"[\s\S]*?<\/a>/)?.[0] || '';
+}
+
+// ── pageNav – structure (02-§115.4, §115.6, §115.11) ─────────────────────────
+
+describe('edit-shortcut button – structure (02-§115.4, §115.6, §115.11)', () => {
+  it('ESHORT-01: renders an <a class="edit-shortcut-btn"> element', () => {
+    const html = pageNav('schema.html', SECTIONS);
+    assert.ok(html.includes('<a class="edit-shortcut-btn"'), `Got: ${html}`);
+  });
+
+  it('ESHORT-02: the button links to redigera.html', () => {
+    const el = editEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('href="redigera.html"'), `Got: ${el}`);
+  });
+
+  it('ESHORT-03: the button has aria-label="Redigera mina aktiviteter"', () => {
+    const el = editEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('aria-label="Redigera mina aktiviteter"'), `Got: ${el}`);
+  });
+
+  it('ESHORT-04: the button is hidden by default (hidden attribute)', () => {
+    const el = editEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('hidden'), `Expected the hidden attribute. Got: ${el}`);
+  });
+
+  it('ESHORT-05: the button contains an inline SVG pencil icon', () => {
+    const el = editEl(pageNav('schema.html', SECTIONS));
+    assert.ok(el.includes('<svg'), `Expected an inline SVG. Got: ${el}`);
+  });
+});
+
+// ── pageNav – omitted on the edit page (02-§115.5) ───────────────────────────
+
+describe('edit-shortcut button – omitted on edit page (02-§115.5)', () => {
+  it('ESHORT-06: present on non-edit pages', () => {
+    for (const href of ['index.html', 'schema.html', 'idag.html', 'arkiv.html', 'lagg-till.html']) {
+      assert.ok(
+        pageNav(href, SECTIONS).includes('edit-shortcut-btn'),
+        `Expected edit-shortcut button on ${href}`,
+      );
+    }
+  });
+
+  it('ESHORT-07: absent on redigera.html', () => {
+    assert.ok(
+      !pageNav('redigera.html', SECTIONS).includes('edit-shortcut-btn'),
+      'Edit-shortcut button must be omitted on the edit page',
+    );
+  });
+});
+
+// ── reachable without the hamburger menu, beside the toggle (02-§115.9) ───────
+
+describe('edit-shortcut button – beside the menu button (02-§115.9)', () => {
+  it('ESHORT-08: rendered after the nav-toggle but before the nav-menu', () => {
+    const html = pageNav('schema.html', SECTIONS);
+    const togglePos = html.indexOf('class="nav-toggle"');
+    const btnPos = html.indexOf('edit-shortcut-btn');
+    const menuPos = html.indexOf('<div class="nav-menu"');
+    assert.ok(togglePos !== -1 && btnPos !== -1 && menuPos !== -1, 'toggle, button and menu must all exist');
+    assert.ok(togglePos < btnPos, 'Edit-shortcut button must come after the hamburger toggle so it sits beside it');
+    assert.ok(
+      btnPos < menuPos,
+      'Edit-shortcut button must be outside the nav-menu so it is reachable without opening the hamburger',
+    );
+  });
+});
+
+// ── rendered pages carry the button except the edit page (02-§115.1, §115.5) ──
+
+describe('edit-shortcut button – across rendered pages (02-§115.1, §115.5)', () => {
+  it('ESHORT-09: schema, idag, index and arkiv pages include the button', () => {
+    assert.ok(renderSchedulePage(CAMP, EVENTS, '', SECTIONS).includes('edit-shortcut-btn'));
+    assert.ok(renderIdagPage(CAMP, EVENTS, '', SECTIONS).includes('edit-shortcut-btn'));
+    assert.ok(
+      renderIndexPage({ heroSrc: null, heroAlt: null, sections: [] }, '', SECTIONS)
+        .includes('edit-shortcut-btn'),
+    );
+    assert.ok(renderArkivPage([], '', SECTIONS).includes('edit-shortcut-btn'));
+  });
+
+  it('ESHORT-10: the edit page itself omits the button', () => {
+    assert.ok(
+      !renderEditPage(CAMP, LOCATIONS, API_URL, '', SECTIONS).includes('edit-shortcut-btn'),
+    );
+  });
+});
+
+// ── CSS – mobile-only visibility and styling (02-§115.8, §115.10) ────────────
+
+describe('edit-shortcut button – CSS rules (02-§115.8, §115.9, §115.10)', () => {
+  it('ESHORT-11: hidden by default (display: none)', () => {
+    assert.match(
+      CSS,
+      /\.edit-shortcut-btn\s*\{[^}]*display:\s*none/,
+      'Expected a default `.edit-shortcut-btn { display: none }` rule',
+    );
+  });
+
+  it('ESHORT-12: shown as a 42×42 terracotta button inside the ≤767 px media query', () => {
+    const mobileRule = CSS.match(/\.edit-shortcut-btn\s*\{[^}]*var\(--color-terracotta\)[^}]*\}/);
+    assert.ok(mobileRule, 'Expected a `.edit-shortcut-btn` rule using --color-terracotta');
+    assert.ok(/display:\s*flex/.test(mobileRule[0]), 'Mobile rule should display: flex');
+    assert.ok(/42px/.test(mobileRule[0]), 'Mobile rule should size the button at 42px');
+    assert.ok(
+      /border-radius:\s*var\(--radius-md\)/.test(mobileRule[0]),
+      'Mobile rule should use --radius-md border-radius',
+    );
+  });
+
+  it('ESHORT-13: the hidden attribute keeps it hidden on mobile until JS clears it', () => {
+    assert.match(
+      CSS,
+      /\.edit-shortcut-btn\[hidden\]\s*\{[^}]*display:\s*none/,
+      'Expected `.edit-shortcut-btn[hidden] { display: none }` so the hidden attribute wins on mobile',
+    );
+  });
+
+  it('ESHORT-14: positioned beside the hamburger menu button', () => {
+    assert.ok(
+      CSS.includes('left: calc(var(--space-sm) + 42px + var(--space-xs))'),
+      'Edit-shortcut button should sit one slot right of the left-anchored hamburger',
+    );
+  });
+});
+
+// ── nav.js – owner-only reveal, admin token ignored (02-§115.6, §115.7) ──────
+
+describe('edit-shortcut button – nav.js reveal logic (02-§115.6, §115.7)', () => {
+  it('ESHORT-15: nav.js targets the edit-shortcut button', () => {
+    assert.ok(NAVJS.includes('edit-shortcut-btn'), 'nav.js should select .edit-shortcut-btn');
+  });
+
+  it('ESHORT-16: nav.js reads the sb_session cookie and fetches events.json', () => {
+    assert.ok(NAVJS.includes('sb_session'), 'nav.js should read the sb_session cookie');
+    assert.ok(NAVJS.includes('events.json'), 'nav.js should fetch events.json to check dates');
+  });
+
+  it('ESHORT-17: nav.js reveals the button by clearing the hidden attribute', () => {
+    assert.match(
+      NAVJS,
+      /\.hidden\s*=\s*false/,
+      'nav.js should reveal the button via btn.hidden = false',
+    );
+  });
+
+  it('ESHORT-18: nav.js never consults the admin token (02-§115.7)', () => {
+    assert.ok(
+      !NAVJS.includes('sb_admin'),
+      'The reveal must depend only on own-activity ownership, never on the admin token',
+    );
+  });
+});


### PR DESCRIPTION
## Sammanfattning

Lägger till en **penna**-knapp bredvid menyknappen (hamburgaren) i den klibbiga toppnavigeringen, som tar deltagaren direkt till `redigera.html` och dess "Mina aktiviteter"-lista. Löser önskemålet i #679.

- `pageNav()` renderar `<a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>` med en inline-SVG pennikon, direkt efter hamburgaren så den sitter bredvid den.
- Knappen är **villkorlig**: dold som standard och avslöjas av `nav.js` (enda skriptet som laddas på alla sidor med navigering) **endast** för besökare som äger minst en **kommande** aktivitet — en giltig signerad post i `sb_session` vars datum inte passerat. Icke-ägare utlöser ingen `events.json`-hämtning.
- **Admintoken ignoreras medvetet** — synligheten styrs enbart av egen lista (02-§115.7). Detta är motsatsen till `injectEditLinks()`, där en admin ser "Redigera" på alla rader.
- Endast mobil (≤ 767 px). På desktop visas den aldrig.
- **Utelämnas på `redigera.html`** (man är redan där).
- Samma terrakotta-pill-stil (42 × 42 px, `var(--radius-md)`) som menyknappen och övriga flytande knappar.
- Ingen ny `<script>`-tagg behövs på 10 render-filer; ingen service-worker-precache eller cache-bump (JS cache-bustas redan via innehållshash).

## Test plan

- [x] `npm test` — 2081/2081 passerar (inkl. 18 nya ESHORT-tester och uppdaterad nav-snapshot)
- [x] `npm run lint` (eslint) och `npm run lint:md` (markdownlint) — rena
- [x] `npm run build` (med `SITE_URL`) — bygger rent; knappen finns på alla sidor utom `redigera.html`, `nav.js` cache-bustad
- [x] Manuell webbläsarverifiering (Chromium, 411 × 822): ingen cookie → dold; äger kommande aktivitet → synlig bredvid hamburgaren; äger bara passerad → dold; bara admintoken → dold; desktop → dold; osignerad post → dold

## Spårbarhet

- Krav: `02-§115` (`docs/02-requirements/pages-navigation.md`)
- Arkitektur: `docs/03-architecture/pages-and-content.md §12.8`
- Design: `docs/07-design/components.md §6.128–6.130`
- Matris: `02-§115.1–115.11` (covered)

## Noteringar

- `markdownlint` `MD024` satt till `siblings_only`: CLAUDE.md kräver en `Context`-subsektion per kravsektion, vilket ger återkommande `### Context`-rubriker. Detta är grundorsaksfixen och gör bara regeln mildare (inget befintligt går sönder).

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018d2zozDwPSU61WQhU62KuU)_