### PR TITLE
Mark moved activities in the schedule (#729)

### DIFF
--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -329,6 +329,15 @@ final class GitHub
         if (!empty($event['cancelled'])) {
             $lines[] = "{$fp}cancelled: true";
         }
+        // Only write the moved block when the activity carries a previous-slot
+        // marker (02-§119.1). Moving it back to its original slot drops it again.
+        if (!empty($event['moved']) && !empty($event['moved']['from_date'])) {
+            $fromEnd  = $event['moved']['from_end'] ?? null;
+            $lines[]  = "{$fp}moved:";
+            $lines[]  = "{$dp}from_date: '{$event['moved']['from_date']}'";
+            $lines[]  = "{$dp}from_start: '{$event['moved']['from_start']}'";
+            $lines[]  = "{$dp}from_end: " . ($fromEnd ? "'{$fromEnd}'" : 'null');
+        }
         $lines[] = "{$fp}owner:";
         $lines[] = "{$dp}name: '" . str_replace("'", "''", $event['owner']['name'] ?? '') . "'";
         $lines[] = "{$dp}email: ''";
@@ -408,12 +417,18 @@ final class GitHub
      */
     public static function patchEventObject(array $event, array $updates, string $now): array
     {
-        return [
+        $date  = array_key_exists('date', $updates) ? ($updates['date'] ?: $event['date']) : $event['date'];
+        $start = array_key_exists('start', $updates) ? ($updates['start'] ?: $event['start']) : $event['start'];
+        $end   = array_key_exists('end', $updates) ? ($updates['end'] ?: null) : ($event['end'] ?? null);
+
+        $moved = self::resolveMoved($event, $date, $start, $end);
+
+        $patched = [
             'id'          => $event['id'],
             'title'       => array_key_exists('title', $updates) ? ($updates['title'] ?: $event['title']) : $event['title'],
-            'date'        => array_key_exists('date', $updates) ? ($updates['date'] ?: $event['date']) : $event['date'],
-            'start'       => array_key_exists('start', $updates) ? ($updates['start'] ?: $event['start']) : $event['start'],
-            'end'         => array_key_exists('end', $updates) ? ($updates['end'] ?: null) : ($event['end'] ?? null),
+            'date'        => $date,
+            'start'       => $start,
+            'end'         => $end,
             'location'    => array_key_exists('location', $updates) ? ($updates['location'] ?: $event['location']) : $event['location'],
             'responsible' => array_key_exists('responsible', $updates) ? ($updates['responsible'] ?: $event['responsible']) : $event['responsible'],
             'description' => array_key_exists('description', $updates) ? ($updates['description'] ?: null) : ($event['description'] ?? null),
@@ -425,6 +440,66 @@ final class GitHub
                 'updated_at' => $now,
             ],
         ];
+        if ($moved !== null) {
+            $patched['moved'] = $moved;
+        }
+
+        return $patched;
+    }
+
+    /**
+     * Normalise a raw `moved` value into null or a clean
+     * { from_date, from_start, from_end } array. A marker needs a previous date
+     * and start; from_end may be null (02-§119.1).
+     *
+     * @param mixed $raw
+     * @return array{from_date:string,from_start:string,from_end:?string}|null
+     */
+    public static function normaliseMoved(mixed $raw): ?array
+    {
+        if (!is_array($raw) || empty($raw['from_date']) || empty($raw['from_start'])) {
+            return null;
+        }
+        $fromEnd = $raw['from_end'] ?? null;
+
+        return [
+            'from_date'  => (string) $raw['from_date'],
+            'from_start' => (string) $raw['from_start'],
+            'from_end'   => $fromEnd ? (string) $fromEnd : null,
+        ];
+    }
+
+    /**
+     * Decide the event's `moved` marker after an edit (02-§119.3–§119.5):
+     * record the slot it left when date/start/end change, clear it when the move
+     * returns it to the slot already recorded in `moved`, and keep the existing
+     * marker untouched on a text-only edit. Mirrors resolveMoved() in
+     * source/api/edit-event.js.
+     *
+     * @param array<string,mixed> $event
+     * @return array{from_date:string,from_start:string,from_end:?string}|null
+     */
+    public static function resolveMoved(array $event, string $newDate, string $newStart, ?string $newEnd): ?array
+    {
+        $oldDate  = (string) $event['date'];
+        $oldStart = (string) $event['start'];
+        $oldEnd   = isset($event['end']) && $event['end'] !== null ? (string) $event['end'] : null;
+        $prev     = self::normaliseMoved($event['moved'] ?? null);
+
+        $timeChanged = $newDate !== $oldDate || $newStart !== $oldStart || $newEnd !== $oldEnd;
+        if (!$timeChanged) {
+            return $prev;
+        }
+
+        if ($prev !== null
+            && $prev['from_date'] === $newDate
+            && $prev['from_start'] === $newStart
+            && ($prev['from_end'] ?? null) === $newEnd
+        ) {
+            return null;
+        }
+
+        return ['from_date' => $oldDate, 'from_start' => $oldStart, 'from_end' => $oldEnd];
     }
 
     /**

--- a/api/tests/GitHubTest.php
+++ b/api/tests/GitHubTest.php
@@ -341,4 +341,58 @@ final class GitHubTest extends TestCase
         $doc = \Symfony\Component\Yaml\Yaml::parse($yaml);
         $this->assertSame('frukost-2026-06-22-0800', $doc['event']['id']);
     }
+
+    // ── moved marker (02-§119) ──────────────────────────────────────────────
+
+    public function testPatchEventObjectRecordsMovedOnStartChange(): void
+    {
+        $patched = GitHub::patchEventObject(self::baseEvent(), ['start' => '10:00'], '2026-06-22 08:00');
+        $this->assertSame(
+            ['from_date' => '2026-06-22', 'from_start' => '08:00', 'from_end' => '09:00'],
+            $patched['moved'],
+        );
+    }
+
+    public function testPatchEventObjectRecordsMovedOnDateChange(): void
+    {
+        $patched = GitHub::patchEventObject(self::baseEvent(), ['date' => '2026-06-24'], '2026-06-22 08:00');
+        $this->assertSame('2026-06-22', $patched['moved']['from_date']);
+    }
+
+    public function testPatchEventObjectPreservesMovedOnTextOnlyEdit(): void
+    {
+        $base = self::baseEvent(['moved' => ['from_date' => '2026-06-21', 'from_start' => '07:00', 'from_end' => '08:00']]);
+        $patched = GitHub::patchEventObject($base, ['title' => 'Nytt namn'], '2026-06-22 08:00');
+        $this->assertSame('2026-06-21', $patched['moved']['from_date']);
+    }
+
+    public function testPatchEventObjectClearsMovedWhenReturnedToOriginalSlot(): void
+    {
+        // Currently at 10:00 with a marker pointing back to 08:00; moving it back
+        // to 08:00 clears the marker (02-§119.5).
+        $base = self::baseEvent([
+            'start' => '10:00',
+            'end'   => '11:00',
+            'moved' => ['from_date' => '2026-06-22', 'from_start' => '08:00', 'from_end' => '09:00'],
+        ]);
+        $patched = GitHub::patchEventObject($base, ['start' => '08:00', 'end' => '09:00'], '2026-06-22 08:00');
+        $this->assertArrayNotHasKey('moved', $patched);
+    }
+
+    public function testBuildFragmentYamlEmitsMovedBlock(): void
+    {
+        $yaml = GitHub::buildFragmentYaml(self::baseEvent([
+            'moved' => ['from_date' => '2026-06-21', 'from_start' => '07:00', 'from_end' => '08:00'],
+        ]));
+        $doc = \Symfony\Component\Yaml\Yaml::parse($yaml);
+        $this->assertSame('2026-06-21', $doc['event']['moved']['from_date']);
+        $this->assertSame('07:00', $doc['event']['moved']['from_start']);
+        $this->assertSame('08:00', $doc['event']['moved']['from_end']);
+    }
+
+    public function testBuildFragmentYamlOmitsMovedWhenAbsent(): void
+    {
+        $yaml = GitHub::buildFragmentYaml(self::baseEvent());
+        $this->assertStringNotContainsString('moved:', $yaml);
+    }
 }

--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -523,3 +523,75 @@ export.
 - In the iCal export (both the full-camp `schema.ics` and the per-event
   `event.ics`), a cancelled activity's VEVENT carries the standard
   `STATUS:CANCELLED` property. <!-- 02-§118.12 -->
+
+---
+
+## 119. Moved Activities
+
+**Context.** When an activity is rescheduled to another time or another day,
+participants who remember the old slot need to see both that it changed and
+where it went. The schedule marks a moved activity in place and leaves a small
+pointer at the slot it used to occupy. This is feedback from a camp organiser
+(issue #729).
+
+### 119.1 Data
+
+- An event may carry an optional `moved` mapping recording the slot it occupied
+  before its most recent reschedule: `from_date` (`YYYY-MM-DD`), `from_start`
+  (`HH:MM`), and `from_end` (`HH:MM` or null). An event that has never been
+  moved, or whose last edit changed only its text, has no `moved` mapping.
+  <!-- 02-§119.1 -->
+- The `moved` mapping is derived and maintained by the edit API, never by a
+  participant directly. The add and edit request bodies do not accept a `moved`
+  field; any `moved` value in a request body is ignored. <!-- 02-§119.2 -->
+
+### 119.2 Capture (edit form)
+
+- When an edit changes an activity's `date`, `start`, or `end`, the edit API
+  records the activity's previous `date`, `start`, and `end` in its `moved`
+  mapping. <!-- 02-§119.3 -->
+- When an edit changes only text fields (title, description, location,
+  responsible, link, cancelled) and leaves `date`, `start`, and `end`
+  unchanged, the activity's existing `moved` mapping is left exactly as it was —
+  a text edit neither creates nor clears the moved marker. <!-- 02-§119.4 -->
+- When an edit moves an activity back to the exact slot recorded in its current
+  `moved` mapping, the `moved` mapping is removed: an activity returned to where
+  it started is no longer marked as moved. <!-- 02-§119.5 -->
+
+### 119.3 Marked time on the activity itself
+
+- In the weekly schedule, the today view, and the per-event page, a moved
+  activity keeps its place at its current (new) time. Its previous time is shown
+  struck through in small text and its new time is highlighted in amber
+  (`--color-amber`). <!-- 02-§119.6 -->
+- When the activity has moved to a different day, the struck-through previous
+  time includes the previous date; when it has only changed time within the same
+  day, only the previous time is shown. <!-- 02-§119.7 -->
+
+### 119.4 Marker at the previous slot
+
+- In the weekly schedule and the today view, a moved activity also appears as a
+  minimal marker at the slot it used to occupy (its `from_date` and
+  `from_start`), sorted into that day at its previous start time. <!-- 02-§119.8 -->
+- The marker shows only the activity's title and the label "Flyttad till" (moved
+  to) followed by the new day and time, or only the new time when the move is
+  within the same day. The marker shows no description, location, responsible,
+  link, or iCal download. <!-- 02-§119.9 -->
+- The per-event page shows no previous-slot marker — it describes a single
+  activity and has no schedule position to mark. <!-- 02-§119.10 -->
+
+### 119.5 Persistence and deletion
+
+- The moved marking and the previous-slot marker stay until the activity is
+  moved again (which records a new previous slot), moved back to its original
+  slot (which clears the marking), or the camp ends. <!-- 02-§119.11 -->
+- The previous-slot marker is derived from the live activity. When an activity
+  is deleted, its previous-slot marker disappears with it; a cancelled
+  ("inställd") activity still exists, so its previous-slot marker remains.
+  <!-- 02-§119.12 -->
+
+### 119.6 Accessibility
+
+- The previous time is conveyed by the visible struck-through text and the
+  "Flyttad till" label, not by colour alone; the amber highlight is an
+  additional cue, never the only one. <!-- 02-§119.13 -->

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -643,3 +643,48 @@ preserves the current state.
 | `api/src/GitHub.php` | `patchEventObject()` + `eventBodyLines()` round-trip `cancelled` |
 | `source/scripts/lint-yaml.js` | `cancelled` boolean type-check in `validateEventObject()` |
 | `source/build/build.js` | Add `cancelled` to `PUBLIC_EVENT_FIELDS` (events.json) |
+
+## 32. Moved Activities (02-§119)
+
+When an edit changes an activity's `date`, `start`, or `end`, the edit API
+records the slot the activity left in an optional `moved` mapping
+(`{ from_date, from_start, from_end }`). This is the only field a participant
+cannot set: the request body never carries `moved`, and the patch derives it
+purely from the event's stored values and the new time — so a client cannot
+forge or clear a marker.
+
+### 32.1 Capture rule
+
+`patchEventObject()` (Node `source/api/edit-event.js`, mirrored in PHP
+`GitHub.php`) computes the new `date`/`start`/`end` first, then calls
+`resolveMoved(event, newDate, newStart, newEnd)`:
+
+- **time/date changed** → record the event's previous `date`/`start`/`end` as
+  the new `moved` mapping (02-§119.3);
+- **unless that move returns the activity to the slot already in its `moved`
+  mapping** → drop the marker; it is back where it started (02-§119.5);
+- **text-only edit** (date/start/end unchanged) → keep the existing `moved`
+  mapping exactly as it was, so a rename or description tweak neither creates nor
+  clears a marker (02-§119.4).
+
+`normaliseMoved()` cleans a loaded marker to either `null` or
+`{ from_date, from_start, from_end }` (with `from_end` allowed to be null), so a
+malformed or partial `moved` value never produces a marker.
+
+### 32.2 Persistence and deletion
+
+`eventBodyLines()` serialises the `moved` block into the fragment YAML only when
+the activity carries one — moving it back to its origin drops the block again
+(02-§119.11). Because the previous-slot marker is **derived from the live event
+at build time** (see `03-architecture/rendering.md §5.7`), deleting an activity
+removes its marker automatically: there is no separate record to clean up
+(02-§119.12).
+
+### 32.3 Files changed
+
+| File | Change |
+| --- | --- |
+| `source/api/edit-event.js` | `resolveMoved()` / `normaliseMoved()`; `patchEventObject()` maintains `moved` |
+| `source/api/github.js` | `eventBodyLines()` serialises the `moved` block |
+| `api/src/GitHub.php` | PHP mirror of the same capture + serialisation |
+| `source/scripts/lint-yaml.js` | `moved` mapping type-check in `validateEventObject()` |

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -153,6 +153,38 @@ rule, so once a cancelled activity is in the past it takes the normal grey
 dimmed treatment; the label and strike-through remain (07-design/components.md
 §6.139–6.141).
 
+### 5.7 Moved activities (02-§119)
+
+An activity rescheduled to another time or day carries an optional `moved`
+mapping recording the slot it left (see `03-architecture/forms-and-api.md §32`).
+The renderers turn that into two things, built from the same merged event set so
+every view agrees. `source/build/moved.js` holds the shared server-side helpers
+(`isMoved`, `movedToText`, `movedFromText`, `movedTimeHtml`, `buildGhosts`);
+`events-today.js` mirrors them for the client-rendered today view.
+
+- **The activity itself** — wherever the activity appears it keeps its place at
+  the new time, with the previous time struck through in small text
+  (`.ev-time-old`) next to the highlighted new time (`.ev-time-new`, amber). The
+  row carries an `is-moved` class. A cross-day move shows the previous date too;
+  a same-day move shows only the previous time. `renderEventRow()` (`render.js`,
+  weekly schedule), `buildRowHtml()` (`events-today.js`, today/display), and
+  `renderEventPage()` (`render-event.js`) all apply this.
+- **A previous-slot marker** — for the weekly schedule and the today view a
+  minimal **ghost** row is generated at the activity's `from_date`/`from_start`:
+  `buildGhosts()` produces one pseudo-event per moved activity, marked `_ghost`,
+  which `renderEventRow()`/`buildRowHtml()` render as the title plus a
+  `Flyttad till …` pointer (`.ev-moved-to`) and nothing else. The ghost carries
+  a `data-event-date` but **no** `data-event-start`, so `schema-status.js` (whose
+  selector requires both) never marks it `is-now`/`is-past`. The per-event page
+  emits no ghost — it has no schedule slot to mark (02-§119.10).
+
+Because the ghost is derived from the live event at build time — never stored as
+its own record — a deleted activity loses its marker automatically, while a
+cancelled ("inställd") activity keeps it (02-§119.12). The today view sorts
+ghosts in with real rows by start time and keeps the real-event count for its
+footer; the live view's per-minute classifier skips ghosts so they always stay
+visible at the old slot.
+
 ---
 
 ## 6. Project Structure

--- a/docs/05-DATA_CONTRACT.md
+++ b/docs/05-DATA_CONTRACT.md
@@ -79,6 +79,10 @@ events:
     description: string (markdown) | null
     link: string | null
     cancelled: boolean | null
+    moved:
+      from_date: YYYY-MM-DD
+      from_start: "HH:MM"
+      from_end: "HH:MM" | null
     owner:
       name: string
       email: string
@@ -126,6 +130,10 @@ event:
   description: string (markdown) | null
   link: string | null
   cancelled: boolean | null
+  moved:
+    from_date: YYYY-MM-DD
+    from_start: "HH:MM"
+    from_end: "HH:MM" | null
   owner:
     name: string
     email: string
@@ -173,6 +181,14 @@ event:
   absent, `null`, or `false` means the activity is active. A cancelled activity
   stays in the schedule, shown struck through and labelled "INSTÄLLD"
   (see `02-requirements/schedule-and-detail.md §118`). <!-- 05-§3.5 -->
+- `moved` — a mapping with `from_date` (`YYYY-MM-DD`), `from_start` (`HH:MM`),
+  and `from_end` (`HH:MM` or null). Present only when the activity has been
+  rescheduled to a different date or time; it records the slot the activity
+  occupied before its most recent reschedule. The edit API maintains this field
+  automatically — it is never set by a participant. A moved activity is shown at
+  its new time with the previous time struck through, and a minimal marker is
+  left at the previous slot
+  (see `02-requirements/schedule-and-detail.md §119`). <!-- 05-§3.6 -->
 - `owner`
 - `meta`
 

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -236,6 +236,12 @@ mint form's per-field validation uses the inline field-error component
 - While the activity is upcoming or in progress, its row text is `var(--color-terracotta)`, the reserved red signal. The "INSTÄLLD" label is part of the visible text, so the cancelled state never depends on colour or strike-through alone. <!-- 07-§6.140 -->
 - Once a cancelled activity has passed (`.is-past`), it takes the same muted grey, `0.5`-opacity treatment as any other past row: the terracotta colour is dropped (the `.is-past` rule wins) while the "INSTÄLLD" label and strike-through remain. <!-- 07-§6.141 -->
 
+### Moved activity (02-§119)
+
+- A moved activity (`.event-row.is-moved`) keeps its place at the new time. Its previous time is shown struck through in small, slightly muted text (`.ev-time-old`) and its new time is highlighted in amber (`.ev-time-new`: a `var(--color-amber)` tint behind bold text). The amber is an additional cue on top of the visible struck-through text — the moved state never depends on colour alone. <!-- 07-§6.142 -->
+- Amber (`var(--color-amber)`) is reserved for the moved-activity marking, distinct from terracotta (cancelled) and sage (in progress), so the three states never read as one another. <!-- 07-§6.143 -->
+- At the slot a moved activity used to occupy, a minimal ghost marker (`.event-row.is-ghost`, muted and italic) shows only the activity's title and a `Flyttad till …` pointer (`.ev-moved-to`, in `var(--color-amber-dark)` for AA-readable text on cream). The marker carries no description, location, responsible, link, or iCal action. <!-- 07-§6.144 -->
+
 ### Display sidebar — portrait layout
 
 `/live.html` is optimised for portrait-orientation screens (e.g. 1080 × 1920 px). The heading moves into the sidebar so events use the full available height from the top of the page. <!-- 07-§6.44 -->

--- a/docs/07-design/css-strategy.md
+++ b/docs/07-design/css-strategy.md
@@ -39,6 +39,8 @@ When CSS is written, start with these at `:root`:
   --color-charcoal: #3B3A38;
   --color-white: #FFFFFF;
   --color-cream-light: #FAF7EF;
+  --color-amber: #E8A23D; /* moved-activity highlight (02-§119) */
+  --color-amber-dark: #8A5A00; /* readable amber-brown for moved text on cream (AA) */
 
   /* Typography */
   --font-sans: system-ui, -apple-system, sans-serif;

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1864,3 +1864,26 @@ Doc ref: `02-requirements/schedule-and-detail.md §118`;
 | `02-§118.10` | covered | RND-CANCEL-02: "INSTÄLLD" is real text in the row (`<span class="ev-cancelled-label">`), announced by screen readers |
 | `02-§118.11` | covered | RSS-CANCEL-01/-02: `render-rss.js` prefixes a cancelled item `<title>` with `[INSTÄLLD]` and a space; active titles unchanged |
 | `02-§118.12` | covered | ICAL-CANCEL-01/-02/-03: `render-ical.js` emits `STATUS:CANCELLED` in `schema.ics` and per-event `event.ics`; active events omit it |
+
+### §119 — Moved Activities
+
+Doc ref: `02-requirements/schedule-and-detail.md §119`;
+`05-DATA_CONTRACT.md §2`, §2.1, §3 (moved field);
+`03-architecture/rendering.md §5.7`, `03-architecture/forms-and-api.md §32`;
+`07-design/components.md §6.142–6.144`, `07-design/css-strategy.md §7`.
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§119.1` | covered | MOVED-12/-13/-14: `buildFragmentYaml()` round-trips/omits the `moved` block; MOVED-15/-16: `lint-yaml.js` validates the mapping. PHP `testBuildFragmentYamlEmitsMovedBlock`/`testBuildFragmentYamlOmitsMovedWhenAbsent` mirror it |
+| `02-§119.2` | covered | MOVED-05: `patchEventObject()` derives `moved` only from stored values + new time; the request body never carries `moved`, so a client cannot set it |
+| `02-§119.3` | covered | MOVED-01/-02/-03: an edit that changes start/end/date records the previous slot. PHP `testPatchEventObjectRecordsMovedOnStartChange`/`...OnDateChange` parity |
+| `02-§119.4` | covered | MOVED-04/-05: a text-only edit leaves an existing marker untouched and adds none. PHP `testPatchEventObjectPreservesMovedOnTextOnlyEdit` |
+| `02-§119.5` | covered | MOVED-06: returning to the recorded original slot clears the marker. PHP `testPatchEventObjectClearsMovedWhenReturnedToOriginalSlot` |
+| `02-§119.6` | covered | MOVED-23/-27: `renderEventRow()` and `renderEventPage()` emit `is-moved` with `.ev-time-old` (struck) + `.ev-time-new` (amber). The today/display view via `events-today.js` `buildRowHtml()` is a manual/browser checkpoint |
+| `02-§119.7` | covered | MOVED-18/-19/-20/-21: `movedFromText()`/`movedToText()` include the date only for a cross-day move |
+| `02-§119.8` | covered | MOVED-22/-24/-25: `buildGhosts()` emits one ghost per moved activity at its old slot; `renderSchedulePage()` places it on the old day. The client ghost on idag/live is a manual/browser checkpoint |
+| `02-§119.9` | covered | MOVED-24: the ghost shows only title + `Flyttad till …` (`.ev-moved-to`) and no detail/iCal |
+| `02-§119.10` | covered | MOVED-27: `renderEventPage()` shows the marked time but emits no ghost (`ev-moved-to` absent) |
+| `02-§119.11` | covered | MOVED-07/-14: a second move records the immediately-prior slot; the block is dropped when the activity returns home. Camp-end clearing follows from the camp lifecycle |
+| `02-§119.12` | implemented | The ghost is derived from the live event (`buildGhosts()` over the merged set), so a deleted activity loses it automatically while a cancelled one keeps it. Verified by the build-integration check (demo fragment → `public/schema.html` ghost + marked row); a manual checkpoint |
+| `02-§119.13` | covered | MOVED-23/-24: the previous time is real struck-through text and the `Flyttad till` label is real text; amber (`.ev-time-new`) is an additional cue. CSS contrast is a manual checkpoint |

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -218,3 +218,5 @@ Part of [the traceability index](./index.md).
 | DEDUP-01..09 | `tests/dedup-submission.test.js` | Duplicate pre-check (Node + PHP): `getFileMaybe` before any branch, 409 + Swedish message, awaited before `app.js`'s response, atomic batch reject (02-§111.1–111.5) |
 | DEDUP-M01..M02 | (manual) | Live 409 on a duplicate submission; a concurrent duplicate's redundant PR is auto-closed (02-§111.2, 111.6–111.9) |
 | DEDUPCLEAN-01..09 | `tests/dedup-cleanup.test.js` | `classifyEventPr` decision table: empty diff → close, fresh add → keep, same-id/different-body → log-manual, out-of-scope → ignore (02-§111.6–111.9) |
+| MOVED-01..27 | `tests/moved-activity.test.js` | Moved-activity capture, serialisation, validation, helpers, schedule/event-page markup + ghost (02-§119) |
+| (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the moved capture + serialisation: `patchEventObject`, `buildFragmentYaml` (02-§119) |

--- a/source/api/edit-event.js
+++ b/source/api/edit-event.js
@@ -9,20 +9,64 @@ function isEventPast(dateStr) {
   return dateStr < today;
 }
 
+// ── moved (rescheduled-activity marker) ───────────────────────────────────────
+
+// Normalise a raw `moved` value from a loaded event into either null or a clean
+// { from_date, from_start, from_end } object. A marker is only meaningful with a
+// previous date and start; from_end may be null (02-§119.1).
+function normaliseMoved(raw) {
+  if (!raw || typeof raw !== 'object' || !raw.from_date || !raw.from_start) return null;
+  return {
+    from_date:  String(raw.from_date),
+    from_start: String(raw.from_start),
+    from_end:   raw.from_end ? String(raw.from_end) : null,
+  };
+}
+
+// Decide the event's `moved` marker after an edit (02-§119.3–§119.5):
+//   - if the edit changed date/start/end, record the slot it left;
+//   - unless that move returns it to the slot already recorded in `moved`, in
+//     which case the marker is cleared (it is back where it started);
+//   - a text-only edit (no date/start/end change) keeps the existing marker.
+function resolveMoved(event, newDate, newStart, newEnd) {
+  const oldDate  = event.date;
+  const oldStart = event.start;
+  const oldEnd   = event.end ?? null;
+  const prev     = normaliseMoved(event.moved);
+
+  const timeChanged = newDate !== oldDate || newStart !== oldStart || newEnd !== oldEnd;
+  if (!timeChanged) return prev;
+
+  if (prev
+      && prev.from_date === newDate
+      && prev.from_start === newStart
+      && (prev.from_end ?? null) === newEnd) {
+    return null;
+  }
+  return { from_date: oldDate, from_start: oldStart, from_end: oldEnd };
+}
+
 // ── patchEventObject ─────────────────────────────────────────────────────────
 
 // Apply `updates` to a single event object, returning a new object with the
 // project's mutable-field rules. This is the only event-edit path: every event
 // lives in its own fragment file, so edits rewrite that file rather than the
 // camp YAML list (02-§109.9, §109.10, §109.26).
-// Immutable: id, owner. Auto-updated: meta.updated_at (created_at preserved).
+// Immutable: id, owner. Auto-updated: meta.updated_at (created_at preserved),
+// moved (the rescheduled-activity marker, 02-§119).
 function patchEventObject(event, updates, now) {
-  return {
+  const date  = 'date'  in updates ? (updates.date  || event.date)  : event.date;
+  const start = 'start' in updates ? (updates.start || event.start) : event.start;
+  const end   = 'end'   in updates ? (updates.end   || null)        : (event.end ?? null);
+
+  const moved = resolveMoved(event, date, start, end);
+
+  const patched = {
     id:          event.id,
     title:       'title'       in updates ? (updates.title       || event.title)       : event.title,
-    date:        'date'        in updates ? (updates.date        || event.date)        : event.date,
-    start:       'start'       in updates ? (updates.start       || event.start)       : event.start,
-    end:         'end'         in updates ? (updates.end   || null)                    : event.end,
+    date,
+    start,
+    end,
     location:    'location'    in updates ? (updates.location    || event.location)    : event.location,
     responsible: 'responsible' in updates ? (updates.responsible || event.responsible) : event.responsible,
     description: 'description' in updates ? (updates.description || null)              : (event.description ?? null),
@@ -34,6 +78,8 @@ function patchEventObject(event, updates, now) {
       updated_at: now,
     },
   };
+  if (moved) patched.moved = moved;
+  return patched;
 }
 
-module.exports = { isEventPast, patchEventObject };
+module.exports = { isEventPast, patchEventObject, normaliseMoved, resolveMoved };

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -58,6 +58,14 @@ function eventBodyLines(event, fp, dp) {
   if (event.cancelled) {
     lines.push(`${fp}cancelled: true`);
   }
+  // Only write the moved block when the activity carries a previous-slot marker
+  // (02-§119.1). Moving it back to its original slot drops the block again.
+  if (event.moved && event.moved.from_date) {
+    lines.push(`${fp}moved:`);
+    lines.push(`${dp}from_date: '${event.moved.from_date}'`);
+    lines.push(`${dp}from_start: '${event.moved.from_start}'`);
+    lines.push(`${dp}from_end: ${event.moved.from_end ? `'${event.moved.from_end}'` : 'null'}`);
+  }
   lines.push(`${fp}owner:`);
   lines.push(`${dp}name: '${((event.owner && event.owner.name) || '').replace(/'/g, "''")}'`);
   lines.push(`${dp}email: ''`);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -9,6 +9,8 @@
   --color-white:      #FFFFFF;
   --color-cream-light:#FAF7EF;
   --color-error:      #b91c1c;
+  --color-amber:      #E8A23D; /* moved-activity highlight (02-§119) */
+  --color-amber-dark: #8A5A00; /* readable amber-brown for moved text on cream (AA) */
   --font-sans:   system-ui, -apple-system, sans-serif;
   --font-serif:  Georgia, serif;
   --font-size-base:  16px;
@@ -775,6 +777,48 @@ body.display-mode .event-row.is-cancelled.is-now {
 
 .ev-cancelled-label {
   font-weight: 700;
+}
+
+/* ── Moved activities (02-§119) ───────────────────────────────────────────────
+   A rescheduled activity keeps its place at the new time: its previous time is
+   struck through in small muted text and its new time is highlighted in amber.
+   A minimal ghost marker (.is-ghost) is left at the slot it used to occupy,
+   showing only the title and a "Flyttad till …" pointer to where it went. */
+.ev-time-old {
+  text-decoration: line-through;
+  font-size: var(--font-size-small);
+  opacity: 0.7;
+  margin-right: 0.25em;
+}
+
+.ev-time-new {
+  background: rgba(232, 162, 61, 0.30); /* var(--color-amber) tint */
+  border-radius: 3px;
+  padding: 0 0.25em;
+  font-weight: 700;
+}
+
+.event-row.is-ghost {
+  opacity: 0.75;
+  font-style: italic;
+}
+
+.ev-moved-to {
+  color: var(--color-amber-dark);
+  font-size: var(--font-size-small);
+  font-style: normal;
+  font-weight: 600;
+  margin-left: 0.5em;
+}
+
+/* Display mode (live.html): amber reads brighter against the dark board. */
+body.display-mode .ev-time-new {
+  background: rgba(232, 162, 61, 0.28);
+  color: var(--color-white);
+}
+
+body.display-mode .ev-moved-to {
+  color: var(--color-amber);
 }
 
 /* ── Per-event detail page ── */

--- a/source/assets/js/client/events-today.js
+++ b/source/assets/js/client/events-today.js
@@ -43,13 +43,19 @@
 
   var todayEvents = events.filter(function (e) { return e.date === today; });
   todayEvents.sort(function (a, b) { return a.start.localeCompare(b.start); });
+  // Today's render list = real events + ghost markers for activities moved away
+  // from today (02-§119.8), sorted together by start time. todayEvents keeps the
+  // real-event count for the footer; todayItems drives rendering and status.
+  var todayItems = todayEvents.concat(buildGhostsFor(today));
+  todayItems.sort(function (a, b) { return a.start.localeCompare(b.start); });
 
   var container = document.getElementById('today-events');
   if (!container) return;
 
-  // idag.html shows today only: with no events there is nothing more to render.
+  // idag.html shows today only: with nothing to render (no events, no ghosts)
+  // there is nothing more to do.
   // live.html (showNextDay) continues so it can still show the next day below.
-  if (todayEvents.length === 0 && !showNextDay) {
+  if (todayItems.length === 0 && !showNextDay) {
     container.innerHTML = '<p class="' + emptyClass + '">Inga aktiviteter schemalagda för idag.</p>';
     return;
   }
@@ -68,6 +74,54 @@
     return /^https?:\/\//i.test(s) ? s : '';
   }
 
+  // ── Moved-activity helpers (02-§119), mirroring source/build/moved.js ──────
+  function shortDate(dateStr) {
+    var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr || '');
+    return m ? parseInt(m[3], 10) + ' ' + months[parseInt(m[2], 10) - 1] : String(dateStr);
+  }
+  function timeRange(s, e) { return e ? (s + '–' + e) : String(s); }
+  function isMovedEvent(e) {
+    return !!(e && e.moved && e.moved.from_date && e.moved.from_start);
+  }
+  // "Flyttad till" target text: new day+time, or just the new time for a
+  // same-day move (02-§119.9).
+  function movedToText(e) {
+    var t = timeRange(e.start, e.end);
+    return e.moved.from_date === e.date ? 'Flyttad till ' + t : 'Flyttad till ' + shortDate(e.date) + ' ' + t;
+  }
+  // Previous-slot text struck through on the activity itself (02-§119.6/7).
+  function movedFromText(e) {
+    var t = timeRange(e.moved.from_start, e.moved.from_end);
+    return e.moved.from_date === e.date ? t : shortDate(e.moved.from_date) + ' ' + t;
+  }
+  // A minimal ghost marker for each activity moved away from `dateStr`
+  // (02-§119.8): title + "Flyttad till …" only, positioned at its old start.
+  function buildGhostsFor(dateStr) {
+    var ghosts = [];
+    for (var i = 0; i < events.length; i++) {
+      var e = events[i];
+      if (isMovedEvent(e) && e.moved.from_date === dateStr) {
+        ghosts.push({
+          _ghost: true,
+          title: e.title,
+          date: e.moved.from_date,
+          start: e.moved.from_start,
+          end: e.moved.from_end || null,
+          movedToText: movedToText(e),
+        });
+      }
+    }
+    return ghosts;
+  }
+  function buildGhostHtml(g) {
+    var timeStr = g.end ? esc(g.start) + '–' + esc(g.end) : esc(g.start);
+    var dateAttr = g.date ? ' data-event-date="' + esc(g.date) + '"' : '';
+    return '<div class="event-row plain is-ghost"' + dateAttr + '>' +
+      '<span class="ev-time">' + timeStr + '</span>' +
+      '<span class="ev-title">' + esc(g.title) + '</span>' +
+      '<span class="ev-moved-to">' + esc(g.movedToText) + '</span></div>';
+  }
+
   // Per-event iCal download link, matching icalDownloadLink() in render.js.
   // Only emitted on idag.html (showIcal) and only when the event has an id.
   function icalLink(e) {
@@ -82,6 +136,13 @@
   // renderEventRow() in render.js.
   function buildRowHtml(e) {
     var timeStr = e.end ? esc(e.start) + '–' + esc(e.end) : esc(e.start);
+    // A moved activity shows its previous time struck through next to the
+    // highlighted new time (02-§119.6).
+    var moved = isMovedEvent(e);
+    var timeCell = moved
+      ? '<span class="ev-time-old">' + esc(movedFromText(e)) + '</span> <span class="ev-time-new">' + timeStr + '</span>'
+      : timeStr;
+    var movedClass = moved ? ' is-moved' : '';
     var metaParts = [e.location, e.responsible].filter(Boolean).map(esc);
     var metaEl = metaParts.length ? '<span class="ev-meta"> · ' + metaParts.join(' · ') + '</span>' : '';
     var icalEl = icalLink(e);
@@ -102,51 +163,55 @@
       if (safeLink) {
         extraParts.push('<a class="event-ext-link" href="' + esc(safeLink) + '" target="_blank" rel="noopener">Extern länk →</a>');
       }
-      return '<details class="event-row' + cancelledClass + '"' + idAttr + dateAttr + '><summary>' +
-        '<span class="ev-time">' + timeStr + '</span>' +
+      return '<details class="event-row' + cancelledClass + movedClass + '"' + idAttr + dateAttr + '><summary>' +
+        '<span class="ev-time">' + timeCell + '</span>' +
         '<span class="ev-title">' + titleHtml + '</span>' +
         metaEl + icalEl + '</summary>' +
         '<div class="event-extra">' + extraParts.join('') + '</div>' +
         '</details>';
     }
-    return '<div class="event-row plain' + cancelledClass + '"' + idAttr + dateAttr + '>' +
-      '<span class="ev-time">' + timeStr + '</span>' +
+    return '<div class="event-row plain' + cancelledClass + movedClass + '"' + idAttr + dateAttr + '>' +
+      '<span class="ev-time">' + timeCell + '</span>' +
       '<span class="ev-title">' + titleHtml + '</span>' +
       metaEl + icalEl + '</div>';
   }
 
-  // Wraps a list of events in a card. The optional id lets the live "now" logic
-  // target today's rows only, leaving the next day's rows untouched.
+  // Wraps a list of items in a card. Each item is either a real event or a
+  // moved-activity ghost marker (_ghost). The optional id lets the live "now"
+  // logic target today's rows only, leaving the next day's rows untouched.
   function renderCard(list, listId) {
     var idAttr = listId ? ' id="' + listId + '"' : '';
     return '<div class="today-card"><div class="event-list"' + idAttr + '>' +
-      list.map(buildRowHtml).join('') + '</div></div>';
+      list.map(function (it) { return it._ghost ? buildGhostHtml(it) : buildRowHtml(it); }).join('') +
+      '</div></div>';
   }
 
   // Next day (display view only): the camp must have another day (tomorrow on or
-  // before the camp end date) and that day must have at least one activity.
-  var tomorrowEvents = [];
+  // before the camp end date) and that day must have at least one item — a real
+  // activity or a ghost for one moved away from tomorrow (02-§119.8).
+  var tomorrowItems = [];
   if (showNextDay) {
     var tmr = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
     var tomorrowStr = tmr.getFullYear() + '-' + pad(tmr.getMonth() + 1) + '-' + pad(tmr.getDate());
     if (!campEnd || tomorrowStr <= campEnd) {
-      tomorrowEvents = events.filter(function (e) { return e.date === tomorrowStr; });
-      tomorrowEvents.sort(function (a, b) { return a.start.localeCompare(b.start); });
+      tomorrowItems = events.filter(function (e) { return e.date === tomorrowStr; })
+        .concat(buildGhostsFor(tomorrowStr));
+      tomorrowItems.sort(function (a, b) { return a.start.localeCompare(b.start); });
     }
   }
 
   var output;
-  if (todayEvents.length) {
-    output = renderCard(todayEvents, 'today-list');
+  if (todayItems.length) {
+    output = renderCard(todayItems, 'today-list');
     if (showFooter) {
       output += '<p class="display-footer">' + todayEvents.length + ' aktiviteter schemalagda idag.</p>';
     }
   } else {
     output = '<p class="' + emptyClass + '">Inga aktiviteter schemalagda för idag.</p>';
   }
-  if (tomorrowEvents.length) {
+  if (tomorrowItems.length) {
     output += '<div class="day-divider"><span>Imorgon</span></div>';
-    output += renderCard(tomorrowEvents, null);
+    output += renderCard(tomorrowItems, null);
   }
   container.innerHTML = output;
 
@@ -163,9 +228,9 @@
       var nowMinIdag = now.getHours() * 60 + now.getMinutes();
       var idagRows = idagListEl.querySelectorAll('.event-row');
       for (var r = 0; r < idagRows.length; r++) {
-        var iev = todayEvents[r];
+        var iev = todayItems[r];
         var iel = idagRows[r];
-        if (!iev || !iel) continue;
+        if (!iev || !iel || iev._ghost) continue;
         var iStart = toMinutes(iev.start);
         if (iStart == null) continue;
         var iEnd = iev.end ? toMinutes(iev.end) : null;
@@ -242,12 +307,15 @@
       var nowMin = d.getHours() * 60 + d.getMinutes();
       var visible = 0;
       for (var i = 0; i < rowEls.length; i++) {
-        var ev = todayEvents[i];
+        var ev = todayItems[i];
         var el = rowEls[i];
         if (!ev || !el) continue;
+        el.classList.remove('is-past', 'is-now');
+        // A ghost marker (02-§119.8) is never "now" or "past": it always stays
+        // visible at its old slot and points to the new time.
+        if (ev._ghost) { visible += 1; continue; }
         var startMin = toMinutes(ev.start);
         var endMin = ev.end ? toMinutes(ev.end) : null;
-        el.classList.remove('is-past', 'is-now');
         if (startMin == null) { visible += 1; continue; }
         // End at or before start means the activity crosses midnight.
         if (endMin != null && endMin <= startMin) endMin += 24 * 60;

--- a/source/build/moved.js
+++ b/source/build/moved.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Server-side helpers for the moved-activity marking (02-§119). A moved event
+// carries a `moved` mapping ({ from_date, from_start, from_end }) recording the
+// slot it occupied before its most recent reschedule. The activity itself shows
+// its previous time struck through next to its highlighted new time, and a
+// minimal "ghost" marker is left at the slot it used to occupy.
+
+const { escapeHtml, formatDateShort } = require('./utils');
+
+// True when the event carries a usable previous-slot marker.
+function isMoved(e) {
+  return !!(e && e.moved && e.moved.from_date && e.moved.from_start);
+}
+
+// Format an "HH:MM" or "HH:MM–HH:MM" time range.
+function timeRange(start, end) {
+  return end ? `${start}–${end}` : String(start);
+}
+
+// "Flyttad till" target text for a moved activity (02-§119.9): the new day and
+// time, or just the new time when the move stayed within the same day.
+function movedToText(e) {
+  const time = timeRange(e.start, e.end);
+  return e.moved.from_date === e.date
+    ? `Flyttad till ${time}`
+    : `Flyttad till ${formatDateShort(e.date)} ${time}`;
+}
+
+// Previous-slot text shown struck through on the activity itself
+// (02-§119.6, §119.7): the old day and time, or just the old time for a
+// same-day move.
+function movedFromText(e) {
+  const time = timeRange(e.moved.from_start, e.moved.from_end);
+  return e.moved.from_date === e.date ? time : `${formatDateShort(e.moved.from_date)} ${time}`;
+}
+
+// Inner HTML for the .ev-time cell of a moved activity: previous time struck
+// through in small text, new time highlighted in amber (02-§119.6).
+// `newTimeStr` is the already-escaped current-time string.
+function movedTimeHtml(e, newTimeStr) {
+  return `<span class="ev-time-old">${escapeHtml(movedFromText(e))}</span> `
+    + `<span class="ev-time-new">${newTimeStr}</span>`;
+}
+
+// Build a previous-slot ghost marker for each moved activity (02-§119.8): a
+// minimal pseudo-event positioned at the old date/start. Marked `_ghost` so the
+// row renderer emits the stripped-down marker (title + "Flyttad till" only).
+function buildGhosts(events) {
+  return events.filter(isMoved).map((e) => ({
+    _ghost: true,
+    title: e.title,
+    date: e.moved.from_date,
+    start: e.moved.from_start,
+    end: e.moved.from_end || null,
+    movedToText: movedToText(e),
+  }));
+}
+
+module.exports = { isMoved, movedToText, movedFromText, movedTimeHtml, buildGhosts };

--- a/source/build/render-event.js
+++ b/source/build/render-event.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { escapeHtml, formatDate, toDateString, safeLinkHref } = require('./utils');
+const { isMoved, movedTimeHtml } = require('./moved');
 const { pageNav, pageFooter } = require('./layout');
 const { renderDescriptionHtml } = require('./markdown');
 const { pwaHeadTags } = require('./pwa');
@@ -55,6 +56,10 @@ function renderEventPage(event, camp, siteUrl, footerHtml = '', navSections = []
   const timeStr = event.end
     ? `${escapeHtml(String(event.start))}–${escapeHtml(String(event.end))}`
     : escapeHtml(String(event.start));
+  // A moved activity shows its previous time struck through beside the
+  // highlighted new time (02-§119.6). The per-event page carries no ghost
+  // marker — it describes one activity and has no schedule slot (02-§119.10).
+  const timeDisplay = isMoved(event) ? movedTimeHtml(event, timeStr) : timeStr;
 
   let descriptionHtml = '';
   if (event.description) {
@@ -88,7 +93,7 @@ ${pageNav('schema.html', navSections)}
   <p class="back-link"><a href="schema.html">← Tillbaka till schemat</a></p>
   <h1${h1Class}>${h1Inner}</h1>
   <div class="event-detail">
-    <p>📅 ${date} 🕐 ${timeStr}</p>
+    <p>📅 ${date} 🕐 ${timeDisplay}</p>
     <p>📍 <strong>Plats:</strong> ${escapeHtml(event.location)} · 👤 <strong>Ansvarig:</strong> ${escapeHtml(event.responsible)}</p>
     <p>📆 <a href="schema/${escapeHtml(String(event.id))}/event.ics" download>Lägg till i kalender (.ics)</a></p>
 ${conflictHtml}${descriptionHtml}${linkHtml}  </div>

--- a/source/build/render-idag.js
+++ b/source/build/render-idag.js
@@ -26,6 +26,7 @@ function renderIdagPage(camp, events, footerHtml = '', navSections = [], cookieD
       descriptionHtml: e.description ? renderDescriptionHtml(e.description) : null,
       link: e.link || null,
       cancelled: e.cancelled === true,
+      moved: e.moved && e.moved.from_date ? e.moved : null,
     })),
   );
 

--- a/source/build/render-today.js
+++ b/source/build/render-today.js
@@ -37,6 +37,7 @@ function renderTodayPage(camp, events, qrSvg, siteUrl = '', buildTime = '', goat
       descriptionHtml: e.description ? renderDescriptionHtml(e.description) : null,
       link: e.link || null,
       cancelled: e.cancelled === true,
+      moved: e.moved && e.moved.from_date ? e.moved : null,
     })),
   );
 

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -2,6 +2,7 @@
 
 const { pageNav, pageFooter } = require('./layout');
 const { toDateString, escapeHtml, formatDate, safeLinkHref } = require('./utils');
+const { isMoved, movedTimeHtml, buildGhosts } = require('./moved');
 const { renderDescriptionHtml } = require('./markdown');
 const { goatcounterScript } = require('./analytics');
 const { pwaHeadTags } = require('./pwa');
@@ -49,10 +50,35 @@ function icalDownloadLink(e) {
 // by screen readers — the cancelled state never relies on colour alone.
 const CANCELLED_LABEL = '<span class="ev-cancelled-label">INSTÄLLD</span> ';
 
-function renderEventRow(e) {
+// A previous-slot ghost marker for a moved activity (02-§119.8): the title and a
+// "Flyttad till …" pointer only — no meta, detail, or iCal link. It carries a
+// data-event-date but no data-event-start, so schema-status.js never marks it
+// is-now/is-past (its selector requires both attributes).
+function renderGhostRow(e) {
   const timeStr = e.end
     ? `${escapeHtml(String(e.start))}–${escapeHtml(String(e.end))}`
     : escapeHtml(String(e.start));
+  const dateAttr = e.date ? ` data-event-date="${escapeHtml(String(e.date))}"` : '';
+  return [
+    `    <div class="event-row plain is-ghost"${dateAttr}>`,
+    `      <span class="ev-time">${timeStr}</span>`,
+    `      <span class="ev-title">${escapeHtml(e.title)}</span>`,
+    `      <span class="ev-moved-to">${escapeHtml(e.movedToText)}</span>`,
+    '    </div>',
+  ].join('\n');
+}
+
+function renderEventRow(e) {
+  if (e._ghost) return renderGhostRow(e);
+
+  const timeStr = e.end
+    ? `${escapeHtml(String(e.start))}–${escapeHtml(String(e.end))}`
+    : escapeHtml(String(e.start));
+  // A moved activity shows its previous time struck through next to the
+  // highlighted new time (02-§119.6); otherwise the plain time string.
+  const moved = isMoved(e);
+  const timeCellHtml = moved ? movedTimeHtml(e, timeStr) : timeStr;
+  const movedClass = moved ? ' is-moved' : '';
   const metaParts = [e.location, e.responsible].filter(Boolean).map(escapeHtml);
   const metaEl = metaParts.length ? `<span class="ev-meta"> · ${metaParts.join(' · ')}</span>` : '';
   const icalEl = icalDownloadLink(e);
@@ -72,9 +98,9 @@ function renderEventRow(e) {
 
   if (hasExtra) {
     return [
-      `    <details class="event-row${cancelledClass}"${idAttr}${timeAttrs}>`,
+      `    <details class="event-row${cancelledClass}${movedClass}"${idAttr}${timeAttrs}>`,
       '      <summary>',
-      `        <span class="ev-time">${timeStr}</span>`,
+      `        <span class="ev-time">${timeCellHtml}</span>`,
       `        <span class="ev-title">${titleHtml}</span>`,
       metaEl ? `        ${metaEl}` : '',
       icalEl ? `        ${icalEl}` : '',
@@ -86,8 +112,8 @@ function renderEventRow(e) {
       .join('\n');
   } else {
     return [
-      `    <div class="event-row plain${cancelledClass}"${idAttr}${timeAttrs}>`,
-      `      <span class="ev-time">${timeStr}</span>`,
+      `    <div class="event-row plain${cancelledClass}${movedClass}"${idAttr}${timeAttrs}>`,
+      `      <span class="ev-time">${timeCellHtml}</span>`,
       `      <span class="ev-title">${titleHtml}</span>`,
       metaEl ? `      ${metaEl}` : '',
       icalEl ? `      ${icalEl}` : '',
@@ -111,7 +137,9 @@ function renderDaySection(date, dayEvents) {
 }
 
 function renderSchedulePage(camp, events, footerHtml = '', navSections = [], siteUrl = '', cookieDomain = '', goatcounterCode = '') {
-  const { dates, byDate } = groupAndSortEvents(events);
+  // A moved activity also leaves a minimal ghost marker at its previous slot
+  // (02-§119.8); ghosts group and sort into their old day like any other row.
+  const { dates, byDate } = groupAndSortEvents(events.concat(buildGhosts(events)));
   const daySections = dates.map((date) => renderDaySection(date, byDate[date])).join('\n\n');
   const campName = escapeHtml(camp.name);
 

--- a/source/build/utils.js
+++ b/source/build/utils.js
@@ -59,6 +59,13 @@ function formatDate(dateStr) {
   return `${weekday} ${day} ${month} ${year}`;
 }
 
+// Short Swedish date ("27 juni"), used where a full weekday+year date would be
+// too long — e.g. the previous date on a moved activity (02-§119.7).
+function formatDateShort(dateStr) {
+  const d = new Date(dateStr + 'T12:00:00');
+  return `${d.getDate()} ${MONTHS_SV[d.getMonth()]}`;
+}
+
 const WEEKDAYS_SHORT_SV = ['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'];
 
 /**
@@ -110,4 +117,4 @@ function injectHtaccessCsp(template, apiUrl) {
   return template.replace(/__API_ORIGIN__ ?/g, origin ? origin + ' ' : '');
 }
 
-module.exports = { toDateString, resolveCountdownTarget, escapeHtml, formatDate, campDayButtons, safeLinkHref, injectHtaccessCsp };
+module.exports = { toDateString, resolveCountdownTarget, escapeHtml, formatDate, formatDateShort, campDayButtons, safeLinkHref, injectHtaccessCsp };

--- a/source/scripts/lint-yaml.js
+++ b/source/scripts/lint-yaml.js
@@ -100,6 +100,24 @@ function validateEventObject(event, ref, opts = {}) {
   if (event.cancelled !== undefined && event.cancelled !== null && typeof event.cancelled !== 'boolean') {
     errors.push(`${ref}: cancelled must be a boolean or null`);
   }
+  // moved is an optional previous-slot marker (05-§3.6, 02-§119.1): a mapping
+  // with from_date (YYYY-MM-DD), from_start (HH:MM), and from_end (HH:MM|null).
+  if (event.moved !== undefined && event.moved !== null) {
+    const m = event.moved;
+    if (typeof m !== 'object' || Array.isArray(m)) {
+      errors.push(`${ref}: moved must be a mapping`);
+    } else {
+      if (!DATE_RE.test(String(m.from_date))) {
+        errors.push(`${ref}: moved.from_date must be YYYY-MM-DD, got "${m.from_date}"`);
+      }
+      if (!TIME_RE.test(String(m.from_start))) {
+        errors.push(`${ref}: moved.from_start must be HH:MM, got "${m.from_start}"`);
+      }
+      if (m.from_end !== undefined && m.from_end !== null && !TIME_RE.test(String(m.from_end))) {
+        errors.push(`${ref}: moved.from_end must be HH:MM or null, got "${m.from_end}"`);
+      }
+    }
+  }
 
   return errors;
 }

--- a/tests/moved-activity.test.js
+++ b/tests/moved-activity.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+// Tests for the moved-activity marking (02-§119): the edit API records the slot
+// a rescheduled activity left, the renderers show the previous time struck
+// through next to the highlighted new time, and a minimal ghost marker is left
+// at the previous slot.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const yaml = require('js-yaml');
+
+const { patchEventObject, resolveMoved, normaliseMoved } = require('../source/api/edit-event');
+const { buildFragmentYaml } = require('../source/api/github');
+const { validateYaml } = require('../source/scripts/lint-yaml');
+const { isMoved, movedToText, movedFromText, buildGhosts } = require('../source/build/moved');
+const { renderSchedulePage, renderEventRow } = require('../source/build/render');
+const { renderEventPage } = require('../source/build/render-event');
+
+function baseEvent(overrides = {}) {
+  return Object.assign({
+    id: 'frukost-2026-06-22-0800',
+    title: 'Frukost',
+    date: '2026-06-22',
+    start: '08:00',
+    end: '09:00',
+    location: 'Matsalen',
+    responsible: 'Alla',
+    description: null,
+    link: null,
+    owner: { name: '', email: '' },
+    meta: { created_at: '2026-06-22 07:00', updated_at: '2026-06-22 07:00' },
+  }, overrides);
+}
+
+const NOW = '2026-06-22 08:00';
+
+describe('patchEventObject – moved capture (02-§119.3–§119.5)', () => {
+  it('MOVED-01: records the previous slot when start changes', () => {
+    const p = patchEventObject(baseEvent(), { start: '10:00' }, NOW);
+    assert.deepEqual(p.moved, { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' });
+  });
+
+  it('MOVED-02: records the previous slot when end changes', () => {
+    const p = patchEventObject(baseEvent(), { end: '09:30' }, NOW);
+    assert.deepEqual(p.moved, { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' });
+  });
+
+  it('MOVED-03: records the previous slot when the date changes', () => {
+    const p = patchEventObject(baseEvent(), { date: '2026-06-24' }, NOW);
+    assert.equal(p.moved.from_date, '2026-06-22');
+  });
+
+  it('MOVED-04: a text-only edit leaves an existing marker untouched', () => {
+    const ev = baseEvent({ moved: { from_date: '2026-06-21', from_start: '07:00', from_end: '08:00' } });
+    const p = patchEventObject(ev, { title: 'Nytt' }, NOW);
+    assert.deepEqual(p.moved, { from_date: '2026-06-21', from_start: '07:00', from_end: '08:00' });
+  });
+
+  it('MOVED-05: a text-only edit on an unmoved activity adds no marker', () => {
+    const p = patchEventObject(baseEvent(), { title: 'Nytt' }, NOW);
+    assert.equal(p.moved, undefined);
+  });
+
+  it('MOVED-06: moving back to the recorded original slot clears the marker', () => {
+    const ev = baseEvent({ start: '10:00', end: '11:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+    const p = patchEventObject(ev, { start: '08:00', end: '09:00' }, NOW);
+    assert.equal(p.moved, undefined);
+  });
+
+  it('MOVED-07: a second move records the immediately-prior slot', () => {
+    const ev = baseEvent({ start: '10:00', end: '11:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+    const p = patchEventObject(ev, { start: '12:00', end: '13:00' }, NOW);
+    assert.deepEqual(p.moved, { from_date: '2026-06-22', from_start: '10:00', from_end: '11:00' });
+  });
+
+  it('MOVED-08: the id never changes when an activity is moved', () => {
+    const p = patchEventObject(baseEvent(), { start: '10:00' }, NOW);
+    assert.equal(p.id, 'frukost-2026-06-22-0800');
+  });
+});
+
+describe('normaliseMoved / resolveMoved (02-§119.1)', () => {
+  it('MOVED-09: normaliseMoved rejects a value with no from_date', () => {
+    assert.equal(normaliseMoved({ from_start: '08:00' }), null);
+  });
+
+  it('MOVED-10: normaliseMoved keeps a null from_end', () => {
+    assert.deepEqual(normaliseMoved({ from_date: '2026-06-22', from_start: '08:00' }),
+      { from_date: '2026-06-22', from_start: '08:00', from_end: null });
+  });
+
+  it('MOVED-11: resolveMoved returns null when nothing changed', () => {
+    assert.equal(resolveMoved(baseEvent(), '2026-06-22', '08:00', '09:00'), null);
+  });
+});
+
+describe('buildFragmentYaml – moved serialisation (02-§119.1)', () => {
+  it('MOVED-12: round-trips the moved block', () => {
+    const y = buildFragmentYaml(baseEvent({ moved: { from_date: '2026-06-21', from_start: '07:00', from_end: '08:00' } }));
+    const doc = yaml.load(y);
+    assert.deepEqual(doc.event.moved, { from_date: '2026-06-21', from_start: '07:00', from_end: '08:00' });
+  });
+
+  it('MOVED-13: serialises a null from_end', () => {
+    const y = buildFragmentYaml(baseEvent({ end: null, moved: { from_date: '2026-06-21', from_start: '07:00', from_end: null } }));
+    const doc = yaml.load(y);
+    assert.equal(doc.event.moved.from_end, null);
+  });
+
+  it('MOVED-14: omits the moved block when absent', () => {
+    assert.ok(!buildFragmentYaml(baseEvent()).includes('moved:'));
+  });
+});
+
+describe('lint-yaml – moved validation (05-§3.6)', () => {
+  const wrap = (eventLines) => `camp:\n  id: c\n  name: C\n  location: L\n  start_date: '2026-06-22'\n  end_date: '2026-06-28'\nevents:\n${eventLines}\n`;
+  const valid = [
+    "- id: a-2026-06-24-1000",
+    "  title: A",
+    "  date: '2026-06-24'",
+    "  start: '10:00'",
+    "  end: '11:00'",
+    "  location: L",
+    "  responsible: R",
+  ];
+
+  it('MOVED-15: accepts a well-formed moved block', () => {
+    const lines = valid.concat([
+      '  moved:',
+      "    from_date: '2026-06-22'",
+      "    from_start: '08:00'",
+      "    from_end: '09:00'",
+    ]).join('\n');
+    assert.equal(validateYaml(wrap(lines)).ok, true);
+  });
+
+  it('MOVED-16: rejects a bad moved.from_start', () => {
+    const lines = valid.concat([
+      '  moved:',
+      "    from_date: '2026-06-22'",
+      "    from_start: 'nope'",
+    ]).join('\n');
+    const res = validateYaml(wrap(lines));
+    assert.equal(res.ok, false);
+    assert.ok(res.errors.some((e) => /moved\.from_start/.test(e)));
+  });
+});
+
+describe('moved.js helpers (02-§119.7–§119.9)', () => {
+  const movedDiffDay = baseEvent({ date: '2026-06-24', start: '16:00', end: '17:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+  const movedSameDay = baseEvent({ start: '16:00', end: '17:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+
+  it('MOVED-17: isMoved is false without a marker', () => {
+    assert.equal(isMoved(baseEvent()), false);
+  });
+
+  it('MOVED-18: movedToText includes the new date for a cross-day move', () => {
+    assert.equal(movedToText(movedDiffDay), 'Flyttad till 24 juni 16:00–17:00');
+  });
+
+  it('MOVED-19: movedToText omits the date for a same-day move', () => {
+    assert.equal(movedToText(movedSameDay), 'Flyttad till 16:00–17:00');
+  });
+
+  it('MOVED-20: movedFromText omits the date for a same-day move', () => {
+    assert.equal(movedFromText(movedSameDay), '08:00–09:00');
+  });
+
+  it('MOVED-21: movedFromText includes the date for a cross-day move', () => {
+    assert.equal(movedFromText(movedDiffDay), '22 juni 08:00–09:00');
+  });
+
+  it('MOVED-22: buildGhosts emits one ghost per moved activity at its old slot', () => {
+    const ghosts = buildGhosts([movedDiffDay, baseEvent()]);
+    assert.equal(ghosts.length, 1);
+    assert.equal(ghosts[0].date, '2026-06-22');
+    assert.equal(ghosts[0].start, '08:00');
+    assert.equal(ghosts[0]._ghost, true);
+  });
+});
+
+describe('renderEventRow / renderSchedulePage – moved markup (02-§119.6, §119.8)', () => {
+  const moved = baseEvent({ date: '2026-06-24', start: '16:00', end: '17:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+
+  it('MOVED-23: a moved row carries is-moved with struck old + amber new time', () => {
+    const html = renderEventRow(moved);
+    assert.ok(html.includes('is-moved'));
+    assert.ok(html.includes('<span class="ev-time-old">22 juni 08:00–09:00</span>'));
+    assert.ok(html.includes('<span class="ev-time-new">16:00–17:00</span>'));
+  });
+
+  it('MOVED-24: a ghost row shows title + Flyttad till and no detail', () => {
+    const html = renderEventRow({ _ghost: true, title: 'Frukost', date: '2026-06-22', start: '08:00', end: '09:00', movedToText: 'Flyttad till 24 juni 16:00–17:00' });
+    assert.ok(html.includes('is-ghost'));
+    assert.ok(html.includes('Flyttad till 24 juni 16:00–17:00'));
+    assert.ok(!html.includes('data-event-start'));
+  });
+
+  it('MOVED-25: the schedule shows the activity on its new day and a ghost on the old day', () => {
+    const html = renderSchedulePage({ name: 'Test' }, [moved]);
+    assert.ok(html.includes('<details class="day" id="2026-06-22" open>'));
+    assert.ok(html.includes('<details class="day" id="2026-06-24" open>'));
+    assert.ok(html.includes('ev-moved-to'));
+  });
+
+  it('MOVED-26: an unmoved schedule is unchanged (no ghost rows)', () => {
+    const html = renderSchedulePage({ name: 'Test' }, [baseEvent()]);
+    assert.ok(!html.includes('is-ghost'));
+    assert.ok(!html.includes('is-moved'));
+  });
+});
+
+describe('renderEventPage – moved time, no ghost (02-§119.6, §119.10)', () => {
+  it('MOVED-27: the event page shows struck old time and highlighted new time', () => {
+    const moved = baseEvent({ date: '2026-06-24', start: '16:00', end: '17:00', moved: { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' } });
+    const html = renderEventPage(moved, { name: 'Test' }, '');
+    assert.ok(html.includes('ev-time-old'));
+    assert.ok(html.includes('ev-time-new'));
+    assert.ok(!html.includes('ev-moved-to'));
+  });
+});


### PR DESCRIPTION
## Summary

Implements "Flyttad aktivitet" (issue #729): when an activity is rescheduled, the schedule shows where it went and leaves a pointer at the slot it used to occupy.

- **Capture** — when an edit changes an activity's `date`, `start`, or `end`, the edit API records the slot it left in an optional `moved` mapping (`{ from_date, from_start, from_end }`). A text-only edit leaves the marker untouched; moving the activity back to its original slot clears it. The field is server-derived only — the request body never carries `moved`. Implemented in both the Node (`source/api`) and PHP (`api/src/GitHub.php`) edit paths so it triggers in QA/production.
- **Marked time** — wherever a moved activity appears (weekly schedule, today/display view, per-event page) it keeps its place at the new time, with the previous time struck through in small text and the new time highlighted in a new amber token (`--color-amber`). A cross-day move shows the previous date; a same-day move shows only the time.
- **Previous-slot marker** — in the weekly schedule and today view, a minimal "ghost" row appears at the old slot showing only the title and a `Flyttad till …` pointer. It is derived from the live event at build time, so deleting the activity removes it automatically while a cancelled ("inställd") activity keeps it. The per-event page has no ghost — it has no schedule slot.

Trigger, persistence, scope, and colour were agreed on the issue during Phase 0.

## Test plan

- [x] `node --test tests/*.test.js` — 2151 pass (27 new in `tests/moved-activity.test.js`)
- [x] PHPUnit `api/tests` — 97 pass (6 new for capture + serialisation)
- [x] `eslint`, `stylelint`, `markdownlint` clean
- [x] Full build green; integration-checked a moved demo fragment → `public/schema.html` shows the ghost on the old day and the struck-old/amber-new time on the new day, then removed the fixture
- [ ] Browser walkthrough on QA: confirm the amber highlight, struck-through previous time, and ghost marker on `idag.html`, the weekly schedule, and a per-event page

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdnDXc2vtPRnpBcfWKayg)_