### PR TITLE
Bumpa service worker-cache till v7 så enheter självläker

### DIFF
--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -966,7 +966,7 @@ from a stale cache.
 
 ### 96.2 Service worker (site requirements)
 
-- The service worker cache name is `sb-sommar-v6`. <!-- 02-§96.1 -->
+- The service worker cache name is `sb-sommar-v7`. <!-- 02-§96.1 -->
 - The `install` event handler calls `self.skipWaiting()` so that a new
   worker moves straight from `installed` to `activating` without
   waiting for all existing clients to close. <!-- 02-§96.2 -->
@@ -1015,8 +1015,8 @@ from a stale cache.
   `sbsommar.se` (or `qa.sbsommar.se`): the browser fetches `sw.js`
   bypassing its HTTP cache, installs the new worker, applies
   `skipWaiting`, and claims the open tab. <!-- 02-§96.9 -->
-- The new worker deletes the old `sb-sommar-v5` cache and rebuilds
-  `sb-sommar-v6` from fresh network responses. <!-- 02-§96.10 -->
+- The new worker deletes the old `sb-sommar-v6` cache and rebuilds
+  `sb-sommar-v7` from fresh network responses. <!-- 02-§96.10 -->
 - After at most one reload following the first post-deploy visit, every
   client sees the same assets that the server serves, including the
   current `style.css` with the §94 registration-banner rules. <!-- 02-§96.11 -->

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -24,7 +24,7 @@ display mode. It is copied to `public/app.webmanifest` during the build.
 ### Service worker
 
 `source/static/sw.js` lives at the site root (`public/sw.js`) so its scope
-covers all pages. It uses a versioned cache name (currently `sb-sommar-v6`).
+covers all pages. It uses a versioned cache name (currently `sb-sommar-v7`).
 
 **Scheme guard:** The fetch handler returns early for any request whose
 URL scheme is not `http:` or `https:`. This prevents errors from

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1116,7 +1116,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§83.12` | covered | PWA-05-*: all 8 pages include apple-touch-icon |
 | `02-§83.13` | covered | PWA-17: `source/static/sw.js` exists; `build.js` copies to public/ |
 | `02-§83.14` | covered | PWA-06-*: all 8 pages include sw-register.js |
-| `02-§83.15` | covered | PWA-18, PWA-31: sw.js CACHE_NAME is sb-sommar-v3 |
+| `02-§83.15` | covered | PWA-18, PWA-31: sw.js CACHE_NAME is sb-sommar-v7 |
 | `02-§83.16` | covered | PWA-19, PWA-19b: pre-cache excludes lagg-till.html, redigera.html; includes /index.html |
 | `02-§83.17` | implemented | Manual: verify network-first HTML, cache-first assets in browser DevTools |
 | `02-§83.18` | covered | PWA-20: sw.js activate handler deletes old caches |
@@ -1135,7 +1135,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§83.31` | implemented | Manual: verify offline page uses shared nav/footer/CSS |
 | `02-§83.32` | covered | PWA-29: offline page contains Swedish offline text |
 | `02-§83.33` | covered | PWA-30: offline.html in PRE_CACHE_URLS |
-| `02-§83.34` | covered | PWA-31: CACHE_NAME is sb-sommar-v3 |
+| `02-§83.34` | covered | PWA-31: CACHE_NAME is sb-sommar-v7 |
 | `02-§83.35` | covered | PWA-32, PWA-33: offline page <main> does not link to lagg-till.html or redigera.html |
 
 ## Sections §84–§100
@@ -1389,7 +1389,7 @@ its requirement rows together with the test-legend rows that evidence them.
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§96.1` | covered | OFF-02, PWA-31: `sw.js` declares `const CACHE_NAME = 'sb-sommar-v6'` |
+| `02-§96.1` | covered | OFF-02, PWA-31: `sw.js` declares `const CACHE_NAME = 'sb-sommar-v7'` |
 | `02-§96.2` | covered | SWH-01: `install` event handler contains `self.skipWaiting()` |
 | `02-§96.3` | covered | SWH-02: `install` handler wraps each URL as `new Request(u, { cache: 'reload' })` before `cache.addAll` |
 | `02-§96.4` | covered | SWH-03, SWH-04: `activate` handler deletes caches `!== CACHE_NAME` and calls `self.clients.claim()` |
@@ -1399,7 +1399,7 @@ its requirement rows together with the test-legend rows that evidence them.
 | `02-§96.7` | implemented | `source/build/build.js` pre-cache-manifest injection uses root-relative paths (no query strings); verified post-build by `public/sw.js` contents |
 | `02-§96.8` | implemented | `cacheFirstThenNetwork` catch branch calls `caches.match(request, { ignoreSearch: true })` so `/style.css` pre-cache entry still serves offline — manual browser verification |
 | `02-§96.9` | implemented | Manual browser verification: load SW v5, deploy v6, confirm next navigation upgrades without user action |
-| `02-§96.10` | implemented | Manual browser verification: confirm `sb-sommar-v5` is deleted on activate and `sb-sommar-v6` populated from fresh network responses |
+| `02-§96.10` | implemented | Manual browser verification: confirm `sb-sommar-v6` is deleted on activate and `sb-sommar-v7` populated from fresh network responses |
 | `02-§96.11` | implemented | Manual browser verification: confirm §94 registration-banner styling applies on second reload after deploy |
 | `02-§96.12` | implemented | Manual browser verification: no clear-site-data or unregister action required from the end user |
 | `02-§96.13` | covered | SWH-08: `sw.js` has no `import`, `require`, or `importScripts` |

--- a/source/static/sw.js
+++ b/source/static/sw.js
@@ -3,7 +3,7 @@
 // cache-first for static assets (CSS, JS, images).
 // The PRE_CACHE_URLS list is injected at build time — see build.js.
 
-const CACHE_NAME = 'sb-sommar-v6';
+const CACHE_NAME = 'sb-sommar-v7';
 
 // Pages and assets to pre-cache on install.
 // The build replaces the placeholder below with the full list of URLs.

--- a/tests/pwa-offline.test.js
+++ b/tests/pwa-offline.test.js
@@ -34,15 +34,15 @@ describe('02-§92.3 — sw.js uses build-injected pre-cache list', () => {
   });
 });
 
-// ── §96.1 — Cache name is sb-sommar-v6 ──────────────────────────────────────
+// ── §96.1 — Cache name is sb-sommar-v7 ──────────────────────────────────────
 
-describe('02-§96.1 — Cache name is sb-sommar-v6', () => {
-  it('OFF-02: sw.js uses sb-sommar-v6 cache name', () => {
+describe('02-§96.1 — Cache name is sb-sommar-v7', () => {
+  it('OFF-02: sw.js uses sb-sommar-v7 cache name', () => {
     const swPath = path.join(__dirname, '..', 'source', 'static', 'sw.js');
     const src = fs.readFileSync(swPath, 'utf8');
     assert.ok(
-      src.includes("'sb-sommar-v6'"),
-      'CACHE_NAME must be sb-sommar-v6',
+      src.includes("'sb-sommar-v7'"),
+      'CACHE_NAME must be sb-sommar-v7',
     );
   });
 });

--- a/tests/pwa.test.js
+++ b/tests/pwa.test.js
@@ -454,12 +454,12 @@ describe('02-§83.33 — Service worker pre-caches offline.html', () => {
 // ── 02-§83.34 — Cache version incremented ───────────────────────────────────
 
 describe('02-§83.34 — Cache version incremented', () => {
-  it('PWA-31: sw.js uses current cache name (sb-sommar-v6 per §96.1)', () => {
+  it('PWA-31: sw.js uses current cache name (sb-sommar-v7 per §96.1)', () => {
     const filePath = path.join(__dirname, '..', 'source', 'static', 'sw.js');
     const src = fs.readFileSync(filePath, 'utf8');
     assert.ok(
-      src.includes("'sb-sommar-v6'"),
-      'CACHE_NAME must be sb-sommar-v6',
+      src.includes("'sb-sommar-v7'"),
+      'CACHE_NAME must be sb-sommar-v7',
     );
   });
 });


### PR DESCRIPTION
## Bakgrund

Service workerns cache-namn var fast (`sb-sommar-v6`), så gamla cachade assets låg kvar tills man rensade manuellt. Det går inte på kiosk-skärmarna (Epiphany/WebKit, inga tangentbord).

## Fix

Bumpa `CACHE_NAME` → `sb-sommar-v7`. `activate`-handlern raderar varje cache vars namn inte är det aktuella, så när den uppdaterade workern tar över bygger den cachen på nytt från färska nätverkssvar i stället för att servera gammalt under det gamla namnet. Tillsammans med `skipWaiting` + `clients.claim` (redan på plats) och reload-loop-spärren (v1.5.4) gör det att enheter som inte kan handrensas **självläker vid nästa service worker-uppdatering efter en deploy**.

## Testplan

- [x] `npm test` — 2087 tester gröna (OFF-02, PWA-31, PWA-18)
- [x] `npm run lint` (eslint) ren
- [x] `npm run lint:md` ren
- [x] Lokal build genererar `sw.js` med `sb-sommar-v7`
- [ ] Manuellt: efter deploy, ladda om en gammal klient och bekräfta att `sb-sommar-v6` raderas och `sb-sommar-v7` fylls från nätverket (DevTools → Application → Cache Storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aVm9LCC67f58nyJzWUYxq)_