### PR TITLE
Mark "Liten extra grillkväll" as moved

### DIFF
--- a/source/data/2026-06-syssleback/liten-extra-grillkvall-2026-06-26-1800.yaml
+++ b/source/data/2026-06-syssleback/liten-extra-grillkvall-2026-06-26-1800.yaml
@@ -15,6 +15,10 @@ event:
     Jag tänder grillarna och hoppas jag kommer ihåg att ta med Thermacellerna den här gången.
     
   link: null
+  moved:
+    from_date: '2026-06-26'
+    from_start: '18:00'
+    from_end: '23:55'
   owner:
     name: ''
     email: ''


### PR DESCRIPTION
## Summary

"Liten extra grillkväll" was rescheduled before the moved-activity feature existed, so it had no `moved` marker. This adds the marker recording its previous slot, so it now shows as a move.

- The activity was moved **2026-06-26 18:00 → 2026-06-27 20:00** (end 23:55 unchanged), per the original edit in git history (commit `92bc4ce`).
- Added `moved: { from_date: 2026-06-26, from_start: 18:00, from_end: 23:55 }` to the event fragment.
- The build then shows the new time (20:00–23:55) above the struck-through previous time (26 juni 18:00–23:55) on 27 June, and a ghost marker — "Liten extra grillkväll · Flyttad till 27 juni 20:00–23:55" — at the old slot on 26 June.

Data-only change to one event fragment; it deploys to QA and production via the event-data pipeline on merge.

## Test plan

- [x] `lint-yaml` validates the fragment
- [x] Built locally → ghost on 26 June and struck-old/new time on 27 June render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdnDXc2vtPRnpBcfWKayg)_