### PR TITLE
Mark location changes on activities (#729)

### DIFF
--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -338,6 +338,12 @@ final class GitHub
             $lines[]  = "{$dp}from_start: '{$event['moved']['from_start']}'";
             $lines[]  = "{$dp}from_end: " . ($fromEnd ? "'{$fromEnd}'" : 'null');
         }
+        // Only write the relocated block when the activity carries a previous
+        // location (02-§119.14). Restoring the original location drops it again.
+        if (!empty($event['relocated']) && !empty($event['relocated']['from_location'])) {
+            $lines[] = "{$fp}relocated:";
+            $lines[] = "{$dp}from_location: " . self::yamlScalar($event['relocated']['from_location']);
+        }
         $lines[] = "{$fp}owner:";
         $lines[] = "{$dp}name: '" . str_replace("'", "''", $event['owner']['name'] ?? '') . "'";
         $lines[] = "{$dp}email: ''";
@@ -423,13 +429,16 @@ final class GitHub
 
         $moved = self::resolveMoved($event, $date, $start, $end);
 
+        $location  = array_key_exists('location', $updates) ? ($updates['location'] ?: $event['location']) : $event['location'];
+        $relocated = self::resolveRelocated($event, (string) $location);
+
         $patched = [
             'id'          => $event['id'],
             'title'       => array_key_exists('title', $updates) ? ($updates['title'] ?: $event['title']) : $event['title'],
             'date'        => $date,
             'start'       => $start,
             'end'         => $end,
-            'location'    => array_key_exists('location', $updates) ? ($updates['location'] ?: $event['location']) : $event['location'],
+            'location'    => $location,
             'responsible' => array_key_exists('responsible', $updates) ? ($updates['responsible'] ?: $event['responsible']) : $event['responsible'],
             'description' => array_key_exists('description', $updates) ? ($updates['description'] ?: null) : ($event['description'] ?? null),
             'link'        => array_key_exists('link', $updates) ? ($updates['link'] ?: null) : ($event['link'] ?? null),
@@ -443,8 +452,52 @@ final class GitHub
         if ($moved !== null) {
             $patched['moved'] = $moved;
         }
+        if ($relocated !== null) {
+            $patched['relocated'] = $relocated;
+        }
 
         return $patched;
+    }
+
+    /**
+     * Normalise a raw `relocated` value into null or a clean { from_location }
+     * array. A marker needs a non-empty previous location (02-§119.14).
+     *
+     * @param mixed $raw
+     * @return array{from_location:string}|null
+     */
+    public static function normaliseRelocated(mixed $raw): ?array
+    {
+        if (!is_array($raw) || empty($raw['from_location'])) {
+            return null;
+        }
+
+        return ['from_location' => (string) $raw['from_location']];
+    }
+
+    /**
+     * Decide the event's `relocated` marker after an edit (02-§119.15): record
+     * the location it left when the location changes, clear it when the change
+     * restores the recorded original, and keep the existing marker untouched when
+     * the location is unchanged. Mirrors resolveRelocated() in
+     * source/api/edit-event.js.
+     *
+     * @param array<string,mixed> $event
+     * @return array{from_location:string}|null
+     */
+    public static function resolveRelocated(array $event, string $newLocation): ?array
+    {
+        $oldLocation = (string) $event['location'];
+        $prev        = self::normaliseRelocated($event['relocated'] ?? null);
+
+        if ($newLocation === $oldLocation) {
+            return $prev;
+        }
+        if ($prev !== null && $prev['from_location'] === $newLocation) {
+            return null;
+        }
+
+        return ['from_location' => $oldLocation];
     }
 
     /**

--- a/api/tests/GitHubTest.php
+++ b/api/tests/GitHubTest.php
@@ -395,4 +395,41 @@ final class GitHubTest extends TestCase
         $yaml = GitHub::buildFragmentYaml(self::baseEvent());
         $this->assertStringNotContainsString('moved:', $yaml);
     }
+
+    // ── relocated marker (02-§119.14) ───────────────────────────────────────
+
+    public function testPatchEventObjectRecordsRelocatedOnLocationChange(): void
+    {
+        $patched = GitHub::patchEventObject(self::baseEvent(), ['location' => 'Nya salen'], '2026-06-22 08:00');
+        $this->assertSame(['from_location' => 'Matsalen'], $patched['relocated']);
+    }
+
+    public function testPatchEventObjectPreservesRelocatedOnNonLocationEdit(): void
+    {
+        $base = self::baseEvent(['relocated' => ['from_location' => 'Ursprung']]);
+        $patched = GitHub::patchEventObject($base, ['title' => 'Nytt'], '2026-06-22 08:00');
+        $this->assertSame(['from_location' => 'Ursprung'], $patched['relocated']);
+    }
+
+    public function testPatchEventObjectClearsRelocatedWhenRestored(): void
+    {
+        $base = self::baseEvent(['location' => 'Nya salen', 'relocated' => ['from_location' => 'Matsalen']]);
+        $patched = GitHub::patchEventObject($base, ['location' => 'Matsalen'], '2026-06-22 08:00');
+        $this->assertArrayNotHasKey('relocated', $patched);
+    }
+
+    public function testBuildFragmentYamlEmitsRelocatedBlock(): void
+    {
+        $yaml = GitHub::buildFragmentYaml(self::baseEvent([
+            'location'  => 'Nya salen',
+            'relocated' => ['from_location' => 'Matsalen'],
+        ]));
+        $doc = \Symfony\Component\Yaml\Yaml::parse($yaml);
+        $this->assertSame('Matsalen', $doc['event']['relocated']['from_location']);
+    }
+
+    public function testBuildFragmentYamlOmitsRelocatedWhenAbsent(): void
+    {
+        $this->assertStringNotContainsString('relocated:', GitHub::buildFragmentYaml(self::baseEvent()));
+    }
 }

--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -595,3 +595,20 @@ pointer at the slot it used to occupy. This is feedback from a camp organiser
 - The previous time is conveyed by the visible struck-through text and the
   "Flyttad till" label, not by colour alone; the amber highlight is an
   additional cue, never the only one. <!-- 02-§119.13 -->
+
+### 119.7 Location changes
+
+- An event may carry an optional `relocated` mapping recording the location it
+  had before its most recent location change: `from_location` (string). An event
+  whose location has never changed, or whose last edit changed only other
+  fields, has no `relocated` mapping. Like `moved`, it is derived and maintained
+  by the edit API and is never accepted from a request body. <!-- 02-§119.14 -->
+- When an edit changes an activity's `location`, the edit API records the
+  previous location in `relocated.from_location`. An edit that leaves the
+  location unchanged keeps the existing `relocated` mapping untouched; changing
+  the location back to the recorded original removes the mapping. <!-- 02-§119.15 -->
+- Wherever an activity's location is shown — the weekly schedule, the today view,
+  and the per-event page — a relocated activity shows its new location as usual,
+  preceded by its previous location in smaller struck-through text. A location
+  change produces no previous-slot marker: only the inline struck-through old
+  location is added. <!-- 02-§119.16 -->

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -671,6 +671,15 @@ forge or clear a marker.
 `{ from_date, from_start, from_end }` (with `from_end` allowed to be null), so a
 malformed or partial `moved` value never produces a marker.
 
+A **location change** is captured the same way through a separate
+`relocated` mapping (`{ from_location }`, 02-§119.14). `resolveRelocated(event,
+newLocation)` records the previous location when `location` changes, keeps the
+existing marker on an edit that leaves the location unchanged, and clears it when
+the location is set back to the recorded original (02-§119.15). The two markers
+are independent: an edit that changes both time and location records both
+`moved` and `relocated`. Unlike `moved`, `relocated` produces no ghost — it is
+shown only inline (see `03-architecture/rendering.md §5.7`).
+
 ### 32.2 Persistence and deletion
 
 `eventBodyLines()` serialises the `moved` block into the fragment YAML only when
@@ -684,7 +693,7 @@ removes its marker automatically: there is no separate record to clean up
 
 | File | Change |
 | --- | --- |
-| `source/api/edit-event.js` | `resolveMoved()` / `normaliseMoved()`; `patchEventObject()` maintains `moved` |
-| `source/api/github.js` | `eventBodyLines()` serialises the `moved` block |
+| `source/api/edit-event.js` | `resolveMoved()`/`resolveRelocated()` + `normalise*()`; `patchEventObject()` maintains `moved` and `relocated` |
+| `source/api/github.js` | `eventBodyLines()` serialises the `moved` and `relocated` blocks |
 | `api/src/GitHub.php` | PHP mirror of the same capture + serialisation |
-| `source/scripts/lint-yaml.js` | `moved` mapping type-check in `validateEventObject()` |
+| `source/scripts/lint-yaml.js` | `moved` and `relocated` mapping type-checks in `validateEventObject()` |

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -159,8 +159,9 @@ An activity rescheduled to another time or day carries an optional `moved`
 mapping recording the slot it left (see `03-architecture/forms-and-api.md §32`).
 The renderers turn that into two things, built from the same merged event set so
 every view agrees. `source/build/moved.js` holds the shared server-side helpers
-(`isMoved`, `movedToText`, `movedFromText`, `movedTimeHtml`, `buildGhosts`);
-`events-today.js` mirrors them for the client-rendered today view.
+(`isMoved`, `movedToText`, `movedFromText`, `movedTimeHtml`, `buildGhosts`, plus
+`isRelocated`/`locationHtml` for location changes); `events-today.js` mirrors
+them for the client-rendered today view.
 
 - **The activity itself** — wherever the activity appears it keeps its place at
   the new time, with the previous time struck through in small text
@@ -177,6 +178,12 @@ every view agrees. `source/build/moved.js` holds the shared server-side helpers
   a `data-event-date` but **no** `data-event-start`, so `schema-status.js` (whose
   selector requires both) never marks it `is-now`/`is-past`. The per-event page
   emits no ghost — it has no schedule slot to mark (02-§119.10).
+- **Location changes (`relocated`)** — `locationHtml()` renders the activity's
+  location cell with the new location as usual, preceded by the previous
+  location struck through in small text (`.ev-loc-old`) when the activity carries
+  a `relocated` marker (02-§119.16). It is applied wherever the location is
+  shown — the schedule/today meta line and the per-event page's "Plats" row — and
+  produces **no** ghost: a location change is purely an inline annotation.
 
 Because the ghost is derived from the live event at build time — never stored as
 its own record — a deleted activity loses its marker automatically, while a

--- a/docs/05-DATA_CONTRACT.md
+++ b/docs/05-DATA_CONTRACT.md
@@ -83,6 +83,8 @@ events:
       from_date: YYYY-MM-DD
       from_start: "HH:MM"
       from_end: "HH:MM" | null
+    relocated:
+      from_location: string
     owner:
       name: string
       email: string
@@ -134,6 +136,8 @@ event:
     from_date: YYYY-MM-DD
     from_start: "HH:MM"
     from_end: "HH:MM" | null
+  relocated:
+    from_location: string
   owner:
     name: string
     email: string
@@ -189,6 +193,13 @@ event:
   its new time with the previous time struck through, and a minimal marker is
   left at the previous slot
   (see `02-requirements/schedule-and-detail.md §119`). <!-- 05-§3.6 -->
+- `relocated` — a mapping with `from_location` (string). Present only when the
+  activity's location has changed; it records the location the activity had
+  before its most recent location change. The edit API maintains this field
+  automatically — it is never set by a participant. A relocated activity is
+  shown at its new location with the previous location struck through in smaller
+  text, with no previous-slot marker
+  (see `02-requirements/schedule-and-detail.md §119.7`). <!-- 05-§3.7 -->
 - `owner`
 - `meta`
 

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -241,6 +241,7 @@ mint form's per-field validation uses the inline field-error component
 - A moved activity (`.event-row.is-moved`) keeps its place at the new time. Its previous time is shown struck through in small, slightly muted text (`.ev-time-old`) and its new time is highlighted in amber (`.ev-time-new`: a `var(--color-amber)` tint behind bold text). The amber is an additional cue on top of the visible struck-through text — the moved state never depends on colour alone. <!-- 07-§6.142 -->
 - Amber (`var(--color-amber)`) is reserved for the moved-activity marking, distinct from terracotta (cancelled) and sage (in progress), so the three states never read as one another. <!-- 07-§6.143 -->
 - At the slot a moved activity used to occupy, a minimal ghost marker (`.event-row.is-ghost`, muted and italic) shows only the activity's title and a `Flyttad till …` pointer (`.ev-moved-to`, in `var(--color-amber-dark)` for AA-readable text on cream). The marker carries no description, location, responsible, link, or iCal action. <!-- 07-§6.144 -->
+- A relocated activity shows its new location as usual, preceded by its previous location struck through in small, slightly muted text (`.ev-loc-old`, sharing the `.ev-time-old` treatment). A location change adds only this inline annotation — no ghost marker and no amber highlight. <!-- 07-§6.145 -->
 
 ### Display sidebar — portrait layout
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1867,10 +1867,10 @@ Doc ref: `02-requirements/schedule-and-detail.md §118`;
 
 ### §119 — Moved Activities
 
-Doc ref: `02-requirements/schedule-and-detail.md §119`;
-`05-DATA_CONTRACT.md §2`, §2.1, §3 (moved field);
+Doc ref: `02-requirements/schedule-and-detail.md §119` (incl. §119.7 location
+changes); `05-DATA_CONTRACT.md §2`, §2.1, §3 (`moved` + `relocated` fields);
 `03-architecture/rendering.md §5.7`, `03-architecture/forms-and-api.md §32`;
-`07-design/components.md §6.142–6.144`, `07-design/css-strategy.md §7`.
+`07-design/components.md §6.142–6.145`, `07-design/css-strategy.md §7`.
 
 | ID | Status | Notes |
 | --- | --- | --- |
@@ -1887,3 +1887,6 @@ Doc ref: `02-requirements/schedule-and-detail.md §119`;
 | `02-§119.11` | covered | MOVED-07/-14: a second move records the immediately-prior slot; the block is dropped when the activity returns home. Camp-end clearing follows from the camp lifecycle |
 | `02-§119.12` | implemented | The ghost is derived from the live event (`buildGhosts()` over the merged set), so a deleted activity loses it automatically while a cancelled one keeps it. Verified by the build-integration check (demo fragment → `public/schema.html` ghost + marked row); a manual checkpoint |
 | `02-§119.13` | covered | MOVED-23/-24: the previous time is real struck-through text and the `Flyttad till` label is real text; amber (`.ev-time-new`) is an additional cue. CSS contrast is a manual checkpoint |
+| `02-§119.14` | covered | MOVED-30/-34/-35: `relocated` derived by the edit API (no request-body input); `buildFragmentYaml()` round-trips/omits the block; MOVED-36/-37: `lint-yaml.js` validates the mapping. PHP `testBuildFragmentYamlEmitsRelocatedBlock`/`...OmitsRelocatedWhenAbsent` |
+| `02-§119.15` | covered | MOVED-28/-29/-31/-32/-33: `resolveRelocated()` records the previous location on a location change, preserves it on a non-location edit, clears it on restore, and is independent of a time move. PHP `testPatchEventObjectRecordsRelocatedOnLocationChange`/`...Preserves...`/`...Clears...` parity |
+| `02-§119.16` | covered | MOVED-39/-40/-41/-42: `locationHtml()` shows the struck old location (`.ev-loc-old`) before the new one in `renderEventRow()`/`renderEventPage()` and emits no ghost. The today/display view via `events-today.js` is a manual/browser checkpoint |

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -218,5 +218,5 @@ Part of [the traceability index](./index.md).
 | DEDUP-01..09 | `tests/dedup-submission.test.js` | Duplicate pre-check (Node + PHP): `getFileMaybe` before any branch, 409 + Swedish message, awaited before `app.js`'s response, atomic batch reject (02-§111.1–111.5) |
 | DEDUP-M01..M02 | (manual) | Live 409 on a duplicate submission; a concurrent duplicate's redundant PR is auto-closed (02-§111.2, 111.6–111.9) |
 | DEDUPCLEAN-01..09 | `tests/dedup-cleanup.test.js` | `classifyEventPr` decision table: empty diff → close, fresh add → keep, same-id/different-body → log-manual, out-of-scope → ignore (02-§111.6–111.9) |
-| MOVED-01..27 | `tests/moved-activity.test.js` | Moved-activity capture, serialisation, validation, helpers, schedule/event-page markup + ghost (02-§119) |
-| (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the moved capture + serialisation: `patchEventObject`, `buildFragmentYaml` (02-§119) |
+| MOVED-01..42 | `tests/moved-activity.test.js` | Moved + relocated capture, serialisation, validation, helpers, schedule/event-page markup + ghost (02-§119) |
+| (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the moved + relocated capture + serialisation: `patchEventObject`, `buildFragmentYaml` (02-§119) |

--- a/source/api/edit-event.js
+++ b/source/api/edit-event.js
@@ -46,6 +46,33 @@ function resolveMoved(event, newDate, newStart, newEnd) {
   return { from_date: oldDate, from_start: oldStart, from_end: oldEnd };
 }
 
+// ── relocated (changed-location marker) ───────────────────────────────────────
+
+// Normalise a raw `relocated` value into either null or a clean
+// { from_location } object. A marker needs a non-empty previous location
+// (02-§119.14).
+function normaliseRelocated(raw) {
+  if (!raw || typeof raw !== 'object' || !raw.from_location) return null;
+  return { from_location: String(raw.from_location) };
+}
+
+// Decide the event's `relocated` marker after an edit (02-§119.15), mirroring
+// resolveMoved but for the single `location` field:
+//   - if the edit changed the location, record the location it left;
+//   - unless that change returns it to the location already recorded in
+//     `relocated`, in which case the marker is cleared;
+//   - an edit that leaves the location unchanged keeps the existing marker.
+function resolveRelocated(event, newLocation) {
+  const oldLocation = event.location;
+  const prev        = normaliseRelocated(event.relocated);
+
+  if (newLocation === oldLocation) return prev;
+
+  if (prev && prev.from_location === newLocation) return null;
+
+  return { from_location: oldLocation };
+}
+
 // ── patchEventObject ─────────────────────────────────────────────────────────
 
 // Apply `updates` to a single event object, returning a new object with the
@@ -61,13 +88,16 @@ function patchEventObject(event, updates, now) {
 
   const moved = resolveMoved(event, date, start, end);
 
+  const location = 'location' in updates ? (updates.location || event.location) : event.location;
+  const relocated = resolveRelocated(event, location);
+
   const patched = {
     id:          event.id,
     title:       'title'       in updates ? (updates.title       || event.title)       : event.title,
     date,
     start,
     end,
-    location:    'location'    in updates ? (updates.location    || event.location)    : event.location,
+    location,
     responsible: 'responsible' in updates ? (updates.responsible || event.responsible) : event.responsible,
     description: 'description' in updates ? (updates.description || null)              : (event.description ?? null),
     link:        'link'        in updates ? (updates.link        || null)              : (event.link ?? null),
@@ -79,7 +109,8 @@ function patchEventObject(event, updates, now) {
     },
   };
   if (moved) patched.moved = moved;
+  if (relocated) patched.relocated = relocated;
   return patched;
 }
 
-module.exports = { isEventPast, patchEventObject, normaliseMoved, resolveMoved };
+module.exports = { isEventPast, patchEventObject, normaliseMoved, resolveMoved, normaliseRelocated, resolveRelocated };

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -66,6 +66,12 @@ function eventBodyLines(event, fp, dp) {
     lines.push(`${dp}from_start: '${event.moved.from_start}'`);
     lines.push(`${dp}from_end: ${event.moved.from_end ? `'${event.moved.from_end}'` : 'null'}`);
   }
+  // Only write the relocated block when the activity carries a previous location
+  // (02-§119.14). Restoring the original location drops the block again.
+  if (event.relocated && event.relocated.from_location) {
+    lines.push(`${fp}relocated:`);
+    lines.push(`${dp}from_location: ${yamlScalar(event.relocated.from_location)}`);
+  }
   lines.push(`${fp}owner:`);
   lines.push(`${dp}name: '${((event.owner && event.owner.name) || '').replace(/'/g, "''")}'`);
   lines.push(`${dp}email: ''`);

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -783,8 +783,11 @@ body.display-mode .event-row.is-cancelled.is-now {
    A rescheduled activity keeps its place at the new time: its previous time is
    struck through in small muted text and its new time is highlighted in amber.
    A minimal ghost marker (.is-ghost) is left at the slot it used to occupy,
-   showing only the title and a "Flyttad till …" pointer to where it went. */
-.ev-time-old {
+   showing only the title and a "Flyttad till …" pointer to where it went.
+   A relocated activity shows its new location as usual with the previous
+   location struck through in small text (.ev-loc-old) — no ghost. */
+.ev-time-old,
+.ev-loc-old {
   text-decoration: line-through;
   font-size: var(--font-size-small);
   opacity: 0.7;

--- a/source/assets/js/client/events-today.js
+++ b/source/assets/js/client/events-today.js
@@ -83,6 +83,17 @@
   function isMovedEvent(e) {
     return !!(e && e.moved && e.moved.from_date && e.moved.from_start);
   }
+  function isRelocated(e) {
+    return !!(e && e.relocated && e.relocated.from_location);
+  }
+  // Location cell: new location as usual, preceded by the previous location
+  // struck through in small text when the activity was relocated (02-§119.16).
+  function locationHtml(e) {
+    var current = e.location ? esc(e.location) : '';
+    if (!isRelocated(e)) return current;
+    var old = '<span class="ev-loc-old">' + esc(e.relocated.from_location) + '</span>';
+    return current ? old + ' ' + current : old;
+  }
   // "Flyttad till" target text: new day+time, or just the new time for a
   // same-day move (02-§119.9).
   function movedToText(e) {
@@ -143,7 +154,9 @@
       ? '<span class="ev-time-old">' + esc(movedFromText(e)) + '</span> <span class="ev-time-new">' + timeStr + '</span>'
       : timeStr;
     var movedClass = moved ? ' is-moved' : '';
-    var metaParts = [e.location, e.responsible].filter(Boolean).map(esc);
+    // A relocated activity shows its new location with the old one struck
+    // through in small text (02-§119.16).
+    var metaParts = [locationHtml(e), e.responsible ? esc(e.responsible) : ''].filter(Boolean);
     var metaEl = metaParts.length ? '<span class="ev-meta"> · ' + metaParts.join(' · ') + '</span>' : '';
     var icalEl = icalLink(e);
     var safeLink = safeHttp(e.link);

--- a/source/build/moved.js
+++ b/source/build/moved.js
@@ -43,6 +43,22 @@ function movedTimeHtml(e, newTimeStr) {
     + `<span class="ev-time-new">${newTimeStr}</span>`;
 }
 
+// True when the event carries a usable previous-location marker (02-§119.14).
+function isRelocated(e) {
+  return !!(e && e.relocated && e.relocated.from_location);
+}
+
+// Location cell HTML for an activity (02-§119.16): the new location as usual,
+// preceded by the previous location struck through in small text when the
+// activity has been relocated. Returns '' when the activity has no location.
+function locationHtml(e) {
+  if (!e.location) return isRelocated(e) ? `<span class="ev-loc-old">${escapeHtml(e.relocated.from_location)}</span>` : '';
+  const current = escapeHtml(e.location);
+  return isRelocated(e)
+    ? `<span class="ev-loc-old">${escapeHtml(e.relocated.from_location)}</span> ${current}`
+    : current;
+}
+
 // Build a previous-slot ghost marker for each moved activity (02-§119.8): a
 // minimal pseudo-event positioned at the old date/start. Marked `_ghost` so the
 // row renderer emits the stripped-down marker (title + "Flyttad till" only).
@@ -57,4 +73,4 @@ function buildGhosts(events) {
   }));
 }
 
-module.exports = { isMoved, movedToText, movedFromText, movedTimeHtml, buildGhosts };
+module.exports = { isMoved, movedToText, movedFromText, movedTimeHtml, buildGhosts, isRelocated, locationHtml };

--- a/source/build/render-event.js
+++ b/source/build/render-event.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { escapeHtml, formatDate, toDateString, safeLinkHref } = require('./utils');
-const { isMoved, movedTimeHtml } = require('./moved');
+const { isMoved, movedTimeHtml, locationHtml } = require('./moved');
 const { pageNav, pageFooter } = require('./layout');
 const { renderDescriptionHtml } = require('./markdown');
 const { pwaHeadTags } = require('./pwa');
@@ -94,7 +94,7 @@ ${pageNav('schema.html', navSections)}
   <h1${h1Class}>${h1Inner}</h1>
   <div class="event-detail">
     <p>📅 ${date} 🕐 ${timeDisplay}</p>
-    <p>📍 <strong>Plats:</strong> ${escapeHtml(event.location)} · 👤 <strong>Ansvarig:</strong> ${escapeHtml(event.responsible)}</p>
+    <p>📍 <strong>Plats:</strong> ${locationHtml(event)} · 👤 <strong>Ansvarig:</strong> ${escapeHtml(event.responsible)}</p>
     <p>📆 <a href="schema/${escapeHtml(String(event.id))}/event.ics" download>Lägg till i kalender (.ics)</a></p>
 ${conflictHtml}${descriptionHtml}${linkHtml}  </div>
 </main>

--- a/source/build/render-idag.js
+++ b/source/build/render-idag.js
@@ -27,6 +27,7 @@ function renderIdagPage(camp, events, footerHtml = '', navSections = [], cookieD
       link: e.link || null,
       cancelled: e.cancelled === true,
       moved: e.moved && e.moved.from_date ? e.moved : null,
+      relocated: e.relocated && e.relocated.from_location ? e.relocated : null,
     })),
   );
 

--- a/source/build/render-today.js
+++ b/source/build/render-today.js
@@ -38,6 +38,7 @@ function renderTodayPage(camp, events, qrSvg, siteUrl = '', buildTime = '', goat
       link: e.link || null,
       cancelled: e.cancelled === true,
       moved: e.moved && e.moved.from_date ? e.moved : null,
+      relocated: e.relocated && e.relocated.from_location ? e.relocated : null,
     })),
   );
 

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -2,7 +2,7 @@
 
 const { pageNav, pageFooter } = require('./layout');
 const { toDateString, escapeHtml, formatDate, safeLinkHref } = require('./utils');
-const { isMoved, movedTimeHtml, buildGhosts } = require('./moved');
+const { isMoved, movedTimeHtml, buildGhosts, locationHtml } = require('./moved');
 const { renderDescriptionHtml } = require('./markdown');
 const { goatcounterScript } = require('./analytics');
 const { pwaHeadTags } = require('./pwa');
@@ -79,7 +79,9 @@ function renderEventRow(e) {
   const moved = isMoved(e);
   const timeCellHtml = moved ? movedTimeHtml(e, timeStr) : timeStr;
   const movedClass = moved ? ' is-moved' : '';
-  const metaParts = [e.location, e.responsible].filter(Boolean).map(escapeHtml);
+  // A relocated activity shows its new location as usual, preceded by the
+  // previous location struck through in small text (02-§119.16).
+  const metaParts = [locationHtml(e), e.responsible ? escapeHtml(e.responsible) : ''].filter(Boolean);
   const metaEl = metaParts.length ? `<span class="ev-meta"> · ${metaParts.join(' · ')}</span>` : '';
   const icalEl = icalDownloadLink(e);
   const hasExtra = e.description || safeLinkHref(e.link);

--- a/source/scripts/lint-yaml.js
+++ b/source/scripts/lint-yaml.js
@@ -118,6 +118,16 @@ function validateEventObject(event, ref, opts = {}) {
       }
     }
   }
+  // relocated is an optional previous-location marker (05-§3.7, 02-§119.14):
+  // a mapping with a non-empty from_location string.
+  if (event.relocated !== undefined && event.relocated !== null) {
+    const r = event.relocated;
+    if (typeof r !== 'object' || Array.isArray(r)) {
+      errors.push(`${ref}: relocated must be a mapping`);
+    } else if (typeof r.from_location !== 'string' || r.from_location.trim() === '') {
+      errors.push(`${ref}: relocated.from_location must be a non-empty string`);
+    }
+  }
 
   return errors;
 }

--- a/tests/moved-activity.test.js
+++ b/tests/moved-activity.test.js
@@ -9,10 +9,10 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const yaml = require('js-yaml');
 
-const { patchEventObject, resolveMoved, normaliseMoved } = require('../source/api/edit-event');
+const { patchEventObject, resolveMoved, normaliseMoved, resolveRelocated } = require('../source/api/edit-event');
 const { buildFragmentYaml } = require('../source/api/github');
 const { validateYaml } = require('../source/scripts/lint-yaml');
-const { isMoved, movedToText, movedFromText, buildGhosts } = require('../source/build/moved');
+const { isMoved, movedToText, movedFromText, buildGhosts, isRelocated, locationHtml } = require('../source/build/moved');
 const { renderSchedulePage, renderEventRow } = require('../source/build/render');
 const { renderEventPage } = require('../source/build/render-event');
 
@@ -217,5 +217,103 @@ describe('renderEventPage – moved time, no ghost (02-§119.6, §119.10)', () =
     assert.ok(html.includes('ev-time-old'));
     assert.ok(html.includes('ev-time-new'));
     assert.ok(!html.includes('ev-moved-to'));
+  });
+});
+
+describe('patchEventObject – relocated capture (02-§119.15)', () => {
+  it('MOVED-28: records the previous location when location changes', () => {
+    const p = patchEventObject(baseEvent(), { location: 'Nya salen' }, NOW);
+    assert.deepEqual(p.relocated, { from_location: 'Matsalen' });
+  });
+
+  it('MOVED-29: a non-location edit leaves an existing relocated marker untouched', () => {
+    const ev = baseEvent({ relocated: { from_location: 'Ursprung' } });
+    const p = patchEventObject(ev, { title: 'Nytt' }, NOW);
+    assert.deepEqual(p.relocated, { from_location: 'Ursprung' });
+  });
+
+  it('MOVED-30: a non-relocated edit adds no marker', () => {
+    const p = patchEventObject(baseEvent(), { title: 'Nytt' }, NOW);
+    assert.equal(p.relocated, undefined);
+  });
+
+  it('MOVED-31: restoring the original location clears the marker', () => {
+    const ev = baseEvent({ location: 'Nya salen', relocated: { from_location: 'Matsalen' } });
+    const p = patchEventObject(ev, { location: 'Matsalen' }, NOW);
+    assert.equal(p.relocated, undefined);
+  });
+
+  it('MOVED-32: resolveRelocated returns null when the location is unchanged', () => {
+    assert.equal(resolveRelocated(baseEvent(), 'Matsalen'), null);
+  });
+
+  it('MOVED-33: a location change is independent of a time move', () => {
+    const p = patchEventObject(baseEvent(), { start: '10:00', location: 'Nya salen' }, NOW);
+    assert.deepEqual(p.moved, { from_date: '2026-06-22', from_start: '08:00', from_end: '09:00' });
+    assert.deepEqual(p.relocated, { from_location: 'Matsalen' });
+  });
+});
+
+describe('buildFragmentYaml – relocated serialisation (02-§119.14)', () => {
+  it('MOVED-34: round-trips the relocated block', () => {
+    const y = buildFragmentYaml(baseEvent({ location: 'Nya salen', relocated: { from_location: 'Matsalen' } }));
+    assert.deepEqual(yaml.load(y).event.relocated, { from_location: 'Matsalen' });
+  });
+
+  it('MOVED-35: omits the relocated block when absent', () => {
+    assert.ok(!buildFragmentYaml(baseEvent()).includes('relocated:'));
+  });
+});
+
+describe('lint-yaml – relocated validation (05-§3.7)', () => {
+  const wrap = (eventLines) => `camp:\n  id: c\n  name: C\n  location: L\n  start_date: '2026-06-22'\n  end_date: '2026-06-28'\nevents:\n${eventLines}\n`;
+  const valid = [
+    "- id: a-2026-06-24-1000",
+    "  title: A",
+    "  date: '2026-06-24'",
+    "  start: '10:00'",
+    "  end: '11:00'",
+    "  location: Nya salen",
+    "  responsible: R",
+  ];
+
+  it('MOVED-36: accepts a well-formed relocated block', () => {
+    const lines = valid.concat(['  relocated:', '    from_location: Gamla salen']).join('\n');
+    assert.equal(validateYaml(wrap(lines)).ok, true);
+  });
+
+  it('MOVED-37: rejects an empty relocated.from_location', () => {
+    const lines = valid.concat(['  relocated:', "    from_location: ''"]).join('\n');
+    const res = validateYaml(wrap(lines));
+    assert.equal(res.ok, false);
+    assert.ok(res.errors.some((e) => /relocated\.from_location/.test(e)));
+  });
+});
+
+describe('moved.js – location markup (02-§119.16)', () => {
+  it('MOVED-38: isRelocated is false without a marker', () => {
+    assert.equal(isRelocated(baseEvent()), false);
+  });
+
+  it('MOVED-39: locationHtml shows the struck old location before the new one', () => {
+    const html = locationHtml(baseEvent({ location: 'Nya salen', relocated: { from_location: 'Matsalen' } }));
+    assert.equal(html, '<span class="ev-loc-old">Matsalen</span> Nya salen');
+  });
+
+  it('MOVED-40: locationHtml is the plain location when not relocated', () => {
+    assert.equal(locationHtml(baseEvent({ location: 'Matsalen' })), 'Matsalen');
+  });
+
+  it('MOVED-41: a relocated schedule row shows the struck old location, no ghost', () => {
+    const ev = baseEvent({ location: 'Nya salen', relocated: { from_location: 'Matsalen' } });
+    const html = renderSchedulePage({ name: 'Test' }, [ev]);
+    assert.ok(html.includes('<span class="ev-loc-old">Matsalen</span> Nya salen'));
+    assert.ok(!html.includes('is-ghost'));
+  });
+
+  it('MOVED-42: the event page shows the struck old location', () => {
+    const ev = baseEvent({ location: 'Nya salen', relocated: { from_location: 'Matsalen' } });
+    const html = renderEventPage(ev, { name: 'Test' }, '');
+    assert.ok(html.includes('<span class="ev-loc-old">Matsalen</span> Nya salen'));
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #754 (moved activities): a **location change (lokalbyte)** is now shown too.

- **Capture** — when an edit changes an activity's `location`, the edit API records the previous location in a new server-derived `relocated` mapping (`{ from_location }`). An edit that leaves the location unchanged keeps the marker; setting the location back to the original clears it. Independent of `moved`, so an edit that changes both time and location records both. Implemented in both the Node and PHP edit paths.
- **Display** — wherever the location appears (weekly schedule, today/display view, per-event page) the **new location shows as usual**, preceded by the **old location struck through in smaller text** (`.ev-loc-old`). Per the request: **no ghost** and no amber highlight for a location change — only the inline struck-through old location.

## Test plan

- [x] `node --test tests/*.test.js` — 2166 pass (15 new relocated cases in `tests/moved-activity.test.js`, MOVED-28..42)
- [x] PHPUnit `api/tests` — 102 pass (5 new relocated cases)
- [x] `eslint`, `stylelint`, `markdownlint` clean
- [x] Full build green; integration-checked a relocated demo fragment → `public/schema.html` and the event page show `~~Gamla salen~~ Nya salen`, with zero ghost rows, then removed the fixture
- [ ] Browser walkthrough on QA: edit an activity's location and confirm the struck-through old location beside the new one on `idag.html`, the weekly schedule, and a per-event page — and that no ghost appears

Relates to #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdnDXc2vtPRnpBcfWKayg)_