### PR TITLE
Place cancel-activity button beside the delete button

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1170,20 +1170,26 @@ h1.is-cancelled {
   outline-offset: 2px;
 }
 
-/* Cancel/restore-activity toggle on the edit form (02-§118). A quiet outline
-   button by default ("Ställ in aktiviteten"); once the activity is marked
-   cancelled it turns solid terracotta ("Återställ aktiviteten"). */
-.cancel-activity-row {
-  margin-top: var(--space-sm);
+/* The cancel/restore toggle and the delete button sit beside each other at the
+   top-right of the edit form. */
+.edit-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
 }
 
+/* Cancel/restore-activity toggle on the edit form (02-§118). A quiet outline
+   pill by default ("Ställ in aktiviteten"), sized to match the delete pill it
+   sits next to; once the activity is marked cancelled it turns solid terracotta
+   ("Återställ aktiviteten"). */
 .btn-cancel-activity {
   display: inline-block;
   background: transparent;
   color: var(--color-terracotta);
   font-weight: 700;
-  font-size: var(--font-size-small);
-  padding: 8px 18px;
+  font-size: 12px;
+  padding: 6px 16px;
   border: 1.5px solid var(--color-terracotta);
   border-radius: 999px;
   cursor: pointer;
@@ -1205,7 +1211,7 @@ h1.is-cancelled {
 }
 
 .cancel-activity-note {
-  margin: var(--space-xs) 0 0;
+  margin: var(--space-xs) 0 var(--space-sm);
   font-size: var(--font-size-small);
   color: var(--color-charcoal);
   opacity: 0.8;

--- a/source/build/render-edit.js
+++ b/source/build/render-edit.js
@@ -78,8 +78,15 @@ ${pageNav('redigera.html', navSections)}
   <section id="edit-section" hidden>
     <div class="edit-header">
       <h1>Redigera aktivitet</h1>
-      <button type="button" id="btn-delete" class="btn-delete-pill">Radera aktivitet</button>
+      <!-- Cancel/restore toggle (02-§118) sits beside the delete button. Its
+           label flips to "Återställ aktiviteten" once cancelled; the pending
+           state is saved with "Spara ändringar". -->
+      <div class="edit-header-actions">
+        <button type="button" id="btn-cancel" class="btn-cancel-activity">Ställ in aktiviteten</button>
+        <button type="button" id="btn-delete" class="btn-delete-pill">Radera aktivitet</button>
+      </div>
     </div>
+    <p class="cancel-activity-note" id="cancel-activity-note" hidden></p>
 
     <form id="edit-form" class="event-form" novalidate
           data-api-url="${escapeHtml(apiUrl || '/edit-event')}"
@@ -153,14 +160,6 @@ ${locationOptions}
       <div class="form-actions">
         <button type="submit" class="btn-primary">Spara ändringar →</button>
         <a href="schema.html" class="btn-secondary">Avbryt</a>
-      </div>
-
-      <!-- Cancel/restore toggle (02-§118): marks the activity inställd. The
-           label flips to "Återställ aktiviteten" once it is cancelled. The
-           pending state is saved with "Spara ändringar". -->
-      <div class="cancel-activity-row">
-        <button type="button" id="btn-cancel" class="btn-cancel-activity">Ställ in aktiviteten</button>
-        <p class="cancel-activity-note" id="cancel-activity-note" hidden></p>
       </div>
 
     </form>


### PR DESCRIPTION
Follow-up to #728. Moves the "Ställ in aktiviteten" / "Återställ aktiviteten" toggle from its own row at the bottom of the edit form up into the edit header, grouped beside the "Radera aktivitet" button via a new `.edit-header-actions` flex wrapper, and sizes it to match the delete pill. The cancelled-state note moves directly below the header.

## Test plan
- [x] `npm test` (2123 pass), `npm run lint`, `lint:md`, `lint:css`, `lint:html` — all clean.
- [x] Build: `redigera.html` renders `#btn-cancel` and `#btn-delete` side by side inside `.edit-header-actions`.
- [ ] Manual (browser): confirm the two buttons sit beside each other and the toggle still flips label + state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpE854v1A7iyT6qYYFkbeZ)_