### PR TITLE
Add description to Fotboll (2026-06-26)

### DIFF
--- a/source/data/2026-06-syssleback/fotboll-2026-06-26-1930.yaml
+++ b/source/data/2026-06-syssleback/fotboll-2026-06-26-1930.yaml
@@ -6,11 +6,12 @@ event:
   end: '20:30'
   location: Fotbollsplan
   responsible: Valentino
-  description: null
+  description: |
+    Fotboll för alla som vill.
   link: null
   owner:
     name: ''
     email: ''
   meta:
     created_at: 2026-06-26 16:21
-    updated_at: 2026-06-26 16:21
+    updated_at: 2026-06-26 22:57


### PR DESCRIPTION
Adds the description "Fotboll för alla som vill." to the already-published Fotboll activity (`fotboll-2026-06-26-1930`).

The description came from a duplicate submission of the same activity (closed PR #731) which couldn't merge because the fragment file already existed. This restores just the description onto the live activity. Data-only change to one per-camp event fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpE854v1A7iyT6qYYFkbeZ)_