### PR TITLE
Cancel/restore activity saves in one click

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -488,13 +488,15 @@ export.
 
 ### 118.2 Marking an activity cancelled (edit form)
 
-- The edit form (`/redigera.html`) has a button that cancels the activity
-  being edited. When the activity is active the button reads
-  "Ställ in aktiviteten"; when it is already cancelled the button reads
+- The edit form (`/redigera.html`) has a button, beside the delete button, that
+  cancels the activity being edited. When the activity is active the button
+  reads "Ställ in aktiviteten"; when it is already cancelled the button reads
   "Återställ aktiviteten", so cancelling can be undone. <!-- 02-§118.4 -->
-- Activating the button sets the `cancelled` state that is saved with the next
-  "Spara ändringar". The current cancelled state of the activity is reflected
-  in the form when it loads. <!-- 02-§118.5 -->
+- The button saves in a single click: activating it persists the new `cancelled`
+  state immediately through the edit API, with no separate "Spara ändringar"
+  step. Because cancelling is reversible, there is no confirmation dialog. The
+  current cancelled state of the activity is reflected in the button when the
+  form loads. <!-- 02-§118.5 -->
 
 ### 118.3 Schedule display
 

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -611,14 +611,16 @@ boolean — so no new endpoint, branch flow, or merge handling is added.
 
 ### 31.1 Edit-form toggle
 
-`render-edit.js` adds a button (`#btn-cancel`) inside the form's
-`.form-actions`. `redigera.js` tracks the current cancelled state in a variable
-seeded from the loaded event (`event.cancelled`), labels the button
-"Ställ in aktiviteten" when active and "Återställ aktiviteten" when cancelled,
-and toggles the variable on click. The edit submit body gains a
-`cancelled: <boolean>` field, sent alongside the existing fields, so "Spara
-ändringar" persists the current state. The button only changes the pending
-state; nothing is written until the form is saved.
+`render-edit.js` adds a button (`#btn-cancel`) in the edit header, beside the
+delete button. `redigera.js` seeds the current cancelled state from the loaded
+event (`event.cancelled`) and labels the button "Ställ in aktiviteten" when
+active and "Återställ aktiviteten" when cancelled. Clicking it saves in one
+step: `submitCancelToggle()` POSTs the current field values plus the flipped
+`cancelled` flag straight to the edit API — reusing the save flow's progress
+modal — and flips the tracked state only on success. There is no confirmation
+dialog (cancelling is reversible) and no separate "Spara ändringar" step. The
+normal save body still carries `cancelled: <boolean>`, so a regular save
+preserves the current state.
 
 ### 31.2 Persistence and validation
 
@@ -635,8 +637,8 @@ state; nothing is written until the form is saved.
 
 | File | Change |
 | --- | --- |
-| `source/build/render-edit.js` | Render the `#btn-cancel` button in `.form-actions` |
-| `source/assets/js/client/redigera.js` | Track cancelled state, toggle label, send `cancelled` in the edit body |
+| `source/build/render-edit.js` | Render the `#btn-cancel` button in the edit header, beside delete |
+| `source/assets/js/client/redigera.js` | `submitCancelToggle()` saves the flipped `cancelled` flag in one click; normal save still carries `cancelled` |
 | `api/src/Validate.php` | Accept optional `cancelled` boolean |
 | `api/src/GitHub.php` | `patchEventObject()` + `eventBodyLines()` round-trip `cancelled` |
 | `source/scripts/lint-yaml.js` | `cancelled` boolean type-check in `validateEventObject()` |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1856,7 +1856,7 @@ Doc ref: `02-requirements/schedule-and-detail.md §118`;
 | `02-§118.2` | covered | PHP `testPatchEventObjectSetsCancelledFromUpdates`/`testBuildFragmentYamlEmitsCancelledTrue`: `patchEventObject()` carries `cancelled` through an edit; `eventBodyLines()` serialises `cancelled: true`. Node mirror `edit-event.js`/`github.js` matches; LINTY-CANCEL type check |
 | `02-§118.3` | covered | PHP `testPatchEventObjectKeepsIdStableWhenCancelling`: `patchEventObject()` keeps `id` unchanged; cancelling rewrites no id-deriving field |
 | `02-§118.4` | covered | RED-CANCEL-01: `render-edit.js` emits `#btn-cancel` with "Ställ in aktiviteten"; the "Återställ aktiviteten" label toggle is a manual/browser checkpoint |
-| `02-§118.5` | implemented | Manual/browser checkpoint: edit body includes `cancelled` (redigera.js `editBody`); form reflects current state on load (redigera.js `populate()` → `cancelledState`) |
+| `02-§118.5` | implemented | Manual/browser checkpoint: `redigera.js` `submitCancelToggle()` POSTs the flipped `cancelled` in one click (no separate save, no confirmation dialog); the normal save body still carries `cancelled`; the button reflects the loaded state via `populate()` → `cancelledState` |
 | `02-§118.6` | covered | RND-CANCEL-01, IDAG-CANCEL-01, REV-CANCEL-01: cancelled row still rendered in schedule/today/event page |
 | `02-§118.7` | covered | RND-CANCEL-02/-03, IDAG-CANCEL-02, REV-CANCEL-01: `renderEventRow()`/`events-today.js`/`renderEventPage()` prefix the title with the `INSTÄLLD` label |
 | `02-§118.8` | covered | CSS-CANCEL-01: `.event-row.is-cancelled` text `line-through`; terracotta only `:not(.is-past)` |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1210,12 +1210,6 @@ h1.is-cancelled {
   outline-offset: 2px;
 }
 
-.cancel-activity-note {
-  margin: var(--space-xs) 0 var(--space-sm);
-  font-size: var(--font-size-small);
-  color: var(--color-charcoal);
-  opacity: 0.8;
-}
 
 .delete-actions {
   display: flex;

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -17,7 +17,6 @@
   var submitBtn    = form ? form.querySelector('button[type="submit"]') : null;
   var deleteBtn    = document.getElementById('btn-delete');
   var cancelBtn    = document.getElementById('btn-cancel');
-  var cancelNote   = document.getElementById('cancel-activity-note');
   var deleteDialog = document.getElementById('delete-confirm');
   var deleteTitle  = document.getElementById('delete-confirm-title');
   var deleteYes    = document.getElementById('delete-confirm-yes');
@@ -153,10 +152,10 @@
     openModal();
   }
 
-  function setModalSuccess(title) {
+  function setModalSuccess(title, heading) {
     clearProgressTimers();
     completeAllSteps();
-    modalHeading.textContent = 'Aktiviteten är uppdaterad!';
+    modalHeading.textContent = heading || 'Aktiviteten är uppdaterad!';
     modalContent.innerHTML =
       '<p class="intro"><strong>' + escHtml(title) + '</strong>' +
       ' syns i schemat inom någon minut, men ibland kan det ta upp till 15 minuter.</p>' +
@@ -324,27 +323,65 @@
 
   // ── Cancel / restore activity toggle (02-§118) ──────────────────────────────
 
-  // Pending cancelled state for the activity being edited. Seeded from the
-  // loaded event and flipped by the toggle; saved with "Spara ändringar".
+  // Current cancelled state of the activity being edited, seeded from the
+  // loaded event. The toggle saves immediately — no separate "Spara ändringar"
+  // is needed (02-§118.5), mirroring how the delete button acts on its own.
   var cancelledState = false;
 
   function updateCancelButton() {
     if (!cancelBtn) return;
     cancelBtn.textContent = cancelledState ? 'Återställ aktiviteten' : 'Ställ in aktiviteten';
     cancelBtn.classList.toggle('is-cancelled', cancelledState);
-    if (cancelNote) {
-      cancelNote.textContent = cancelledState
-        ? 'Aktiviteten är markerad som inställd. Spara ändringarna för att uppdatera schemat.'
-        : '';
-      cancelNote.hidden = !cancelledState;
-    }
+  }
+
+  // Persist a cancel/restore in one click: send the current field values plus
+  // the flipped `cancelled` flag straight to the edit API, with the same
+  // progress modal the save flow uses. Cancelling is reversible, so there is no
+  // confirmation step. `cancelledState` only flips on success.
+  function submitCancelToggle() {
+    if (!form) return;
+    var els = form.elements;
+    var target = !cancelledState;
+    var body = {
+      id:          els.id.value,
+      title:       els.title.value.trim(),
+      date:        els.date.value,
+      start:       els.start.value,
+      end:         els.end.value,
+      location:    els.location.value,
+      responsible: els.responsible.value.trim(),
+      description: els.description.value,
+      link:        els.link.value.trim(),
+      cancelled:   target,
+    };
+    if (adminToken) body.adminToken = adminToken;
+
+    lock();
+    setModalLoading();
+
+    fetch(form.dataset.apiUrl || '/edit-event', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (json) {
+        if (!json.success) {
+          setModalError(json.error || 'Något gick fel.');
+          return;
+        }
+        cancelledState = target;
+        updateCancelButton();
+        setModalSuccess(body.title, target ? 'Aktiviteten är inställd!' : 'Aktiviteten är återställd!');
+      })
+      .catch(function () {
+        setModalError('Något gick fel. Kontrollera din internetanslutning och försök igen.');
+      });
   }
 
   if (cancelBtn) {
-    cancelBtn.addEventListener('click', function () {
-      cancelledState = !cancelledState;
-      updateCancelButton();
-    });
+    cancelBtn.addEventListener('click', submitCancelToggle);
   }
 
   // ── Time-gating (02-§26.9, §26.14–§26.19) ──────────────────────────────────

--- a/source/build/render-edit.js
+++ b/source/build/render-edit.js
@@ -78,15 +78,14 @@ ${pageNav('redigera.html', navSections)}
   <section id="edit-section" hidden>
     <div class="edit-header">
       <h1>Redigera aktivitet</h1>
-      <!-- Cancel/restore toggle (02-§118) sits beside the delete button. Its
-           label flips to "Återställ aktiviteten" once cancelled; the pending
-           state is saved with "Spara ändringar". -->
+      <!-- Cancel/restore toggle (02-§118) sits beside the delete button. It
+           saves in one click — its label flips to "Återställ aktiviteten" once
+           the activity is cancelled. -->
       <div class="edit-header-actions">
         <button type="button" id="btn-cancel" class="btn-cancel-activity">Ställ in aktiviteten</button>
         <button type="button" id="btn-delete" class="btn-delete-pill">Radera aktivitet</button>
       </div>
     </div>
-    <p class="cancel-activity-note" id="cancel-activity-note" hidden></p>
 
     <form id="edit-form" class="event-form" novalidate
           data-api-url="${escapeHtml(apiUrl || '/edit-event')}"


### PR DESCRIPTION
Follow-up to #728. The "Ställ in aktiviteten" / "Återställ aktiviteten" toggle no longer needs a separate "Spara ändringar".

- Clicking it POSTs the flipped `cancelled` flag straight to the edit API (`submitCancelToggle()`), reusing the save progress modal — like the delete button acts on its own.
- No confirmation dialog, since cancelling is reversible; the tracked state flips only on success.
- Removes the now-obsolete "spara ändringarna" note.
- A normal "Spara ändringar" still carries the `cancelled` flag, so it preserves the current state.

Docs (02-§118.5, architecture §31) updated to match.

## Test plan
- [x] `npm test` (2123 pass), eslint / stylelint / markdownlint / html-validate — all clean.
- [x] Build OK; `redigera.html` renders `#btn-cancel` beside `#btn-delete`, no leftover note.
- [x] Deployed to QA (Deploy to QA run #463, success).
- [ ] Manual (browser): one click cancels and flips the label to "Återställ aktiviteten" with no second save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpE854v1A7iyT6qYYFkbeZ)_