### PR TITLE
Cancelled activity never shows the green in-progress highlight

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -764,6 +764,15 @@ body:not(.display-mode) .event-row.is-cancelled:not(.is-past) .ev-meta {
   opacity: 1;
 }
 
+/* A cancelled activity must never wear the green "in progress" highlight — it
+   is off, not running now. Suppress the .is-now background wash and accent bar
+   on cancelled rows; the terracotta struck-through text still marks it. */
+body:not(.display-mode) .event-row.is-cancelled.is-now,
+body.display-mode .event-row.is-cancelled.is-now {
+  background: transparent;
+  box-shadow: none;
+}
+
 .ev-cancelled-label {
   font-weight: 700;
 }

--- a/tests/cancelled-activity.test.js
+++ b/tests/cancelled-activity.test.js
@@ -201,6 +201,15 @@ describe('02-§118.8/.9 — cancelled CSS', () => {
     }
     assert.ok(checked > 0, 'at least one .event-row.is-cancelled terracotta rule exists');
   });
+
+  it('CSS-CANCEL-03: a cancelled in-progress row drops the green is-now highlight', () => {
+    // The .is-cancelled.is-now override must clear the in-progress background
+    // and accent bar, so a cancelled activity never looks like it is running.
+    const rule = CSS.match(/\.event-row\.is-cancelled\.is-now[^{]*\{([^}]*)\}/);
+    assert.ok(rule, '.is-cancelled.is-now override exists');
+    assert.match(rule[1], /background:\s*transparent/, 'background cleared');
+    assert.match(rule[1], /box-shadow:\s*none/, 'accent bar cleared');
+  });
 });
 
 // ── Validation (lint-yaml.js) ────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #728. A cancelled activity whose time is "now" still got the green `.is-now` background wash and accent bar, so it looked like it was running. This suppresses the in-progress highlight on `.is-cancelled` rows (weekly schedule, today view, and display view); the terracotta struck-through "INSTÄLLD" treatment still marks it.

## Test plan
- [x] `npm test`, `lint:css` clean; CSS-CANCEL-03 asserts `.is-cancelled.is-now` clears background + accent bar.
- [x] Build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpE854v1A7iyT6qYYFkbeZ)_