### PR TITLE
Stack moved time and tint the ghost amber (#729)

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -561,9 +561,9 @@ pointer at the slot it used to occupy. This is feedback from a camp organiser
 ### 119.3 Marked time on the activity itself
 
 - In the weekly schedule, the today view, and the per-event page, a moved
-  activity keeps its place at its current (new) time. Its previous time is shown
-  struck through in small text and its new time is highlighted in amber
-  (`--color-amber`). <!-- 02-§119.6 -->
+  activity keeps its place at its current (new) time. The new time is shown on
+  top, highlighted in amber (`--color-amber`), and the previous time is shown
+  struck through in smaller text directly below it. <!-- 02-§119.6 -->
 - When the activity has moved to a different day, the struck-through previous
   time includes the previous date; when it has only changed time within the same
   day, only the previous time is shown. <!-- 02-§119.7 -->
@@ -572,7 +572,8 @@ pointer at the slot it used to occupy. This is feedback from a camp organiser
 
 - In the weekly schedule and the today view, a moved activity also appears as a
   minimal marker at the slot it used to occupy (its `from_date` and
-  `from_start`), sorted into that day at its previous start time. <!-- 02-§119.8 -->
+  `from_start`), sorted into that day at its previous start time. The marker is
+  shown in an amber tone so it reads as a "moved away" pointer. <!-- 02-§119.8 -->
 - The marker shows only the activity's title and the label "Flyttad till" (moved
   to) followed by the new day and time, or only the new time when the move is
   within the same day. The marker shows no description, location, responsible,

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -164,17 +164,20 @@ every view agrees. `source/build/moved.js` holds the shared server-side helpers
 them for the client-rendered today view.
 
 - **The activity itself** — wherever the activity appears it keeps its place at
-  the new time, with the previous time struck through in small text
-  (`.ev-time-old`) next to the highlighted new time (`.ev-time-new`, amber). The
-  row carries an `is-moved` class. A cross-day move shows the previous date too;
-  a same-day move shows only the previous time. `renderEventRow()` (`render.js`,
-  weekly schedule), `buildRowHtml()` (`events-today.js`, today/display), and
-  `renderEventPage()` (`render-event.js`) all apply this.
+  the new time. The highlighted new time (`.ev-time-new`, amber) sits on top and
+  the previous time is struck through in smaller text (`.ev-time-old`) directly
+  below it; in the schedule and today views the `.ev-time` cell becomes an
+  `inline-flex` column to stack them. The row carries an `is-moved` class. A
+  cross-day move shows the previous date too; a same-day move shows only the
+  previous time. `renderEventRow()` (`render.js`, weekly schedule),
+  `buildRowHtml()` (`events-today.js`, today/display), and `renderEventPage()`
+  (`render-event.js`) all apply this.
 - **A previous-slot marker** — for the weekly schedule and the today view a
   minimal **ghost** row is generated at the activity's `from_date`/`from_start`:
   `buildGhosts()` produces one pseudo-event per moved activity, marked `_ghost`,
   which `renderEventRow()`/`buildRowHtml()` render as the title plus a
-  `Flyttad till …` pointer (`.ev-moved-to`) and nothing else. The ghost carries
+  `Flyttad till …` pointer (`.ev-moved-to`) and nothing else, in a soft amber
+  tone with an amber accent bar. The ghost carries
   a `data-event-date` but **no** `data-event-start`, so `schema-status.js` (whose
   selector requires both) never marks it `is-now`/`is-past`. The per-event page
   emits no ghost — it has no schedule slot to mark (02-§119.10).

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -238,9 +238,9 @@ mint form's per-field validation uses the inline field-error component
 
 ### Moved activity (02-§119)
 
-- A moved activity (`.event-row.is-moved`) keeps its place at the new time. Its previous time is shown struck through in small, slightly muted text (`.ev-time-old`) and its new time is highlighted in amber (`.ev-time-new`: a `var(--color-amber)` tint behind bold text). The amber is an additional cue on top of the visible struck-through text — the moved state never depends on colour alone. <!-- 07-§6.142 -->
+- A moved activity (`.event-row.is-moved`) keeps its place at the new time. The new time sits on top, highlighted in amber (`.ev-time-new`: a `var(--color-amber)` tint behind bold text), and the previous time is struck through in smaller, slightly muted text (`.ev-time-old`) on its own line directly below. The amber is an additional cue on top of the visible struck-through text — the moved state never depends on colour alone. <!-- 07-§6.142 -->
 - Amber (`var(--color-amber)`) is reserved for the moved-activity marking, distinct from terracotta (cancelled) and sage (in progress), so the three states never read as one another. <!-- 07-§6.143 -->
-- At the slot a moved activity used to occupy, a minimal ghost marker (`.event-row.is-ghost`, muted and italic) shows only the activity's title and a `Flyttad till …` pointer (`.ev-moved-to`, in `var(--color-amber-dark)` for AA-readable text on cream). The marker carries no description, location, responsible, link, or iCal action. <!-- 07-§6.144 -->
+- At the slot a moved activity used to occupy, a minimal ghost marker (`.event-row.is-ghost`, italic with a soft `var(--color-amber)` background tint and an amber accent bar) shows only the activity's title and a `Flyttad till …` pointer (`.ev-moved-to`, in `var(--color-amber-dark)` for AA-readable text on cream). The marker carries no description, location, responsible, link, or iCal action. <!-- 07-§6.144 -->
 - A relocated activity shows its new location as usual, preceded by its previous location struck through in small, slightly muted text (`.ev-loc-old`, sharing the `.ev-time-old` treatment). A location change adds only this inline annotation — no ghost marker and no amber highlight. <!-- 07-§6.145 -->
 
 ### Display sidebar — portrait layout

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -780,18 +780,35 @@ body.display-mode .event-row.is-cancelled.is-now {
 }
 
 /* ── Moved activities (02-§119) ───────────────────────────────────────────────
-   A rescheduled activity keeps its place at the new time: its previous time is
-   struck through in small muted text and its new time is highlighted in amber.
-   A minimal ghost marker (.is-ghost) is left at the slot it used to occupy,
-   showing only the title and a "Flyttad till …" pointer to where it went.
-   A relocated activity shows its new location as usual with the previous
-   location struck through in small text (.ev-loc-old) — no ghost. */
+   A rescheduled activity keeps its place at the new time: the new time sits on
+   top (where the time normally is) and the previous time is struck through in
+   smaller text directly below it. A minimal ghost marker (.is-ghost) is left at
+   the slot it used to occupy, in a soft amber tone, showing only the title and a
+   "Flyttad till …" pointer to where it went. A relocated activity shows its new
+   location as usual with the previous location struck through in small text
+   (.ev-loc-old) — no ghost. */
 .ev-time-old,
 .ev-loc-old {
   text-decoration: line-through;
   font-size: var(--font-size-small);
   opacity: 0.7;
+}
+
+.ev-loc-old {
   margin-right: 0.25em;
+}
+
+/* Stack the moved time: the new time on top, the struck-through previous time
+   on its own line directly below. The cell's first baseline (the new time)
+   aligns with the activity title. */
+.event-row.is-moved .ev-time {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.event-row.is-moved .ev-time-old {
+  display: block;
 }
 
 .ev-time-new {
@@ -801,9 +818,12 @@ body.display-mode .event-row.is-cancelled.is-now {
   font-weight: 700;
 }
 
+/* The previous-slot ghost marker carries a soft amber tone and an amber accent
+   bar, marking it clearly as a "moved away" pointer. */
 .event-row.is-ghost {
-  opacity: 0.75;
   font-style: italic;
+  background: rgba(232, 162, 61, 0.15); /* var(--color-amber) tint */
+  box-shadow: inset 4px 0 0 var(--color-amber);
 }
 
 .ev-moved-to {
@@ -818,6 +838,11 @@ body.display-mode .event-row.is-cancelled.is-now {
 body.display-mode .ev-time-new {
   background: rgba(232, 162, 61, 0.28);
   color: var(--color-white);
+}
+
+body.display-mode .event-row.is-ghost {
+  background: rgba(232, 162, 61, 0.18);
+  box-shadow: inset 3px 0 0 var(--color-amber);
 }
 
 body.display-mode .ev-moved-to {

--- a/source/assets/js/client/events-today.js
+++ b/source/assets/js/client/events-today.js
@@ -147,11 +147,11 @@
   // renderEventRow() in render.js.
   function buildRowHtml(e) {
     var timeStr = e.end ? esc(e.start) + '–' + esc(e.end) : esc(e.start);
-    // A moved activity shows its previous time struck through next to the
-    // highlighted new time (02-§119.6).
+    // A moved activity shows the highlighted new time on top with its previous
+    // time struck through directly below (02-§119.6).
     var moved = isMovedEvent(e);
     var timeCell = moved
-      ? '<span class="ev-time-old">' + esc(movedFromText(e)) + '</span> <span class="ev-time-new">' + timeStr + '</span>'
+      ? '<span class="ev-time-new">' + timeStr + '</span><span class="ev-time-old">' + esc(movedFromText(e)) + '</span>'
       : timeStr;
     var movedClass = moved ? ' is-moved' : '';
     // A relocated activity shows its new location with the old one struck

--- a/source/build/moved.js
+++ b/source/build/moved.js
@@ -35,12 +35,12 @@ function movedFromText(e) {
   return e.moved.from_date === e.date ? time : `${formatDateShort(e.moved.from_date)} ${time}`;
 }
 
-// Inner HTML for the .ev-time cell of a moved activity: previous time struck
-// through in small text, new time highlighted in amber (02-§119.6).
-// `newTimeStr` is the already-escaped current-time string.
+// Inner HTML for the .ev-time cell of a moved activity: the new time highlighted
+// in amber on top, the previous time struck through in smaller text directly
+// below (02-§119.6). `newTimeStr` is the already-escaped current-time string.
 function movedTimeHtml(e, newTimeStr) {
-  return `<span class="ev-time-old">${escapeHtml(movedFromText(e))}</span> `
-    + `<span class="ev-time-new">${newTimeStr}</span>`;
+  return `<span class="ev-time-new">${newTimeStr}</span>`
+    + `<span class="ev-time-old">${escapeHtml(movedFromText(e))}</span>`;
 }
 
 // True when the event carries a usable previous-location marker (02-§119.14).

--- a/tests/moved-activity.test.js
+++ b/tests/moved-activity.test.js
@@ -189,6 +189,11 @@ describe('renderEventRow / renderSchedulePage – moved markup (02-§119.6, §11
     assert.ok(html.includes('<span class="ev-time-new">16:00–17:00</span>'));
   });
 
+  it('MOVED-43: the new time is rendered before (above) the struck old time', () => {
+    const html = renderEventRow(moved);
+    assert.ok(html.indexOf('ev-time-new') < html.indexOf('ev-time-old'));
+  });
+
   it('MOVED-24: a ghost row shows title + Flyttad till and no detail', () => {
     const html = renderEventRow({ _ghost: true, title: 'Frukost', date: '2026-06-22', start: '08:00', end: '09:00', movedToText: 'Flyttad till 24 juni 16:00–17:00' });
     assert.ok(html.includes('is-ghost'));


### PR DESCRIPTION
## Summary

Two visual refinements to the moved-activity display (follow-up to #754):

- **Stacked time** — the new time now sits on top (where the time normally is, left-aligned) and the previous struck-through time drops to its own line in smaller text directly below it, instead of sitting inline to its left. In the schedule and today views the `.ev-time` cell becomes an `inline-flex` column; its first baseline (the new time) still aligns with the activity title.
- **Amber ghost** — the previous-slot ghost marker now carries a soft `--color-amber` background tint and an amber accent bar, so it clearly reads as a "moved away" pointer (the `Flyttad till …` text was already amber).

No data or capture changes — display only.

## Test plan

- [x] `node --test tests/*.test.js` — 2167 pass (new MOVED-43 asserts the new time renders before the old)
- [x] `eslint`, `stylelint`, `markdownlint` clean
- [x] Full build green; integration-checked a moved demo fragment → time cell renders `ev-time-new` above `ev-time-old` and the ghost row carries `is-ghost` with the amber tint, then removed the fixture
- [ ] Browser walkthrough on QA: confirm the new time sits above the struck old time on `idag.html`, the weekly schedule, and the per-event page, and that the ghost row reads in a yellow tone

Relates to #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdnDXc2vtPRnpBcfWKayg)_