### PR TITLE
Fix clash creation-order + ignore Lunch/Middag (#729)

### DIFF
--- a/docs/02-requirements/schedule-and-detail.md
+++ b/docs/02-requirements/schedule-and-detail.md
@@ -638,6 +638,10 @@ per-event conflict banner and the locale overview (§99).
   activity there is never part of a clash and never causes one. <!-- 02-§120.2 -->
 - A cancelled ("inställd") activity has freed its room: it is never marked and
   never causes another activity to be marked. <!-- 02-§120.3 -->
+- The communal meals "Lunch" and "Middag" are ignored by the clash logic
+  entirely (matched case-insensitively by title): a meal is never marked and
+  never causes another activity to be marked, because everyone shares the meal
+  and it is not a competing booking. <!-- 02-§120.7 -->
 
 ### 120.2 Which activity is marked
 

--- a/docs/03-architecture/rendering.md
+++ b/docs/03-architecture/rendering.md
@@ -207,8 +207,11 @@ catch-all is excluded by `isRealLocation()`), it looks for an **earlier-created*
 activity on the same date in the same room whose time overlaps — reusing the
 shared `overlaps()` predicate from `conflict-check.js` (the same logic behind the
 per-event conflict banner and the locale overview). The later booking gets
-`_clash = true`; the earliest booking is left unmarked. Cancelled activities have
-freed the room, so they neither clash nor are marked.
+`_clash = true`; the earliest booking is left unmarked. Creation times are
+compared by epoch (`createdMs`) so a YAML Date-object timestamp and a string
+timestamp order correctly. Cancelled activities have freed the room, and the
+communal meals "Lunch"/"Middag" (`isIgnoredActivity`) are shared by everyone —
+both are skipped, so they neither clash nor are marked (02-§120.7).
 
 `renderEventRow()` (`render.js`) adds an `is-clash` class to a flagged row, and
 `build.js` exposes the boolean as `clash` in the today/display event JSON so

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1907,3 +1907,4 @@ Reuses the shared overlap predicate (`conflict-check.js`, §99).
 | `02-§120.4` | covered | CLASH-01/-02/-08: the later-created booking is flagged regardless of array order; with three overlaps the two later ones are marked. CLASH-12: creation times are compared by epoch (`createdMs`) so a YAML Date-object timestamp and a string timestamp order correctly |
 | `02-§120.5` | covered | CLASH-10/-11: `renderEventRow()` adds `is-clash`; `events-today.js` mirrors it via the `clash` JSON flag. CSS `.event-row.is-clash` uses `--color-error` (red wash + bar + title). The today/display view and visual appearance are manual/browser checkpoints |
 | `02-§120.6` | covered | CSS scopes the clash red with `:not(.is-past)` so a passed clash takes the grey `.is-past` treatment. Visual appearance is a manual/browser checkpoint |
+| `02-§120.7` | covered | CLASH-13/-14/-15: `isIgnoredActivity()` skips "Lunch"/"Middag" (case-insensitive) both as the marked and the conflicting event |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1904,6 +1904,6 @@ Reuses the shared overlap predicate (`conflict-check.js`, §99).
 | `02-§120.1` | covered | CLASH-01/-07: `markLocationClashes()` uses the shared `overlaps()` predicate (same-date, same-room, overlapping); back-to-back is not a clash |
 | `02-§120.2` | covered | CLASH-03/-09: `isRealLocation()` excludes "Annat"/"[annat]" so they never clash; build-integration check confirmed only real rooms are flagged on the live schedule |
 | `02-§120.3` | covered | CLASH-06: a cancelled activity is skipped both as the marked and the conflicting event |
-| `02-§120.4` | covered | CLASH-01/-02/-08: the later-created booking is flagged regardless of array order; with three overlaps the two later ones are marked |
+| `02-§120.4` | covered | CLASH-01/-02/-08: the later-created booking is flagged regardless of array order; with three overlaps the two later ones are marked. CLASH-12: creation times are compared by epoch (`createdMs`) so a YAML Date-object timestamp and a string timestamp order correctly |
 | `02-§120.5` | covered | CLASH-10/-11: `renderEventRow()` adds `is-clash`; `events-today.js` mirrors it via the `clash` JSON flag. CSS `.event-row.is-clash` uses `--color-error` (red wash + bar + title). The today/display view and visual appearance are manual/browser checkpoints |
 | `02-§120.6` | covered | CSS scopes the clash red with `:not(.is-past)` so a passed clash takes the grey `.is-past` treatment. Visual appearance is a manual/browser checkpoint |

--- a/docs/99-traceability/test-id-legend.md
+++ b/docs/99-traceability/test-id-legend.md
@@ -219,5 +219,5 @@ Part of [the traceability index](./index.md).
 | DEDUP-M01..M02 | (manual) | Live 409 on a duplicate submission; a concurrent duplicate's redundant PR is auto-closed (02-§111.2, 111.6–111.9) |
 | DEDUPCLEAN-01..09 | `tests/dedup-cleanup.test.js` | `classifyEventPr` decision table: empty diff → close, fresh add → keep, same-id/different-body → log-manual, out-of-scope → ignore (02-§111.6–111.9) |
 | MOVED-01..44 | `tests/moved-activity.test.js` | Moved + relocated capture, serialisation, validation, helpers, schedule/event-page markup + ghost (02-§119) |
-| CLASH-01..11 | `tests/location-clash.test.js` | Location-clash marking: later-created flagged, Annat/cancelled/back-to-back excluded, `is-clash` markup (02-§120) |
+| CLASH-01..15 | `tests/location-clash.test.js` | Location-clash marking: later-created flagged, Annat/cancelled/back-to-back excluded, `is-clash` markup (02-§120) |
 | (PHPUnit) | `api/tests/GitHubTest.php` | PHP mirror of the moved + relocated capture + serialisation: `patchEventObject`, `buildFragmentYaml` (02-§119) |

--- a/source/build/clashes.js
+++ b/source/build/clashes.js
@@ -19,10 +19,16 @@ function isRealLocation(loc) {
   return norm !== 'annat';
 }
 
-// Comparable creation key. Events without a created_at sort first (treated as
-// the original booking), so a missing timestamp never marks the legacy event.
-function createdKey(e) {
-  return e && e.meta && e.meta.created_at ? String(e.meta.created_at) : '';
+// Comparable creation time in epoch milliseconds. YAML parses an ISO timestamp
+// (`2026-02-27T09:12:59Z`) into a Date object but leaves a space-separated one
+// (`2026-06-27 00:40`) as a string, so the two must not be compared as raw text
+// — `new Date(...)` normalises both. A missing or unparseable created_at sorts
+// earliest, so it counts as the original booking and is never the one flagged.
+function createdMs(e) {
+  const v = e && e.meta ? e.meta.created_at : null;
+  if (!v) return -Infinity;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? -Infinity : t;
 }
 
 // Sets `_clash = true` on every event that overlaps an EARLIER-created event in
@@ -31,13 +37,13 @@ function createdKey(e) {
 function markLocationClashes(events) {
   for (const e of events) {
     if (e.cancelled || !isRealLocation(e.location)) continue;
-    const ek = createdKey(e);
+    const ems = createdMs(e);
     for (const f of events) {
       if (f === e || f.cancelled) continue;
       if (f.date !== e.date || f.location !== e.location) continue;
       if (!overlaps(e, f)) continue;
       // `e` came after `f` (created later) and they share the room — mark `e`.
-      if (createdKey(f) < ek) {
+      if (createdMs(f) < ems) {
         e._clash = true;
         break;
       }

--- a/source/build/clashes.js
+++ b/source/build/clashes.js
@@ -19,6 +19,14 @@ function isRealLocation(loc) {
   return norm !== 'annat';
 }
 
+// Communal meals everyone shares. They are ignored by the clash logic entirely:
+// a meal is never flagged and never causes another activity to be flagged
+// (02-§120.7).
+const IGNORED_TITLES = new Set(['lunch', 'middag']);
+function isIgnoredActivity(e) {
+  return !!(e && e.title && IGNORED_TITLES.has(String(e.title).trim().toLowerCase()));
+}
+
 // Comparable creation time in epoch milliseconds. YAML parses an ISO timestamp
 // (`2026-02-27T09:12:59Z`) into a Date object but leaves a space-separated one
 // (`2026-06-27 00:40`) as a string, so the two must not be compared as raw text
@@ -36,10 +44,10 @@ function createdMs(e) {
 // they neither clash nor cause a clash. Mutates and returns `events`.
 function markLocationClashes(events) {
   for (const e of events) {
-    if (e.cancelled || !isRealLocation(e.location)) continue;
+    if (e.cancelled || isIgnoredActivity(e) || !isRealLocation(e.location)) continue;
     const ems = createdMs(e);
     for (const f of events) {
-      if (f === e || f.cancelled) continue;
+      if (f === e || f.cancelled || isIgnoredActivity(f)) continue;
       if (f.date !== e.date || f.location !== e.location) continue;
       if (!overlaps(e, f)) continue;
       // `e` came after `f` (created later) and they share the room — mark `e`.
@@ -52,4 +60,4 @@ function markLocationClashes(events) {
   return events;
 }
 
-module.exports = { markLocationClashes, isRealLocation };
+module.exports = { markLocationClashes, isRealLocation, isIgnoredActivity };

--- a/tests/location-clash.test.js
+++ b/tests/location-clash.test.js
@@ -79,6 +79,17 @@ describe('markLocationClashes (02-§120)', () => {
     assert.equal(evs[2]._clash, true);
   });
 
+  it('CLASH-12: a Date-object created_at orders correctly against a string one', () => {
+    // Mirrors real data: a seed event whose created_at YAML-parsed into a Date
+    // object, overlapping a later event whose created_at stayed a string. They
+    // must be compared by time, not as raw text ("Fri Feb 27 …" vs "2026-06-…").
+    const seed = ev('Middag', 'Servicehus', '17:00', '18:00', new Date('2026-02-27T09:12:59Z'));
+    const late = ev('Töm', 'Servicehus', '17:00', '18:00', '2026-06-27 00:40');
+    markLocationClashes([seed, late]);
+    assert.equal(seed._clash, undefined); // created first (Feb) — not flagged
+    assert.equal(late._clash, true);      // created later (Jun) — flagged
+  });
+
   it('CLASH-09: isRealLocation rejects annat variants and empty, accepts real rooms', () => {
     assert.equal(isRealLocation('Annat'), false);
     assert.equal(isRealLocation('[annat]'), false);

--- a/tests/location-clash.test.js
+++ b/tests/location-clash.test.js
@@ -8,7 +8,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { markLocationClashes, isRealLocation } = require('../source/build/clashes');
+const { markLocationClashes, isRealLocation, isIgnoredActivity } = require('../source/build/clashes');
 const { renderEventRow } = require('../source/build/render');
 
 function ev(id, location, start, end, created, extra) {
@@ -83,11 +83,32 @@ describe('markLocationClashes (02-§120)', () => {
     // Mirrors real data: a seed event whose created_at YAML-parsed into a Date
     // object, overlapping a later event whose created_at stayed a string. They
     // must be compared by time, not as raw text ("Fri Feb 27 …" vs "2026-06-…").
-    const seed = ev('Middag', 'Servicehus', '17:00', '18:00', new Date('2026-02-27T09:12:59Z'));
-    const late = ev('Töm', 'Servicehus', '17:00', '18:00', '2026-06-27 00:40');
+    const seed = ev('Pyssel', 'Servicehus', '17:00', '18:00', new Date('2026-02-27T09:12:59Z'));
+    const late = ev('Möte', 'Servicehus', '17:00', '18:00', '2026-06-27 00:40');
     markLocationClashes([seed, late]);
     assert.equal(seed._clash, undefined); // created first (Feb) — not flagged
     assert.equal(late._clash, true);      // created later (Jun) — flagged
+  });
+
+  it('CLASH-13: Lunch and Middag are never flagged, even when booked later', () => {
+    const seed = ev('Workshop', 'Servicehus', '17:00', '18:00', '2026-06-01 10:00');
+    const meal = ev('Middag', 'Servicehus', '17:00', '18:00', '2026-06-27 00:40');
+    markLocationClashes([seed, meal]);
+    assert.equal(meal._clash, undefined);
+  });
+
+  it('CLASH-14: a meal never causes another activity to be flagged', () => {
+    const meal = ev('Lunch', 'Servicehus', '12:00', '13:00', '2026-02-27 09:00');
+    const later = ev('Möte', 'Servicehus', '12:00', '13:00', '2026-06-27 09:00');
+    markLocationClashes([meal, later]);
+    assert.equal(later._clash, undefined); // only the (ignored) meal overlaps it
+  });
+
+  it('CLASH-15: meal titles are matched case-insensitively', () => {
+    assert.equal(isIgnoredActivity({ title: '  MIDDAG ' }), true);
+    assert.equal(isIgnoredActivity({ title: 'lunch' }), true);
+    assert.equal(isIgnoredActivity({ title: 'Middag & dans' }), false);
+    assert.equal(isIgnoredActivity({ title: 'Workshop' }), false);
   });
 
   it('CLASH-09: isRealLocation rejects annat variants and empty, accepts real rooms', () => {


### PR DESCRIPTION
## Summary

Two corrections to the location-clash marking (#774), both from your review:

1. **Creation-order bug** — "Middag" was flagged even though it was booked first. Event `created_at` comes in two YAML forms: an ISO timestamp (`2026-02-27T09:12:59Z`) is parsed into a **Date object**, a space-separated one (`2026-06-27 00:40`) stays a **string**. The code compared them as text, and `String(Date)` is `"Fri Feb 27 2026 …"`, which sorts *after* `"2026-06-…"`. Fixed by comparing epoch milliseconds (`new Date(v).getTime()`), which normalises both.

2. **Lunch and Middag are ignored** — the communal meals everyone shares are never flagged and never cause another activity to be flagged (matched case-insensitively by title), just like a cancelled activity. So "Töm kyl och frys inför kvällen" sharing Servicehus with Middag is no longer a clash.

## Test plan

- [x] `node --test tests/*.test.js` — 2183 pass (CLASH-12 Date/string ordering; CLASH-13/14/15 meal exclusion)
- [x] `eslint`, `stylelint`, `markdownlint` clean
- [x] Rebuilt the live schedule → flagged clashes are now `Färga t-shirt`, `Rubikskub/ speedkub`, `Skrivmaraton`, `Musikklass träff`; **Middag, Lunch and Töm kyl are no longer flagged**

Relates to #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)