### PR TITLE
Match moved old-time weight to relocated old-location style

### DIFF
--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -813,6 +813,7 @@ body.display-mode .event-row.is-clash:not(.is-past) {
 .ev-loc-old {
   text-decoration: line-through;
   font-size: var(--font-size-small);
+  font-weight: 400;
   opacity: 0.7;
 }
 


### PR DESCRIPTION
## Summary

On a moved activity, the struck-through **previous time** (`.ev-time-old`, shown below the new time) read heavier and larger than intended: it inherited the bold `font-weight: 700` of the `.ev-time` cell. The struck-through **previous location** of a relocated activity (`.ev-loc-old`) sits in the non-bold `.ev-meta` line and already looked correctly subtle.

This sets the shared `.ev-time-old, .ev-loc-old` rule to `font-weight: 400`, so the moved old time matches the relocated old location exactly. The design doc already describes the two as sharing one treatment, "smaller, slightly muted text" (07-§6.142, §6.145) — this aligns the implementation with that description; no requirement or doc change is needed.

## Changes

- `source/assets/cs/style.css`: add `font-weight: 400` to the `.ev-time-old, .ev-loc-old` rule (one line).

## Test plan

- [x] `stylelint` clean
- [x] `npm run build` succeeds; rule present in `public/style.css`
- [x] No markup change → existing MOVED tests still pass (class names/order unchanged)
- [ ] Manual/browser: a moved activity's struck old time now matches the weight/size of a relocated activity's struck old location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018shDtnCeLYjHcP7VtYSeR3)_