### PR TITLE
Flag the later booking of a same-room time clash in red (#729)

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -619,3 +619,38 @@ pointer at the slot it used to occupy. This is feedback from a camp organiser
   preceded by its previous location in smaller struck-through text. A location
   change produces no previous-slot marker: only the inline struck-through old
   location is added. <!-- 02-§119.16 -->
+
+---
+
+## 120. Location-Clash Marking
+
+**Context.** Two activities can be booked into the same room at overlapping
+times. The schedule highlights the booking that came later so organisers can
+spot and resolve the double-booking. The same overlap logic already powers the
+per-event conflict banner and the locale overview (§99).
+
+### 120.1 What counts as a clash
+
+- A location clash ("lokalkrock") is two activities on the same date, in the same
+  room, whose times overlap. Back-to-back activities (one ends exactly when the
+  next starts) do not clash, matching the conflict rule in §99.3. <!-- 02-§120.1 -->
+- The catch-all location "Annat" (shown as "[annat]") is never a real room, so an
+  activity there is never part of a clash and never causes one. <!-- 02-§120.2 -->
+- A cancelled ("inställd") activity has freed its room: it is never marked and
+  never causes another activity to be marked. <!-- 02-§120.3 -->
+
+### 120.2 Which activity is marked
+
+- Of two clashing activities, the one created later (by its creation time) is
+  marked; the earlier booking keeps the room and is left unmarked. When three or
+  more activities overlap in the same room, every booking created after the
+  earliest is marked. <!-- 02-§120.4 -->
+
+### 120.3 How it is shown
+
+- A marked activity is shown in the reserved conflict red (`--color-error`) — a
+  red wash, a red left accent bar, and the title in red — in the weekly schedule
+  and the today view. <!-- 02-§120.5 -->
+- Once a marked activity has passed in time, it takes the same muted grey,
+  dimmed treatment as any other passed activity; the red gives way to grey.
+  <!-- 02-§120.6 -->

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -198,6 +198,25 @@ ghosts in with real rows by start time and keeps the real-event count for its
 footer; the live view's per-minute classifier skips ghosts so they always stay
 visible at the old slot.
 
+### 5.8 Location-clash marking (02-§120)
+
+`source/build/clashes.js` `markLocationClashes(events)` runs once in `build.js`
+right after the active camp's events are loaded, so every view sees the same
+flags. For each non-cancelled activity in a real room (the "Annat"/"[annat]"
+catch-all is excluded by `isRealLocation()`), it looks for an **earlier-created**
+activity on the same date in the same room whose time overlaps — reusing the
+shared `overlaps()` predicate from `conflict-check.js` (the same logic behind the
+per-event conflict banner and the locale overview). The later booking gets
+`_clash = true`; the earliest booking is left unmarked. Cancelled activities have
+freed the room, so they neither clash nor are marked.
+
+`renderEventRow()` (`render.js`) adds an `is-clash` class to a flagged row, and
+`build.js` exposes the boolean as `clash` in the today/display event JSON so
+`buildRowHtml()` (`events-today.js`) marks the same rows. CSS styles
+`.event-row.is-clash` in the reserved conflict red (`--color-error`), placed
+after the in-progress rule so red wins over the sage "now" accent and yields to
+the grey `.is-past` treatment once the activity has passed.
+
 ---
 
 ## 6. Project Structure

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -244,6 +244,11 @@ mint form's per-field validation uses the inline field-error component
 - Once the ghost marker's old slot is in the past it takes the same muted grey, `0.5`-opacity `.is-past` treatment as any other passed row (the amber tint and accent bar are dropped), so a past ghost reads as grey, not amber. <!-- 07-§6.146 -->
 - A relocated activity shows its new location as usual, preceded by its previous location struck through in small, slightly muted text (`.ev-loc-old`, sharing the `.ev-time-old` treatment). A location change adds only this inline annotation — no ghost marker and no amber highlight. <!-- 07-§6.145 -->
 
+### Location clash (02-§120)
+
+- When two activities are booked into the same room at overlapping times, the later-booked one (`.event-row.is-clash`) is flagged in the reserved conflict red (`var(--color-error)`): a red wash, a red left accent bar, and the title in red — the same red already used for the conflict-warning banner. The earlier booking is left unmarked. <!-- 07-§6.147 -->
+- The clash red is placed after the in-progress rule so it wins over the sage "now" accent, and it yields to the grey, `0.5`-opacity `.is-past` treatment once the activity has passed. The catch-all "Annat" location is never flagged. <!-- 07-§6.148 -->
+
 ### Display sidebar — portrait layout
 
 `/live.html` is optimised for portrait-orientation screens (e.g. 1080 × 1920 px). The heading moves into the sidebar so events use the full available height from the top of the page. <!-- 07-§6.44 -->

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1892,3 +1892,18 @@ changes); `05-DATA_CONTRACT.md §2`, §2.1, §3 (`moved` + `relocated` fields);
 | `02-§119.16` | covered | MOVED-39/-40/-41/-42: `locationHtml()` shows the struck old location (`.ev-loc-old`) before the new one in `renderEventRow()`/`renderEventPage()` and emits no ghost. The today/display view via `events-today.js` is a manual/browser checkpoint |
 | `02-§119.17` | covered | MOVED-44: the ghost row carries `data-event-date`/`-start`/`-end`; `schema-status.js` and `events-today.js` add `.is-past` (greying it) when that slot is past and the `is-ghost` guard blocks `.is-now`. CSS `.event-row.is-ghost.is-past` drops the amber for grey. The live/browser greying is a manual checkpoint |
 | `02-§119.18` | covered | CSS `.event-row.is-ghost .ev-time, .ev-title { text-decoration: line-through }` strikes the ghost's first line while `.ev-moved-to` stays un-struck. Visual appearance is a manual/browser checkpoint |
+
+### §120 — Location-Clash Marking
+
+Doc ref: `02-requirements/schedule-and-detail.md §120`;
+`03-architecture/rendering.md §5.8`; `07-design/components.md §6.147–6.148`.
+Reuses the shared overlap predicate (`conflict-check.js`, §99).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§120.1` | covered | CLASH-01/-07: `markLocationClashes()` uses the shared `overlaps()` predicate (same-date, same-room, overlapping); back-to-back is not a clash |
+| `02-§120.2` | covered | CLASH-03/-09: `isRealLocation()` excludes "Annat"/"[annat]" so they never clash; build-integration check confirmed only real rooms are flagged on the live schedule |
+| `02-§120.3` | covered | CLASH-06: a cancelled activity is skipped both as the marked and the conflicting event |
+| `02-§120.4` | covered | CLASH-01/-02/-08: the later-created booking is flagged regardless of array order; with three overlaps the two later ones are marked |
+| `02-§120.5` | covered | CLASH-10/-11: `renderEventRow()` adds `is-clash`; `events-today.js` mirrors it via the `clash` JSON flag. CSS `.event-row.is-clash` uses `--color-error` (red wash + bar + title). The today/display view and visual appearance are manual/browser checkpoints |
+| `02-§120.6` | covered | CSS scopes the clash red with `:not(.is-past)` so a passed clash takes the grey `.is-past` treatment. Visual appearance is a manual/browser checkpoint |

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -219,4 +219,5 @@ Part of [the traceability index](./index.md).
 | DEDUP-M01..M02 | (manual) | Live 409 on a duplicate submission; a concurrent duplicate's redundant PR is auto-closed (02-§111.2, 111.6–111.9) |
 | DEDUPCLEAN-01..09 | `tests/dedup-cleanup.test.js` | `classifyEventPr` decision table: empty diff → close, fresh add → keep, same-id/different-body → log-manual, out-of-scope → ignore (02-§111.6–111.9) |
 | MOVED-01..44 | `tests/moved-activity.test.js` | Moved + relocated capture, serialisation, validation, helpers, schedule/event-page markup + ghost (02-§119) |
+| CLASH-01..11 | `tests/location-clash.test.js` | Location-clash marking: later-created flagged, Annat/cancelled/back-to-back excluded, `is-clash` markup (02-§120) |
 | (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the moved + relocated capture + serialisation: `patchEventObject`, `buildFragmentYaml` (02-§119) |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -779,6 +779,28 @@ body.display-mode .event-row.is-cancelled.is-now {
   font-weight: 700;
 }
 
+/* ── Location clashes (02-§120) ───────────────────────────────────────────────
+   When two activities are booked into the same room at overlapping times, the
+   one booked later is flagged in the reserved conflict red (--color-error): a
+   red wash, a red left accent bar, and the title in red. Placed after the
+   in-progress rule so the red wins over the sage "now" accent. Like the other
+   row states, the red gives way to the grey .is-past treatment once the
+   activity has passed. */
+body:not(.display-mode) .event-row.is-clash:not(.is-past) {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  box-shadow: inset 4px 0 0 var(--color-error);
+}
+
+body:not(.display-mode) .event-row.is-clash:not(.is-past) .ev-title {
+  color: var(--color-error);
+  font-weight: 700;
+}
+
+body.display-mode .event-row.is-clash:not(.is-past) {
+  background: color-mix(in srgb, var(--color-error) 22%, transparent);
+  box-shadow: inset 3px 0 0 var(--color-error);
+}
+
 /* ── Moved activities (02-§119) ───────────────────────────────────────────────
    A rescheduled activity keeps its place at the new time: the new time sits on
    top (where the time normally is) and the previous time is struck through in

--- a/source/assets/js/client/events-today.js
+++ b/source/assets/js/client/events-today.js
@@ -164,6 +164,8 @@
     var idAttr = e.id ? ' data-event-id="' + esc(e.id) + '"' : '';
     var dateAttr = e.date ? ' data-event-date="' + esc(e.date) + '"' : '';
     var cancelledClass = e.cancelled === true ? ' is-cancelled' : '';
+    // A later-booked same-room time clash is flagged in red (02-§120).
+    var clashClass = e.clash === true ? ' is-clash' : '';
     var titleHtml = (e.cancelled === true ? '<span class="ev-cancelled-label">INSTÄLLD</span> ' : '') + esc(e.title);
 
     if (hasExtra) {
@@ -176,14 +178,14 @@
       if (safeLink) {
         extraParts.push('<a class="event-ext-link" href="' + esc(safeLink) + '" target="_blank" rel="noopener">Extern länk →</a>');
       }
-      return '<details class="event-row' + cancelledClass + movedClass + '"' + idAttr + dateAttr + '><summary>' +
+      return '<details class="event-row' + cancelledClass + movedClass + clashClass + '"' + idAttr + dateAttr + '><summary>' +
         '<span class="ev-time">' + timeCell + '</span>' +
         '<span class="ev-title">' + titleHtml + '</span>' +
         metaEl + icalEl + '</summary>' +
         '<div class="event-extra">' + extraParts.join('') + '</div>' +
         '</details>';
     }
-    return '<div class="event-row plain' + cancelledClass + movedClass + '"' + idAttr + dateAttr + '>' +
+    return '<div class="event-row plain' + cancelledClass + movedClass + clashClass + '"' + idAttr + dateAttr + '>' +
       '<span class="ev-time">' + timeCell + '</span>' +
       '<span class="ev-title">' + titleHtml + '</span>' +
       metaEl + icalEl + '</div>';

--- a/source/build/build.js
+++ b/source/build/build.js
@@ -21,6 +21,7 @@ const { renderAdminPage } = require('./render-admin');
 const { renderOfflinePage } = require('./render-offline');
 const { resolveActiveCamp } = require('../scripts/resolve-active-camp');
 const { loadCampEvents } = require('./load-events');
+const { markLocationClashes } = require('./clashes');
 const { addOneDay } = require('../api/time-gate');
 const { setFeedbackUrl } = require('./layout');
 const { resolveVersionString } = require('./version');
@@ -91,6 +92,10 @@ const camp = campData.camp;
 camp.opens_for_editing = activeCamp.opens_for_editing;
 // Events come from the camp file merged with any fragment files (02-§109.13).
 const events = loadCampEvents(DATA_DIR, activeCamp.file);
+// Flag the later-booked event of each same-room time clash so every view can
+// mark it (02-§120). Tagged once here so the schedule, today, and display views
+// all agree.
+markLocationClashes(events);
 
 // ── Load locations from local.yaml ───────────────────────────────────────────
 

--- a/source/build/clashes.js
+++ b/source/build/clashes.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Flags the later-booked event in each same-location time clash so the schedule
+// can mark it (02-§120). A "lokalkrock" is two non-cancelled events on the same
+// date, in the same real room, whose times overlap; the one created later (by
+// meta.created_at) is the offender and gets `_clash = true`. The earlier booking
+// keeps the room and is left unmarked.
+//
+// The catch-all "Annat" / "[annat]" location is never a real room, so it can
+// never be in conflict.
+
+const { overlaps } = require('../assets/js/client/conflict-check.js');
+
+// True when `loc` names a real, bookable room. The catch-all "Annat" (and the
+// "[annat]" form shown in the schedule) is excluded — it never clashes.
+function isRealLocation(loc) {
+  if (!loc) return false;
+  const norm = String(loc).trim().toLowerCase().replace(/[[\]]/g, '').trim();
+  return norm !== 'annat';
+}
+
+// Comparable creation key. Events without a created_at sort first (treated as
+// the original booking), so a missing timestamp never marks the legacy event.
+function createdKey(e) {
+  return e && e.meta && e.meta.created_at ? String(e.meta.created_at) : '';
+}
+
+// Sets `_clash = true` on every event that overlaps an EARLIER-created event in
+// the same real room on the same date. Cancelled events have freed the room, so
+// they neither clash nor cause a clash. Mutates and returns `events`.
+function markLocationClashes(events) {
+  for (const e of events) {
+    if (e.cancelled || !isRealLocation(e.location)) continue;
+    const ek = createdKey(e);
+    for (const f of events) {
+      if (f === e || f.cancelled) continue;
+      if (f.date !== e.date || f.location !== e.location) continue;
+      if (!overlaps(e, f)) continue;
+      // `e` came after `f` (created later) and they share the room — mark `e`.
+      if (createdKey(f) < ek) {
+        e._clash = true;
+        break;
+      }
+    }
+  }
+  return events;
+}
+
+module.exports = { markLocationClashes, isRealLocation };

--- a/source/build/render-idag.js
+++ b/source/build/render-idag.js
@@ -28,6 +28,7 @@ function renderIdagPage(camp, events, footerHtml = '', navSections = [], cookieD
       cancelled: e.cancelled === true,
       moved: e.moved && e.moved.from_date ? e.moved : null,
       relocated: e.relocated && e.relocated.from_location ? e.relocated : null,
+      clash: e._clash === true,
     })),
   );
 

--- a/source/build/render-today.js
+++ b/source/build/render-today.js
@@ -39,6 +39,7 @@ function renderTodayPage(camp, events, qrSvg, siteUrl = '', buildTime = '', goat
       cancelled: e.cancelled === true,
       moved: e.moved && e.moved.from_date ? e.moved : null,
       relocated: e.relocated && e.relocated.from_location ? e.relocated : null,
+      clash: e._clash === true,
     })),
   );
 

--- a/source/build/render.js
+++ b/source/build/render.js
@@ -91,6 +91,8 @@ function renderEventRow(e) {
 
   const cancelled = e.cancelled === true;
   const cancelledClass = cancelled ? ' is-cancelled' : '';
+  // A later-booked same-room time clash is flagged in red (02-§120).
+  const clashClass = e._clash ? ' is-clash' : '';
   const titleHtml = `${cancelled ? CANCELLED_LABEL : ''}${escapeHtml(e.title)}`;
 
   const idAttr = e.id ? ` data-event-id="${escapeHtml(String(e.id))}"` : '';
@@ -103,7 +105,7 @@ function renderEventRow(e) {
 
   if (hasExtra) {
     return [
-      `    <details class="event-row${cancelledClass}${movedClass}"${idAttr}${timeAttrs}>`,
+      `    <details class="event-row${cancelledClass}${movedClass}${clashClass}"${idAttr}${timeAttrs}>`,
       '      <summary>',
       `        <span class="ev-time">${timeCellHtml}</span>`,
       `        <span class="ev-title">${titleHtml}</span>`,
@@ -117,7 +119,7 @@ function renderEventRow(e) {
       .join('\n');
   } else {
     return [
-      `    <div class="event-row plain${cancelledClass}${movedClass}"${idAttr}${timeAttrs}>`,
+      `    <div class="event-row plain${cancelledClass}${movedClass}${clashClass}"${idAttr}${timeAttrs}>`,
       `      <span class="ev-time">${timeCellHtml}</span>`,
       `      <span class="ev-title">${titleHtml}</span>`,
       metaEl ? `      ${metaEl}` : '',

--- a/tests/location-clash.test.js
+++ b/tests/location-clash.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+// Tests for the location-clash marking (02-§120): when two activities are booked
+// into the same real room at overlapping times, the one created later is flagged
+// (`_clash`) so the schedule can mark it in the reserved conflict red. The
+// catch-all "Annat" / "[annat]" location never clashes.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { markLocationClashes, isRealLocation } = require('../source/build/clashes');
+const { renderEventRow } = require('../source/build/render');
+
+function ev(id, location, start, end, created, extra) {
+  return Object.assign({
+    id, title: id, date: '2026-06-27', start, end, location,
+    responsible: 'R', meta: { created_at: created },
+  }, extra || {});
+}
+
+describe('markLocationClashes (02-§120)', () => {
+  it('CLASH-01: marks the later-created event, not the earlier one', () => {
+    const evs = [ev('A', 'Sal', '14:00', '16:00', '2026-06-01 10:00'), ev('B', 'Sal', '15:00', '17:00', '2026-06-02 10:00')];
+    markLocationClashes(evs);
+    assert.equal(evs[0]._clash, undefined);
+    assert.equal(evs[1]._clash, true);
+  });
+
+  it('CLASH-02: order in the array does not matter — the later booking is marked', () => {
+    const evs = [ev('B', 'Sal', '15:00', '17:00', '2026-06-02 10:00'), ev('A', 'Sal', '14:00', '16:00', '2026-06-01 10:00')];
+    markLocationClashes(evs);
+    assert.equal(evs[0]._clash, true);   // B, created later
+    assert.equal(evs[1]._clash, undefined);
+  });
+
+  it('CLASH-03: "Annat" and "[annat]" never clash', () => {
+    const evs = [
+      ev('C', '[annat]', '14:00', '16:00', '2026-06-01 10:00'),
+      ev('D', '[annat]', '15:00', '17:00', '2026-06-02 10:00'),
+      ev('E', 'Annat', '15:00', '17:00', '2026-06-03 10:00'),
+    ];
+    markLocationClashes(evs);
+    assert.ok(!evs.some((e) => e._clash));
+  });
+
+  it('CLASH-04: different rooms do not clash', () => {
+    const evs = [ev('F', 'Sal', '14:00', '16:00', '2026-06-01 10:00'), ev('G', 'Tält', '15:00', '17:00', '2026-06-02 10:00')];
+    markLocationClashes(evs);
+    assert.ok(!evs.some((e) => e._clash));
+  });
+
+  it('CLASH-05: different dates do not clash', () => {
+    const evs = [ev('H', 'Sal', '14:00', '16:00', '2026-06-01 10:00'), Object.assign(ev('I', 'Sal', '15:00', '17:00', '2026-06-02 10:00'), { date: '2026-06-28' })];
+    markLocationClashes(evs);
+    assert.ok(!evs.some((e) => e._clash));
+  });
+
+  it('CLASH-06: a cancelled event neither clashes nor is marked', () => {
+    const evs = [ev('J', 'Sal', '14:00', '16:00', '2026-06-01 10:00', { cancelled: true }), ev('K', 'Sal', '15:00', '17:00', '2026-06-02 10:00')];
+    markLocationClashes(evs);
+    assert.equal(evs[1]._clash, undefined);
+  });
+
+  it('CLASH-07: back-to-back bookings are not a clash', () => {
+    const evs = [ev('L', 'Sal', '14:00', '16:00', '2026-06-01 10:00'), ev('M', 'Sal', '16:00', '18:00', '2026-06-02 10:00')];
+    markLocationClashes(evs);
+    assert.ok(!evs.some((e) => e._clash));
+  });
+
+  it('CLASH-08: with three overlapping bookings, the two later ones are marked', () => {
+    const evs = [
+      ev('A', 'Sal', '14:00', '17:00', '2026-06-01 10:00'),
+      ev('B', 'Sal', '15:00', '16:00', '2026-06-02 10:00'),
+      ev('C', 'Sal', '15:30', '16:30', '2026-06-03 10:00'),
+    ];
+    markLocationClashes(evs);
+    assert.equal(evs[0]._clash, undefined);
+    assert.equal(evs[1]._clash, true);
+    assert.equal(evs[2]._clash, true);
+  });
+
+  it('CLASH-09: isRealLocation rejects annat variants and empty, accepts real rooms', () => {
+    assert.equal(isRealLocation('Annat'), false);
+    assert.equal(isRealLocation('[annat]'), false);
+    assert.equal(isRealLocation('  annat '), false);
+    assert.equal(isRealLocation(''), false);
+    assert.equal(isRealLocation('Samlingssalen'), true);
+  });
+});
+
+describe('renderEventRow – clash markup (02-§120)', () => {
+  it('CLASH-10: a flagged event gets the is-clash class', () => {
+    const html = renderEventRow(ev('B', 'Sal', '15:00', '17:00', '2026-06-02 10:00', { _clash: true }));
+    assert.ok(html.includes('is-clash'));
+  });
+
+  it('CLASH-11: an unflagged event has no is-clash class', () => {
+    const html = renderEventRow(ev('A', 'Sal', '14:00', '16:00', '2026-06-01 10:00'));
+    assert.ok(!html.includes('is-clash'));
+  });
+});


### PR DESCRIPTION
## Summary

Marks "lokalkrock" in the schedule: when two activities are booked into the same room at overlapping times, the **later-booked** one is flagged in the **reserved conflict red** (`--color-error` — the same red the conflict-warning banner already uses).

- **Detection** — `source/build/clashes.js` `markLocationClashes(events)` runs once in `build.js`, reusing the shared `overlaps()` predicate from `conflict-check.js` (same logic as the per-event conflict banner / locale overview). For each non-cancelled activity in a real room, if an **earlier-created** activity shares the date+room and overlaps in time, the later one gets `_clash`. The earliest booking keeps the room, unmarked.
- **"Annat" never clashes** — the catch-all `[annat]`/`Annat` location is excluded entirely.
- **Cancelled freed the room** — a cancelled activity is never marked and never causes a clash.
- **Display** — flagged rows get `is-clash` (red wash + red left bar + red title) in the weekly schedule and today view; the red yields to the grey `.is-past` treatment once the activity has passed.

## Test plan

- [x] `node --test tests/*.test.js` — 2179 pass (11 new CLASH-01..11)
- [x] `eslint`, `stylelint`, `markdownlint` clean
- [x] Full build green; the live schedule flags 5 real same-room overlaps (Tält1, Grillplats, Kaffetält, GA Stilla hyllan, Servicehus) and **zero** "Annat" false positives
- [ ] Browser walkthrough on QA: confirm the later booking of a same-room overlap shows red, the earlier one doesn't, and "Annat" overlaps are never flagged

Relates to #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdnDXc2vtPRnpBcfWKayg)_