### PR TITLE
Move edit-shortcut button beside the quick-add button

### DIFF
--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -536,9 +536,9 @@ administration.
   edit-shortcut button; only own-activity ownership does. <!-- 02-§115.7 -->
 - The edit-shortcut button is visible only on mobile viewports (≤ 767 px). On
   desktop it is never displayed. <!-- 02-§115.8 -->
-- The edit-shortcut button is a child of `<nav class="page-nav">`, positioned
-  beside the hamburger menu button. <!-- 02-§115.9 -->
-- The edit-shortcut button matches the menu and floating action buttons in size
+- The edit-shortcut button is a child of `<nav class="page-nav">`, positioned in
+  the row of floating action buttons beside the quick-add button. <!-- 02-§115.9 -->
+- The edit-shortcut button matches the other floating action buttons in size
   (42 × 42 px), terracotta background, white icon, and `var(--radius-md)`
   border-radius. <!-- 02-§115.10 -->
 - The edit-shortcut button displays a pencil (edit) icon. <!-- 02-§115.11 -->

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -132,8 +132,8 @@ page-specific positioning rules.
 `pageNav()` renders an edit-shortcut button as an `<a class="edit-shortcut-btn"
 href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>` element
 containing an inline SVG pencil icon. It is a direct child of `<nav
-class="page-nav">`, rendered immediately after the hamburger menu button so it
-sits beside it.
+class="page-nav">`, rendered next to the quick-add button so the two
+sit beside each other in the floating-action-button row.
 
 `pageNav(activeHref, …)` omits the button entirely when `activeHref ===
 'redigera.html'`, so it never appears on the edit page itself.
@@ -162,10 +162,15 @@ display: none }` rule so the `hidden` attribute keeps it hidden until JS clears
 it — the same pattern as `.scroll-top`. On desktop the bare `display: none`
 applies regardless of the `hidden` attribute, so the button never appears there.
 
-It shares the 42 × 42 px terracotta pill styling and is positioned with
-`position: absolute; top: var(--space-xs)` beside the hamburger menu button
-(`left: calc(var(--space-sm) + 42px + var(--space-xs))`), matching the menu
-button's positioning model.
+It shares the 42 × 42 px terracotta pill styling of the other floating action
+buttons and is positioned with `position: fixed; top: var(--space-xs)` in the
+slot immediately left of the quick-add button
+(`right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`). The
+`.pwa-install-btn` moves one slot further left
+(`right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))`) so the buttons
+never overlap. Because both the edit-shortcut and install buttons are usually
+hidden, the row collapses to just the feedback and quick-add buttons for most
+visitors, with no visible gaps.
 
 ---
 

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -59,11 +59,12 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
 ### Edit-shortcut button (mobile)
 
 - A pencil edit-shortcut button (`.edit-shortcut-btn`) sits beside the
-  hamburger menu button in the sticky navigation, linking to the edit
-  page. <!-- 07-§6.128 -->
+  quick-add button in the sticky navigation's floating-action-button row,
+  linking to the edit page. <!-- 07-§6.128 -->
 - Mobile only (`≤ 767px`): `42 × 42px`, `background: var(--color-terracotta)`,
-  white pencil icon, `border-radius: var(--radius-md)` — matching the menu and
-  floating action buttons. Hidden on desktop. <!-- 07-§6.129 -->
+  white pencil icon, `border-radius: var(--radius-md)` — matching the other
+  floating action buttons. The PWA-install button shifts one slot left so they
+  never overlap. Hidden on desktop. <!-- 07-§6.129 -->
 - Hidden by default; revealed by `nav.js` only for visitors who own an upcoming
   activity. An admin token does not reveal it. <!-- 07-§6.130 -->
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1786,7 +1786,7 @@ Doc ref: `02-requirements/pages-navigation.md §114`;
 | `02-§114.6` | covered | QADD-12: `right: calc(var(--space-sm) + 42px + var(--space-xs))` between scroll-top and feedback; `source/assets/cs/style.css`. Visual placement is manual checkpoint |
 | `02-§114.7` | covered | QADD-11: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
 | `02-§114.8` | covered | QADD-04: inline SVG plus icon inside the anchor; `source/build/layout.js` |
-| `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`; `source/assets/cs/style.css` |
+| `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))` (one slot left of the edit-shortcut button, which took the slot beside quick-add); `source/assets/cs/style.css` |
 
 ### §115 — Edit-Shortcut Button in Sticky Navigation
 
@@ -1804,6 +1804,6 @@ Doc ref: `02-requirements/pages-navigation.md §115`;
 | `02-§115.6` | covered | ESHORT-15/-16/-17: `nav.js` reads `sb_session` signed entries, fetches `events.json`, sets `btn.hidden = false` for an owned event with `date >= today`; `source/assets/js/client/nav.js` |
 | `02-§115.7` | covered | ESHORT-18: the `nav.js` reveal IIFE never consults the admin token; `source/assets/js/client/nav.js` |
 | `02-§115.8` | covered | ESHORT-11/-12/-13: `.edit-shortcut-btn { display: none }` default, `flex` inside `@media (max-width: 767px)`, `[hidden]` re-hide; `source/assets/cs/style.css`. Desktop absence is a manual checkpoint |
-| `02-§115.9` | covered | ESHORT-08/-14: rendered after the toggle, before `.nav-menu`; positioned `left: calc(var(--space-sm) + 42px + var(--space-xs))` beside the hamburger; `layout.js` / `style.css` |
+| `02-§115.9` | covered | ESHORT-08/-14: rendered in the floating-action-button group, outside `.nav-menu`; positioned `right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))` beside the quick-add button; `layout.js` / `style.css` |
 | `02-§115.10` | covered | ESHORT-12: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
 | `02-§115.11` | covered | ESHORT-05: inline SVG pencil icon inside the anchor; `source/build/layout.js` |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2656,7 +2656,7 @@ body.modal-open {
     justify-content: center;
     position: fixed;
     top: var(--space-xs);
-    right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)));
+    right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)));
     width: 42px;
     height: 42px;
     background: var(--color-terracotta);
@@ -2720,9 +2720,9 @@ body.modal-open {
     display: flex;
     align-items: center;
     justify-content: center;
-    position: absolute;
+    position: fixed;
     top: var(--space-xs);
-    left: calc(var(--space-sm) + 42px + var(--space-xs));
+    right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)));
     width: 42px;
     height: 42px;
     background: var(--color-terracotta);

--- a/source/build/layout.js
+++ b/source/build/layout.js
@@ -67,7 +67,7 @@ function pageNav(activeHref, navSections = []) {
     </a>\n`;
 
   // Edit-shortcut button — a one-tap link to the edit page, shown beside the
-  // hamburger menu button. Rendered hidden; nav.js reveals it only for visitors
+  // quick-add button. Rendered hidden; nav.js reveals it only for visitors
   // who own an upcoming activity (admin token is deliberately ignored).
   // Omitted on the edit page itself, where it would be redundant.
   const editShortcutBtn = activeHref === 'redigera.html'
@@ -94,8 +94,8 @@ function pageNav(activeHref, navSections = []) {
       <span class="nav-toggle-bar"></span>
       <span class="nav-toggle-bar"></span>
     </button>
-${editShortcutBtn}    <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
-${quickAddBtn}${installBtn}
+    <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
+${quickAddBtn}${editShortcutBtn}${installBtn}
 ${feedbackBtn}
     <div class="nav-menu" id="nav-menu">
       <div class="nav-pages">

--- a/tests/__snapshots__/renderSchedulePage.snap
+++ b/tests/__snapshots__/renderSchedulePage.snap
@@ -21,17 +21,17 @@
       <span class="nav-toggle-bar"></span>
       <span class="nav-toggle-bar"></span>
     </button>
-    <a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M12 20h9"/>
-        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/>
-      </svg>
-    </a>
     <button type="button" class="scroll-top" aria-label="Till toppen" hidden>&#x2B06;</button>
     <a class="quick-add-btn" href="lagg-till.html" aria-label="Lägg till aktivitet">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
         <line x1="12" y1="5" x2="12" y2="19"/>
         <line x1="5" y1="12" x2="19" y2="12"/>
+      </svg>
+    </a>
+    <a class="edit-shortcut-btn" href="redigera.html" aria-label="Redigera mina aktiviteter" hidden>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 20h9"/>
+        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/>
       </svg>
     </a>
     <button type="button" class="pwa-install-btn" aria-label="Installera appen" hidden>

--- a/tests/edit-shortcut-button.test.js
+++ b/tests/edit-shortcut-button.test.js
@@ -97,14 +97,14 @@ describe('edit-shortcut button – omitted on edit page (02-§115.5)', () => {
 
 // ── reachable without the hamburger menu, beside the toggle (02-§115.9) ───────
 
-describe('edit-shortcut button – beside the menu button (02-§115.9)', () => {
-  it('ESHORT-08: rendered after the nav-toggle but before the nav-menu', () => {
+describe('edit-shortcut button – beside the quick-add button (02-§115.9)', () => {
+  it('ESHORT-08: rendered next to the quick-add button, outside the nav-menu', () => {
     const html = pageNav('schema.html', SECTIONS);
-    const togglePos = html.indexOf('class="nav-toggle"');
+    const quickPos = html.indexOf('quick-add-btn');
     const btnPos = html.indexOf('edit-shortcut-btn');
     const menuPos = html.indexOf('<div class="nav-menu"');
-    assert.ok(togglePos !== -1 && btnPos !== -1 && menuPos !== -1, 'toggle, button and menu must all exist');
-    assert.ok(togglePos < btnPos, 'Edit-shortcut button must come after the hamburger toggle so it sits beside it');
+    assert.ok(quickPos !== -1 && btnPos !== -1 && menuPos !== -1, 'quick-add, edit button and menu must all exist');
+    assert.ok(quickPos < btnPos, 'Edit-shortcut button is rendered next to the quick-add button');
     assert.ok(
       btnPos < menuPos,
       'Edit-shortcut button must be outside the nav-menu so it is reachable without opening the hamburger',
@@ -162,10 +162,12 @@ describe('edit-shortcut button – CSS rules (02-§115.8, §115.9, §115.10)', (
     );
   });
 
-  it('ESHORT-14: positioned beside the hamburger menu button', () => {
+  it('ESHORT-14: positioned beside the quick-add button (one slot left of it)', () => {
+    const mobileRule = CSS.match(/\.edit-shortcut-btn\s*\{[^}]*var\(--color-terracotta\)[^}]*\}/);
+    assert.ok(mobileRule, 'Expected the mobile `.edit-shortcut-btn` rule');
     assert.ok(
-      CSS.includes('left: calc(var(--space-sm) + 42px + var(--space-xs))'),
-      'Edit-shortcut button should sit one slot right of the left-anchored hamburger',
+      /right:\s*calc\(var\(--space-sm\) \+ 2 \* \(42px \+ var\(--space-xs\)\)\)/.test(mobileRule[0]),
+      'Edit-shortcut button should occupy the slot beside the quick-add button',
     );
   });
 });

--- a/tests/quick-add-button.test.js
+++ b/tests/quick-add-button.test.js
@@ -149,10 +149,12 @@ describe('quick-add button – CSS rules (02-§114.5, §114.6, §114.7, §114.9)
     );
   });
 
-  it('QADD-13: PWA-install button shifts one slot left so they never overlap', () => {
+  it('QADD-13: PWA-install button shifts left of quick-add so they never overlap', () => {
+    // The edit-shortcut button (02-§115) sits in the slot immediately left of
+    // quick-add, so the PWA-install button moves one slot further still.
     assert.ok(
-      CSS.includes('right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))'),
-      'PWA-install button should move one slot further left',
+      CSS.includes('right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))'),
+      'PWA-install button should sit two slots left of quick-add',
     );
   });
 });


### PR DESCRIPTION
## Sammanfattning

Flyttar redigera-genvägen (penna) från platsen bredvid hamburgaren till **raden med flytande knappar, jämte plusknappen** — de hör ihop som "lägg till / redigera mina aktiviteter". Uppföljning på #683 (önskemål från #679).

- `.edit-shortcut-btn` är nu `position: fixed` i slotten direkt till vänster om plusknappen: `right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`.
- PWA-installationsknappen flyttas ett steg till vänster (`3 * …`) så att knapparna aldrig överlappar.
- All annan logik oförändrad: dold som standard, avslöjas av `nav.js` endast för den som äger minst en kommande aktivitet, admintoken ignoreras, endast mobil (≤ 767 px), utelämnas på `redigera.html`.

Höger-till-vänster på mobil: feedback, **plus**, **penna**. Eftersom både penna- och installationsknappen oftast är dolda kollapsar raden till bara feedback + plus för de flesta besökare, utan tomma luckor.

## Test plan

- [x] `npm test` — 2081/2081 passerar (uppdaterade ESHORT-08/-14 och QADD-13 samt nav-snapshot)
- [x] `npm run lint` + `npm run lint:md` — rena
- [x] `npm run build` (med `SITE_URL`) — bygger rent
- [x] Manuell webbläsarverifiering (Chromium): penna sitter jämte plusknappen på mobil; alla sex synlighetsfall oförändrade (ingen cookie → dold; kommande aktivitet → synlig; bara passerad → dold; bara admintoken → dold; desktop → dold; osignerad → dold)

## Spårbarhet

- Krav: `02-§115.9–115.10` (`docs/02-requirements/pages-navigation.md`) — placering uppdaterad
- Arkitektur: `docs/03-architecture/pages-and-content.md §12.8`
- Design: `docs/07-design/components.md §6.128–6.129`
- `02-§114.9`-noten uppdaterad eftersom PWA-knappen nu ligger i `3 *`-slotten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018d2zozDwPSU61WQhU62KuU)_