### PR TITLE
Recover stranded event PRs by enqueuing, not toggling auto-merge

### DIFF
--- a/.github/workflows/merge-queue-recovery.yml
+++ b/.github/workflows/merge-queue-recovery.yml
@@ -6,8 +6,10 @@ name: Merge Queue Recovery
 # primary trigger is check_suite: completed — recovery runs right then (02-§112.16),
 # rather than waiting for GitHub's unreliable schedule delivery. The post-merge sweep
 # in event-data-deploy-post-merge.yml covers the burst case; the schedule below is a
-# slow backstop (02-§112.8). The sweep is cheap when idle: it lists open event PRs and
-# exits when none are stranded (02-§112.9).
+# last-resort backstop (02-§112.8). Recovery re-queues a stranded PR with the imperative
+# enqueuePullRequest mutation and verifies a merge-queue entry results (02-§112.2). The
+# sweep is cheap when idle: it lists open event PRs and exits when none are stranded
+# (02-§112.9).
 
 permissions:
   contents: read
@@ -16,8 +18,10 @@ on:
   check_suite:
     types: [completed]
   schedule:
-    # Every 15 minutes — slow backstop; GitHub does not guarantee this cadence.
-    - cron: '*/15 * * * *'
+    # Every 120 minutes — last-resort backstop only. check_suite recovers within about
+    # a minute; GitHub throttles high-frequency schedules, so a long interval matches
+    # what it reliably delivers and keeps the load low (02-§112.8).
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 # All recovery triggers (here plus the post-merge job) share one group so bursts of

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -948,15 +948,21 @@ stuck in the queue handoff.
   also qualifies. A pull request whose mergeable state reports a real conflict
   (`DIRTY`) is not recovered, because re-queuing cannot resolve a
   conflict. <!-- 02-§112.18 -->
-- A stranded event pull request is recovered by placing it back in the merge queue
-  with the GraphQL `enqueuePullRequest` mutation, using the pull request's node id.
-  This is the same mutation the form API uses to enqueue a pull request at submission
-  (§113). Enqueuing places the pull request in the queue directly, so recovery does
-  not depend on `main` advancing or on any further mergeability event. <!-- 02-§112.2 -->
-- Recovery leaves auto-merge enabled on the pull request; it does not disable it.
-  Auto-merge remains as a complement to the enqueue call, matching how the form API
-  keeps squash auto-merge enabled alongside the proactive enqueue at submission
-  (§113.2). <!-- 02-§112.3 -->
+- A stranded event pull request is recovered primarily by placing it back in the merge
+  queue with the GraphQL `enqueuePullRequest` mutation, using the pull request's node
+  id. This is the same mutation the form API uses to enqueue a pull request at
+  submission (§113). Enqueuing places the pull request in the queue directly, so
+  recovery does not depend on `main` advancing or on any further mergeability event.
+  If the enqueue cannot be confirmed — the pull request's checks have passed but its
+  mergeable state is still catching up (§112.18), so the queue declines to enqueue it
+  — recovery falls back to re-arming auto-merge (see §112.3) so the pull request
+  enqueues once its mergeable state converges. <!-- 02-§112.2 -->
+- Recovery keeps auto-merge enabled as a complement to the enqueue call, matching how
+  the form API keeps squash auto-merge enabled alongside the proactive enqueue at
+  submission (§113.2). In the fallback case only — when the pull request cannot be
+  enqueued yet — recovery disables and then re-enables auto-merge (squash) to re-arm
+  it, which registers a fresh queue entry against the current `main` at the moment the
+  mergeable state becomes clean. <!-- 02-§112.3 -->
 - An event pull request that already has a merge-queue entry is left untouched: it is
   progressing through the queue normally and does not need to be re-queued. <!-- 02-§112.4 -->
 - An event pull request whose required checks are still pending, or have failed, is
@@ -965,9 +971,13 @@ stuck in the queue handoff.
 - Recovery confirms the enqueue took effect: after enqueuing, it re-reads the pull
   request and checks that a merge-queue entry now exists. If none does, it enqueues
   again with exponential backoff, until a merge-queue entry is confirmed or the
-  attempts are exhausted, in which case the failure is logged. Auto-merge is left
-  enabled throughout, so a failed enqueue never leaves the pull request worse off than
-  stranded and the next recovery pass retries. <!-- 02-§112.11 -->
+  attempts are exhausted. When they are exhausted, recovery re-arms auto-merge as the
+  fallback (§112.3); its re-enable step is likewise retried with backoff, because once
+  auto-merge has been disabled a transient failure to re-enable it would leave the pull
+  request with auto-merge off — worse than stranded. The disable step is a single
+  attempt: a failed disable leaves the pull request unchanged for the next pass. Only
+  when both the enqueue and the fallback re-arm fail is the recovery of that pull
+  request treated as failed. <!-- 02-§112.11 -->
 - Each event pull request is evaluated in isolation, so a failure to read or recover
   one pull request does not abort the recovery of the others. <!-- 02-§112.6 -->
 - When one or more stranded pull requests could not be recovered during a pass, the
@@ -997,9 +1007,11 @@ stuck in the queue handoff.
   configured interval. <!-- 02-§112.16 -->
 - Recovery runs are single-flight: all recovery triggers (post-merge, scheduled,
   check-suite, manual) share one concurrency group, and an in-progress run is never
-  cancelled. This coalesces bursts of check-suite completions into few runs and lets
-  each run finish its enqueue-and-verify pass without a concurrent run racing it on
-  the same pull request. <!-- 02-§112.17 -->
+  cancelled. This coalesces bursts of check-suite completions into few runs, lets each
+  run finish its enqueue-and-verify pass without a concurrent run racing it on the same
+  pull request, and guarantees a run that has entered the fallback re-arm (auto-merge
+  disabled, not yet re-enabled) is allowed to finish, so a pull request is never left
+  with auto-merge off. <!-- 02-§112.17 -->
 - Recovery is idempotent. A pull request that is not stranded is left unchanged on
   every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->
 

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -917,10 +917,10 @@ Event submissions arrive in bursts (§109.1), so several event pull requests oft
 compete for the queue at once. When one pull request merges, `main` advances. A
 sibling pull request whose auto-merge was enabled against the previous `main` tip
 can then be left **stranded**: it has auto-merge enabled, all required checks green,
-and a clean mergeable state, yet it never reaches the queue and never merges. GitHub
-treats auto-merge as already enabled, so a second enable request changes nothing; the
-pull request only re-enters the queue when auto-merge is disabled and then enabled
-again, which registers a fresh queue entry against the current `main`.
+and a clean mergeable state, yet it never reaches the queue and never merges. Enabling
+auto-merge again changes nothing, because GitHub only enqueues a pull request at the
+moment its checks pass, and that moment has already gone by. The pull request merges
+only once it is placed back in the merge queue explicitly.
 
 The observable signature of a stranded pull request is precise: auto-merge enabled,
 required checks passing, mergeable state clean, and **no merge-queue entry**. A
@@ -946,26 +946,28 @@ stuck in the queue handoff.
   checks have all passed and that is not in the queue as stranded even while its
   mergeable state still reports `BLOCKED` or `UNKNOWN`; a mergeable state of clean
   also qualifies. A pull request whose mergeable state reports a real conflict
-  (`DIRTY`) is not recovered, because re-enabling auto-merge cannot resolve a
+  (`DIRTY`) is not recovered, because re-queuing cannot resolve a
   conflict. <!-- 02-§112.18 -->
-- A stranded event pull request is recovered by disabling and then re-enabling
-  auto-merge, which registers a fresh merge-queue entry against the current `main`
-  so the pull request merges. Re-enabling auto-merge without first disabling it is a
-  no-op and does not recover the pull request. <!-- 02-§112.2 -->
-- Recovery re-enables auto-merge with the squash merge method, matching how the form
-  API enables auto-merge at submission. <!-- 02-§112.3 -->
+- A stranded event pull request is recovered by placing it back in the merge queue
+  with the GraphQL `enqueuePullRequest` mutation, using the pull request's node id.
+  This is the same mutation the form API uses to enqueue a pull request at submission
+  (§113). Enqueuing places the pull request in the queue directly, so recovery does
+  not depend on `main` advancing or on any further mergeability event. <!-- 02-§112.2 -->
+- Recovery leaves auto-merge enabled on the pull request; it does not disable it.
+  Auto-merge remains as a complement to the enqueue call, matching how the form API
+  keeps squash auto-merge enabled alongside the proactive enqueue at submission
+  (§113.2). <!-- 02-§112.3 -->
 - An event pull request that already has a merge-queue entry is left untouched: it is
-  progressing through the queue normally and disabling its auto-merge would remove it
-  from the queue. <!-- 02-§112.4 -->
+  progressing through the queue normally and does not need to be re-queued. <!-- 02-§112.4 -->
 - An event pull request whose required checks are still pending, or have failed, is
   left untouched: it is not yet eligible to merge, so there is nothing to
   recover. <!-- 02-§112.5 -->
-- The re-enable step is retried with backoff. Once auto-merge has been disabled, a
-  transient failure to re-enable it would leave the pull request with auto-merge off
-  — worse than stranded — so re-enabling is retried until it succeeds or the
-  attempts are exhausted, in which case the failure is logged. The disable step is
-  not retried: if it fails the pull request is unchanged and the next recovery pass
-  retries the whole recovery. <!-- 02-§112.11 -->
+- Recovery confirms the enqueue took effect: after enqueuing, it re-reads the pull
+  request and checks that a merge-queue entry now exists. If none does, it enqueues
+  again with exponential backoff, until a merge-queue entry is confirmed or the
+  attempts are exhausted, in which case the failure is logged. Auto-merge is left
+  enabled throughout, so a failed enqueue never leaves the pull request worse off than
+  stranded and the next recovery pass retries. <!-- 02-§112.11 -->
 - Each event pull request is evaluated in isolation, so a failure to read or recover
   one pull request does not abort the recovery of the others. <!-- 02-§112.6 -->
 - When one or more stranded pull requests could not be recovered during a pass, the
@@ -979,11 +981,12 @@ stuck in the queue handoff.
   pipeline as the concurrent-duplicate cleanup (§111.8). That merge is what advances
   the base and can strand a sibling pull request, so recovery happens immediately
   when stranding is most likely. <!-- 02-§112.7 -->
-- Recovery also runs on a fixed schedule, every 15 minutes, as a safety net. A
-  pull request can be stranded by a merge that is not itself an event-data merge, or
-  by a stranding that no subsequent event merge follows to trigger the post-merge
-  pass; the scheduled pass bounds how long such a pull request waits before it is
-  recovered. <!-- 02-§112.8 -->
+- Recovery also runs on a fixed schedule, every 120 minutes, as a last-resort
+  backstop. The check-suite trigger (§112.16) recovers a stranded pull request within
+  about a minute, so the schedule exists only for the rare pull request that no
+  check-suite completion or event merge follows. GitHub throttles high-frequency
+  scheduled workflows, so a long interval matches what it reliably delivers and keeps
+  the load low. <!-- 02-§112.8 -->
 - The scheduled safety-net pass is inexpensive when there are no open event pull
   requests: it lists the open event pull requests and exits without further work when
   none are stranded. <!-- 02-§112.9 -->
@@ -994,18 +997,19 @@ stuck in the queue handoff.
   configured interval. <!-- 02-§112.16 -->
 - Recovery runs are single-flight: all recovery triggers (post-merge, scheduled,
   check-suite, manual) share one concurrency group, and an in-progress run is never
-  cancelled. This coalesces bursts of check-suite completions into few runs and
-  guarantees a run that is mid-toggle (auto-merge disabled, not yet re-enabled) is
-  allowed to finish, so a pull request is never left with auto-merge off. <!-- 02-§112.17 -->
+  cancelled. This coalesces bursts of check-suite completions into few runs and lets
+  each run finish its enqueue-and-verify pass without a concurrent run racing it on
+  the same pull request. <!-- 02-§112.17 -->
 - Recovery is idempotent. A pull request that is not stranded is left unchanged on
   every pass, so running recovery repeatedly is safe. <!-- 02-§112.10 -->
 
 ### 112.4 Recovery job authentication (site requirements)
 
 - The recovery job authenticates to the GitHub API with a token that is permitted to
-  enable and disable auto-merge on pull requests. The default GitHub Actions workflow
-  token (`secrets.GITHUB_TOKEN`) cannot perform the auto-merge GraphQL mutations even
-  when granted `pull-requests: write`, so recovery uses a separate token. <!-- 02-§112.12 -->
+  place pull requests in the merge queue and manage auto-merge. The default GitHub
+  Actions workflow token (`secrets.GITHUB_TOKEN`) cannot perform these GraphQL
+  mutations even when granted `pull-requests: write`, so recovery uses a separate
+  token. <!-- 02-§112.12 -->
 - The token is supplied through the repository-level Actions secret
   `EVENT_AUTOMERGE_TOKEN`, which holds a credential with pull-request and contents
   write access to the repository. The secret is repository-level (not environment
@@ -1025,9 +1029,8 @@ auto-merge (squash) enabled at creation (§109, §110, §111). Enabling auto-mer
 not the same as being placed in the merge queue: GitHub only adds a pull request to
 the queue once its required checks pass, and during bursts a pull request can fail to
 enter the queue at all and hang with auto-merge enabled but no queue entry (§112).
-The reactive recovery in §112 repairs such a pull request, but it is reactive — a
-stranded pull request can in the worst case wait up to the recovery sweep's interval
-(~15 minutes) before it is detected and re-queued.
+The reactive recovery in §112 repairs such a pull request, but it is reactive — the
+pull request waits until a recovery trigger fires before it is detected and re-queued.
 
 To keep submission latency low, the form API places each newly opened event pull
 request in the merge queue immediately at submission, via the GraphQL
@@ -1069,9 +1072,10 @@ for them: auto-merge stays enabled as a complement, and the reactive recovery in
 
 ### 113.4 Unchanged guarantees (site requirements)
 
-- The reactive stranded-recovery automation (§112) is unchanged and remains the safety
-  net for any event pull request that falls out of the merge queue, including one whose
-  proactive enqueue failed at submission. <!-- 02-§113.8 -->
+- The reactive stranded-recovery automation (§112) remains the safety net for any
+  event pull request that falls out of the merge queue, including one whose proactive
+  enqueue failed at submission. Recovery re-queues a stranded pull request with the
+  same `enqueuePullRequest` mutation used here. <!-- 02-§113.8 -->
 - The event-data validation gate is unchanged by proactive enqueue: the `event-data
   check` (the hard `check-yaml-security.js` block and `lint-yaml.js`) and the API-layer
   validation remain required and run exactly as before. Enqueuing a pull request places

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -103,7 +103,7 @@ their `source/data/**.yaml` path filter matches files nested one level under
 | `ci.yml` | All branches + PRs | Lint, test, build for code changes; pass-through for data-only |
 | `event-data-deploy.yml` | PRs from `event/**`, `event-edit/**` | No-op branch protection gate |
 | `event-data-deploy-post-merge.yml` | Push to `main` (data YAMLs only) | setup-node + npm ci + build + deploy to QA, Production; plus write-scoped jobs that close duplicate event PRs made redundant by the merge (02-§111.7) and recover event PRs stranded in the merge queue by the base move (02-§112.7) |
-| `merge-queue-recovery.yml` | 15-minute `schedule` cron | Write-scoped safety-net sweep that recovers event PRs stranded in the merge queue (02-§112.8) |
+| `merge-queue-recovery.yml` | `check_suite` completed + 120-minute `schedule` cron | Write-scoped sweep that recovers event PRs stranded in the merge queue by re-queuing them (02-§112.8, 112.16) |
 | `deploy-qa.yml` | Push to `main` (ignores per-camp event YAMLs) | Full build + SCP/SSH swap (QA) |
 | `deploy-prod.yml` | Manual `workflow_dispatch` | Full build + SCP/SSH swap (Production) |
 | `deploy-reusable.yml` | Called by `deploy-qa.yml` / `deploy-prod.yml` | Shared build-and-deploy logic |
@@ -240,9 +240,9 @@ queue. If one merges and advances `main` while a sibling's auto-merge was enable
 against the previous tip, GitHub can leave that sibling **stranded**: auto-merge
 stays enabled, the required checks are green and the mergeable state is clean, but
 the pull request never enters the queue (it has no `mergeQueueEntry`). Because
-GitHub already considers auto-merge enabled, re-enabling it is a no-op; only
-disabling and re-enabling auto-merge registers a fresh queue entry against the
-current `main` (02-§112.2).
+GitHub only enqueues a pull request at the moment its checks pass — a moment that has
+already gone by — re-enabling auto-merge is a no-op. The pull request merges only once
+it is placed back in the queue explicitly (02-§112.2).
 
 The form API also enqueues each event pull request proactively at submission
 (`enqueuePullRequest`, 02-§113, see `forms-and-api.md §30`), which puts most pull
@@ -270,13 +270,16 @@ unit-tested classifier (`classifyStrandedPr`) decides:
   pending or failing (02-§112.5); a real conflict (`mergeStateStatus` `DIRTY`); or
   auto-merge is not enabled.
 
-For a `recover` verdict the script calls `disablePullRequestAutoMerge` then
-`enablePullRequestAutoMerge` (mergeMethod `SQUASH`, matching the form API, 02-§112.3).
-The re-enable is wrapped in `withRetry` (exponential backoff) because once auto-merge
-has been disabled, a transient failure to re-enable it would leave the pull request
-with auto-merge off — worse than stranded; the disable is a single attempt, since a
-failed disable leaves the pull request unchanged for the next sweep to retry
-(02-§112.11). Each pull request is processed inside its own `try`/`catch`, so one
+For a `recover` verdict the script places the pull request back in the queue with the
+`enqueuePullRequest` GraphQL mutation — the same mutation the form API uses at
+submission (02-§113) — and leaves auto-merge enabled as a complement (02-§112.3). It
+then re-reads the pull request and confirms a `mergeQueueEntry` now exists; the
+enqueue-and-verify is wrapped in `withRetry` (exponential backoff), so a transient
+enqueue that does not take effect is retried until a queue entry is confirmed or the
+attempts are exhausted (02-§112.11). Enqueuing is imperative — it does not wait for
+`main` to advance or for another mergeability event — so a single sweep durably
+re-queues a stranded pull request. Each pull request is processed inside its own
+`try`/`catch`, so one
 failed read or mutation does not abort the sweep (02-§112.6), mirroring the
 redundant-PR cleanup.
 The classifier never recovers a pull request that is not stranded, so repeated runs
@@ -292,12 +295,13 @@ invoking the same `recover-stranded-event-prs.js`:
 - `merge-queue-recovery.yml` on a `check_suite` `completed` trigger — a pull request
   becomes stranded the instant its required checks finish and it turns mergeable, so
   the sweep runs at that moment instead of waiting (02-§112.16). This is the primary
-  fast path: GitHub does not reliably deliver scheduled runs at the configured 15-minute
-  interval, so the schedule alone leaves a stranded pull request waiting until the next
-  (sporadic) cron delivery.
-- The same `merge-queue-recovery.yml` on a 15-minute `schedule` cron (plus
-  `workflow_dispatch`), as a slow backstop for strandings that neither an event-data
-  merge nor a check-suite completion happens to cover (02-§112.8). The sweep lists the
+  fast path, and it recovers a stranded pull request within about a minute.
+- The same `merge-queue-recovery.yml` on a 120-minute `schedule` cron (plus
+  `workflow_dispatch`), as a last-resort backstop for the rare stranding that neither
+  an event-data merge nor a check-suite completion happens to cover (02-§112.8). GitHub
+  throttles high-frequency scheduled workflows and does not reliably deliver runs at
+  their configured interval, so the schedule is only a backstop, not the fast path; a
+  long interval matches what it delivers and keeps the load low. The sweep lists the
   open event pull requests first and exits cheaply when none are stranded (02-§112.9).
 
 **Single-flight (02-§112.17).** `merge-queue-recovery.yml` (workflow-level) and the
@@ -305,19 +309,19 @@ post-merge `recover-stranded-event-prs` job both declare the same
 `concurrency: stranded-recovery` group with `cancel-in-progress: false`. Check-suite
 completions arrive in bursts, so the group coalesces them — at most one run executes
 while one waits, and superseded pending runs are dropped. `cancel-in-progress: false`
-is deliberate: a run that has disabled auto-merge but not yet re-enabled it must finish,
-or the pull request would be left with auto-merge off — worse than stranded (02-§112.11).
+is deliberate: a run must finish its enqueue-and-verify pass without a concurrent run
+racing it on the same pull request (02-§112.17).
 
 **Authentication (02-§112.12, 112.14, 112.15).** The default Actions workflow token
-(`secrets.GITHUB_TOKEN`) cannot run the `enablePullRequestAutoMerge` /
-`disablePullRequestAutoMerge` GraphQL mutations even with `pull-requests: write` — it
+(`secrets.GITHUB_TOKEN`) cannot run the `enqueuePullRequest` /
+`enablePullRequestAutoMerge` GraphQL mutations even with `pull-requests: write` — it
 fails with `Resource not accessible by integration`. Both recovery jobs therefore pass
 the repository-level secret `EVENT_AUTOMERGE_TOKEN` (a credential with pull-request and
 contents write access) to the script as `GITHUB_TOKEN`, which `gh` uses for its API
 calls. The secret is repository-level because the recovery jobs run without a GitHub
-Environment and so see only repository- and organisation-level secrets. Re-enabling
-auto-merge under this identity — rather than the Actions bot — also means the eventual
-merge to `main` triggers the push-driven `event-data-deploy-post-merge.yml` deploy
+Environment and so see only repository- and organisation-level secrets. Re-queuing
+under this identity — rather than the Actions bot — also means the eventual merge to
+`main` triggers the push-driven `event-data-deploy-post-merge.yml` deploy
 (02-§112.15).
 
 **Failure handling (02-§112.13).** Each pull request is still processed in its own

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -278,7 +278,19 @@ enqueue-and-verify is wrapped in `withRetry` (exponential backoff), so a transie
 enqueue that does not take effect is retried until a queue entry is confirmed or the
 attempts are exhausted (02-§112.11). Enqueuing is imperative — it does not wait for
 `main` to advance or for another mergeability event — so a single sweep durably
-re-queues a stranded pull request. Each pull request is processed inside its own
+re-queues a stranded pull request.
+
+When the enqueue cannot be confirmed after its retries, the script falls back to
+re-arming auto-merge: `disablePullRequestAutoMerge` then `enablePullRequestAutoMerge`
+(mergeMethod `SQUASH`), the re-enable wrapped in `withRetry`. This covers the
+checks-passed-but-`BLOCKED`/`UNKNOWN` case (02-§112.18), where GitHub's mergeable-state
+recompute lags and the queue declines an immediate enqueue: re-arming auto-merge makes
+it enqueue at the `BLOCKED`→`CLEAN` transition. The two mechanisms are complementary —
+enqueue for the clean-at-rest case the toggle alone misses, the re-arm for the laggy
+case the enqueue alone misses (02-§112.2, 112.3). Only when both fail is the pull
+request's recovery treated as failed.
+
+Each pull request is processed inside its own
 `try`/`catch`, so one
 failed read or mutation does not abort the sweep (02-§112.6), mirroring the
 redundant-PR cleanup.

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -563,10 +563,11 @@ All pull requests to `main` merge through a required merge queue. Enabling
 auto-merge is not the same as being in the queue: GitHub only adds a pull request
 to the queue once its required checks pass, and during a burst of submissions a
 pull request can hang with auto-merge enabled but no queue entry (02-§112). The
-reactive recovery repairs that, but only on its next sweep — in the worst case
-~15 minutes. Calling `enqueuePullRequest` at submission time puts the pull request
-in the queue right away, so a submitted activity merges in roughly the queue's
-normal cycle (~50 s) instead of waiting for a sweep (02-§113.1).
+reactive recovery repairs that by re-queuing the pull request with the same
+`enqueuePullRequest` mutation (02-§112.2), but only once a recovery trigger fires.
+Calling `enqueuePullRequest` at submission time puts the pull request in the queue
+right away, so a submitted activity merges in roughly the queue's normal cycle
+(~50 s) instead of waiting for a recovery trigger (02-§113.1).
 
 ### The enqueue call
 

--- a/docs/04-OPERATIONS.md
+++ b/docs/04-OPERATIONS.md
@@ -169,11 +169,12 @@ event submissions arrive in a burst and one merges, `main` advances; a sibling P
 whose auto-merge was enabled against the previous tip can be left stranded —
 auto-merge enabled, checks green, `mergeable_state: clean`, but with **no
 merge-queue entry**, so it never merges. Re-enabling auto-merge is a no-op (GitHub
-sees it as already on); only disabling and re-enabling it registers a fresh queue
-entry. This is recovered automatically: a sweep
-(`source/scripts/recover-stranded-event-prs.js`) runs after every event-data merge
-and on a 15-minute schedule (`merge-queue-recovery.yml`), finds stranded `event/*`,
-`event-edit/*`, and `event-delete/*` PRs, and toggles their auto-merge off then on
+only enqueues at the moment checks pass, which has already gone by); the PR merges
+only once it is placed back in the queue explicitly. This is recovered automatically:
+a sweep (`source/scripts/recover-stranded-event-prs.js`) runs after every event-data
+merge, on `check_suite` completion, and on a 120-minute backstop schedule
+(`merge-queue-recovery.yml`), finds stranded `event/*`, `event-edit/*`, and
+`event-delete/*` PRs, and re-queues them with the `enqueuePullRequest` mutation
 (02-§112, issue #495).
 
 ### Environment Variables

--- a/docs/08-ENVIRONMENTS.md
+++ b/docs/08-ENVIRONMENTS.md
@@ -89,7 +89,7 @@ the secrets.
 | Secret     | Used by    | Purpose                                           |
 | ---------- | ---------- | ------------------------------------------------- |
 | `SITE_URL` | `ci.yml`   | Any valid URL — just needs to pass the build step |
-| `EVENT_AUTOMERGE_TOKEN` | `merge-queue-recovery.yml`, `event-data-deploy-post-merge.yml` (`recover-stranded-event-prs` job) | Token used by the stranded-PR recovery sweep to toggle auto-merge (§112). The default `GITHUB_TOKEN` cannot run the auto-merge GraphQL mutations, so a separate credential is required. Use a fine-grained PAT scoped to this repository with **Pull requests: Read and write** and **Contents: Read and write**, or a GitHub App installation token with the same access. Must be **repository-level** (the recovery jobs run without a GitHub Environment and cannot read environment-scoped secrets). |
+| `EVENT_AUTOMERGE_TOKEN` | `merge-queue-recovery.yml`, `event-data-deploy-post-merge.yml` (`recover-stranded-event-prs` job) | Token used by the stranded-PR recovery sweep to re-queue stranded PRs via the `enqueuePullRequest` GraphQL mutation (§112). The default `GITHUB_TOKEN` cannot run the enqueue/auto-merge GraphQL mutations, so a separate credential is required. Use a fine-grained PAT scoped to this repository with **Pull requests: Read and write** and **Contents: Read and write**, or a GitHub App installation token with the same access. Must be **repository-level** (the recovery jobs run without a GitHub Environment and cannot read environment-scoped secrets). |
 
 ### GitHub Environment: `qa` (PHP on Loopia)
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1740,8 +1740,8 @@ Doc ref: `02-requirements/event-data.md §112`;
 | ID | Status | Notes |
 | --- | --- | --- |
 | `02-§112.1` | covered | STRAND-01/-02/-03: `classifyStrandedPr` returns `recover` only for an `event/`/`event-edit/`/`event-delete/` branch with auto-merge enabled, `mergeStateStatus === CLEAN`, and no `mergeQueueEntry` |
-| `02-§112.2` | implemented | `enqueueAndVerify()` runs the `enqueuePullRequest` mutation (`ENQUEUE_MUTATION`, mirroring `buildEnqueueMutation`) and confirms a `mergeQueueEntry` results; STRAND-29 checks the mutation shape; the live "enqueue durably re-queues a stranded PR against an idle `main`" behaviour is manual checkpoint STRAND-M01 |
-| `02-§112.3` | implemented | `enqueueAndVerify()` leaves auto-merge enabled (never disables it), so submission's squash auto-merge stays as a complement; live behaviour is STRAND-M01 |
+| `02-§112.2` | covered | `recoverPr()` runs `enqueueAndVerify()` (primary: `enqueuePullRequest` via `ENQUEUE_MUTATION` + confirm `mergeQueueEntry`) and falls back to `reArmAutoMerge()` when no queue entry is confirmed; STRAND-30/31 cover the two paths, STRAND-29 the mutation shape; live behaviour is manual checkpoint STRAND-M01 |
+| `02-§112.3` | covered | `recoverPr()` keeps auto-merge enabled; only in the fallback does `reArmAutoMerge()` disable→re-enable (SQUASH) to re-arm it (STRAND-31); live behaviour is STRAND-M01 |
 | `02-§112.4` | covered | STRAND-04, STRAND-10: `classifyStrandedPr` returns `skip` when a `mergeQueueEntry` is present (already progressing) |
 | `02-§112.5` | covered | STRAND-05, STRAND-06: `classifyStrandedPr` returns `skip` when `mergeStateStatus` is not `CLEAN` (checks pending/failing or not mergeable) |
 | `02-§112.6` | implemented | Per-PR `try`/`catch` in `main()` isolates a failed read or mutation from the rest of the sweep; exercised live (STRAND-M01) |
@@ -1749,7 +1749,7 @@ Doc ref: `02-requirements/event-data.md §112`;
 | `02-§112.8` | covered | RECTRIG-01: `merge-queue-recovery.yml` runs the sweep on a 120-minute `schedule` cron (`0 */2 * * *`, plus `workflow_dispatch`); CI/manual checkpoint STRAND-M01 |
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
-| `02-§112.11` | covered | STRAND-26/-27/-28: `enqueueAndVerify()` wraps enqueue-and-verify in `withRetry` (exponential backoff), retrying until a `mergeQueueEntry` is confirmed or attempts exhaust (then throws → fail-loud); STRAND-11/-12/-13 cover `withRetry` itself |
+| `02-§112.11` | covered | STRAND-26/-27/-28: `enqueueAndVerify()` wraps enqueue-and-verify in `withRetry` (exponential backoff), retrying until a `mergeQueueEntry` is confirmed or attempts exhaust; STRAND-32: `recoverPr()` treats both enqueue and fallback re-arm failing as `failed` (fail-loud); `reArmAutoMerge()` retries the re-enable with `withRetry`; STRAND-11/-12/-13 cover `withRetry` itself |
 | `02-§112.12` | implemented | Both recovery jobs pass `secrets.EVENT_AUTOMERGE_TOKEN` as `GITHUB_TOKEN` (not the default token, which fails the enqueue/auto-merge mutations); live behaviour is manual checkpoint STRAND-M01 |
 | `02-§112.13` | covered | STRAND-16/-17 (`processPr` returns `'failed'` on fetch/recover error), STRAND-18/-19 (`runSweep` counts failures and keeps going); `main()` throws when the count is non-zero |
 | `02-§112.14` | implemented | `EVENT_AUTOMERGE_TOKEN` documented as a repository-level secret in 08-ENVIRONMENTS; recovery jobs declare no `environment:` so only repo-level secrets resolve |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1740,20 +1740,20 @@ Doc ref: `02-requirements/event-data.md §112`;
 | ID | Status | Notes |
 | --- | --- | --- |
 | `02-§112.1` | covered | STRAND-01/-02/-03: `classifyStrandedPr` returns `recover` only for an `event/`/`event-edit/`/`event-delete/` branch with auto-merge enabled, `mergeStateStatus === CLEAN`, and no `mergeQueueEntry` |
-| `02-§112.2` | implemented | `recoverPr()` calls `disablePullRequestAutoMerge` then `enablePullRequestAutoMerge`; the live "disable→enable creates a fresh queue entry, re-enable alone is a no-op" premise is manual checkpoint STRAND-M01 |
-| `02-§112.3` | implemented | `recoverPr()` re-enables with mergeMethod `SQUASH`, matching `enableAutoMerge` in the form API; live behaviour is STRAND-M01 |
+| `02-§112.2` | implemented | `enqueueAndVerify()` runs the `enqueuePullRequest` mutation (`ENQUEUE_MUTATION`, mirroring `buildEnqueueMutation`) and confirms a `mergeQueueEntry` results; STRAND-29 checks the mutation shape; the live "enqueue durably re-queues a stranded PR against an idle `main`" behaviour is manual checkpoint STRAND-M01 |
+| `02-§112.3` | implemented | `enqueueAndVerify()` leaves auto-merge enabled (never disables it), so submission's squash auto-merge stays as a complement; live behaviour is STRAND-M01 |
 | `02-§112.4` | covered | STRAND-04, STRAND-10: `classifyStrandedPr` returns `skip` when a `mergeQueueEntry` is present (already progressing) |
 | `02-§112.5` | covered | STRAND-05, STRAND-06: `classifyStrandedPr` returns `skip` when `mergeStateStatus` is not `CLEAN` (checks pending/failing or not mergeable) |
 | `02-§112.6` | implemented | Per-PR `try`/`catch` in `main()` isolates a failed read or mutation from the rest of the sweep; exercised live (STRAND-M01) |
 | `02-§112.7` | implemented | `recover-stranded-event-prs` job in `event-data-deploy-post-merge.yml` runs on push to `main` (`source/data/**`); CI/manual checkpoint STRAND-M01 |
-| `02-§112.8` | implemented | `merge-queue-recovery.yml` runs the sweep on a 15-minute `schedule` cron (plus `workflow_dispatch`); CI/manual checkpoint STRAND-M01 |
+| `02-§112.8` | covered | RECTRIG-01: `merge-queue-recovery.yml` runs the sweep on a 120-minute `schedule` cron (`0 */2 * * *`, plus `workflow_dispatch`); CI/manual checkpoint STRAND-M01 |
 | `02-§112.9` | implemented | `main()` filters to open event PRs and returns early with "nothing to recover" when none exist; live behaviour is STRAND-M01 |
 | `02-§112.10` | covered | STRAND-10: `classifyStrandedPr` is pure and returns `skip` for any non-stranded PR, so repeated sweeps are no-ops |
-| `02-§112.11` | covered | STRAND-11/-12/-13: `recoverPr()` wraps the re-enable in `withRetry` (exponential backoff); disable is a single attempt; live toggle is STRAND-M01 |
-| `02-§112.12` | implemented | Both recovery jobs pass `secrets.EVENT_AUTOMERGE_TOKEN` as `GITHUB_TOKEN` (not the default token, which fails auto-merge mutations); live behaviour is manual checkpoint STRAND-M01 |
+| `02-§112.11` | covered | STRAND-26/-27/-28: `enqueueAndVerify()` wraps enqueue-and-verify in `withRetry` (exponential backoff), retrying until a `mergeQueueEntry` is confirmed or attempts exhaust (then throws → fail-loud); STRAND-11/-12/-13 cover `withRetry` itself |
+| `02-§112.12` | implemented | Both recovery jobs pass `secrets.EVENT_AUTOMERGE_TOKEN` as `GITHUB_TOKEN` (not the default token, which fails the enqueue/auto-merge mutations); live behaviour is manual checkpoint STRAND-M01 |
 | `02-§112.13` | covered | STRAND-16/-17 (`processPr` returns `'failed'` on fetch/recover error), STRAND-18/-19 (`runSweep` counts failures and keeps going); `main()` throws when the count is non-zero |
 | `02-§112.14` | implemented | `EVENT_AUTOMERGE_TOKEN` documented as a repository-level secret in 08-ENVIRONMENTS; recovery jobs declare no `environment:` so only repo-level secrets resolve |
-| `02-§112.15` | implemented | Re-enable runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
+| `02-§112.15` | implemented | Enqueue runs under the PAT identity so the merge triggers `event-data-deploy-post-merge.yml`; manual checkpoint STRAND-M01 |
 | `02-§112.16` | covered | RECTRIG-02: `merge-queue-recovery.yml` declares a `check_suite: [completed]` trigger (schedule + workflow_dispatch retained, RECTRIG-01) |
 | `02-§112.17` | covered | RECTRIG-03/-04: scheduled workflow and post-merge job share `concurrency: stranded-recovery` with `cancel-in-progress: false` |
 | `02-§112.18` | covered | STRAND-20/-21 (recover on checksPassed + BLOCKED/UNKNOWN), STRAND-22/-23 (skip pending and DIRTY), STRAND-25 (CLEAN still recovers); `fetchPrState` reads `statusCheckRollup.state` |
@@ -1773,7 +1773,7 @@ Doc ref: `02-requirements/event-data.md §113`;
 | `02-§113.5` | covered | ENQ-09: a "checks still running" failure is swallowed and reported as not enqueued; the queue actually declining an unmergeable PR is live checkpoint ENQ-M01 |
 | `02-§113.6` | covered | ENQ-08: exactly one warning is logged on failure and nothing else; no GitHub issue is created (the best-effort wrapper only calls `log`) |
 | `02-§113.7` | covered | ENQ-07: the enqueue step is contained so the submission outcome is unchanged whether enqueue succeeds or fails |
-| `02-§113.8` | covered | Recovery (`recover-stranded-event-prs.js`, §112) is untouched; STRAND-01..13 still pass. A proactively enqueued PR has a `mergeQueueEntry`, so `classifyStrandedPr` returns `skip` (STRAND-04) and recovery still catches any PR that later falls out of the queue |
+| `02-§113.8` | covered | Recovery (`recover-stranded-event-prs.js`, §112) remains the safety net and re-queues a stranded PR with the same `enqueuePullRequest` mutation used at submission. A proactively enqueued PR has a `mergeQueueEntry`, so `classifyStrandedPr` returns `skip` (STRAND-04) and recovery catches any PR that later falls out of the queue |
 | `02-§113.9` | covered | The event-data validation gate (`check-yaml-security.js`, `lint-yaml.js`) and API-layer validation are unchanged; YSEC/validation tests still pass. Enqueue only changes when a PR enters the queue, not whether its required checks run |
 
 ### §114 — Quick-Add Activity Button in Sticky Navigation

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -177,14 +177,13 @@ Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
   confirmed against production (#481).
 
 Note: §112 (Stranded Auto-Merge Recovery) adds 18 requirements
-  (02-§112.1–112.18): 9 covered (STRAND-01..25 and RECTRIG-01..05 in
+  (02-§112.1–112.18): 10 covered (STRAND-01..29 and RECTRIG-01..05 in
   tests/stranded-recovery.test.js and tests/recovery-trigger-workflow.test.js)
-  and 9 implemented (the GraphQL
-  disable→enable toggle, the per-PR isolation and early-exit in main(), the two
-  workflow entry points, the EVENT_AUTOMERGE_TOKEN auth, and the deploy-trigger
-  identity, STRAND-M01 manual). A third trigger runs the sweep on check_suite
-  completion — the moment a PR turns mergeable — so recovery no longer depends on
-  GitHub's unreliable schedule delivery; all triggers share one single-flight
+  and 8 implemented (the enqueue-and-verify recovery, the per-PR isolation and
+  early-exit in main(), the two workflow entry points, the EVENT_AUTOMERGE_TOKEN
+  auth, and the deploy-trigger identity, STRAND-M01 manual). A trigger runs the sweep
+  on check_suite completion — the moment a PR turns mergeable — so recovery does not
+  depend on GitHub's unreliable schedule delivery; all triggers share one single-flight
   concurrency group (02-§112.16–112.17). Recovery keys off the status-check rollup
   rather than the mergeable-state status, which GitHub recomputes minutes later, so a
   checks-passed PR is recovered at check-suite time even while its mergeable state
@@ -192,11 +191,12 @@ Note: §112 (Stranded Auto-Merge Recovery) adds 18 requirements
   required merge queue; when main advances between auto-merge enablement and
   queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
   CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js
-  detects that signature and toggles auto-merge off then on to register a fresh
-  queue entry, running after each event merge and on a 15-minute safety-net
-  schedule (#495). The toggle uses EVENT_AUTOMERGE_TOKEN because the default
-  GITHUB_TOKEN cannot run the auto-merge mutations, and the sweep exits non-zero
-  when any stranded PR could not be recovered (#496-followup).
+  detects that signature and re-queues the PR with the enqueuePullRequest mutation,
+  verifying a mergeQueueEntry results, running after each event merge, on check_suite
+  completion, and on a 120-minute backstop schedule (#495). Recovery uses
+  EVENT_AUTOMERGE_TOKEN because the default GITHUB_TOKEN cannot run the
+  enqueue/auto-merge mutations, and the sweep exits non-zero when any stranded PR
+  could not be recovered (#496-followup).
 
 Note: §111 (Duplicate Submission Hardening) adds 9 requirements
   (02-§111.1–111.9): 7 covered (DEDUP-01..09, DEDUPCLEAN-01..09,

--- a/docs/99-traceability/index.md
+++ b/docs/99-traceability/index.md
@@ -177,11 +177,11 @@ Note: §113 (Proactive Merge-Queue Enqueue) adds 9 requirements
   confirmed against production (#481).
 
 Note: §112 (Stranded Auto-Merge Recovery) adds 18 requirements
-  (02-§112.1–112.18): 10 covered (STRAND-01..29 and RECTRIG-01..05 in
+  (02-§112.1–112.18): 12 covered (STRAND-01..32 and RECTRIG-01..05 in
   tests/stranded-recovery.test.js and tests/recovery-trigger-workflow.test.js)
-  and 8 implemented (the enqueue-and-verify recovery, the per-PR isolation and
-  early-exit in main(), the two workflow entry points, the EVENT_AUTOMERGE_TOKEN
-  auth, and the deploy-trigger identity, STRAND-M01 manual). A trigger runs the sweep
+  and 6 implemented (the per-PR isolation and early-exit in main(), the two workflow
+  entry points, the EVENT_AUTOMERGE_TOKEN auth, and the deploy-trigger identity,
+  STRAND-M01 manual). A trigger runs the sweep
   on check_suite completion — the moment a PR turns mergeable — so recovery does not
   depend on GitHub's unreliable schedule delivery; all triggers share one single-flight
   concurrency group (02-§112.16–112.17). Recovery keys off the status-check rollup
@@ -191,9 +191,11 @@ Note: §112 (Stranded Auto-Merge Recovery) adds 18 requirements
   required merge queue; when main advances between auto-merge enablement and
   queue entry, a sibling event PR can strand (auto-merge on, mergeStateStatus
   CLEAN, no mergeQueueEntry) and never merge. recover-stranded-event-prs.js
-  detects that signature and re-queues the PR with the enqueuePullRequest mutation,
-  verifying a mergeQueueEntry results, running after each event merge, on check_suite
-  completion, and on a 120-minute backstop schedule (#495). Recovery uses
+  detects that signature and re-queues the PR primarily with the enqueuePullRequest
+  mutation, verifying a mergeQueueEntry results, and falls back to re-arming auto-merge
+  (disable→enable) when the enqueue cannot be confirmed because the mergeable state is
+  still lagging (02-§112.18); it runs after each event merge, on check_suite completion,
+  and on a 120-minute backstop schedule (#495). Recovery uses
   EVENT_AUTOMERGE_TOKEN because the default GITHUB_TOKEN cannot run the
   enqueue/auto-merge mutations, and the sweep exits non-zero when any stranded PR
   could not be recovered (#496-followup).

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -2,7 +2,8 @@
 
 // Recovers event-submission pull requests that have stranded in the merge-queue
 // handoff (02-§112). Runs in event-data-deploy-post-merge.yml after each event
-// merge, and on a 15-minute schedule in merge-queue-recovery.yml.
+// merge, on check_suite completion, and on a 120-minute backstop schedule in
+// merge-queue-recovery.yml.
 //
 // All pull requests to main merge through a merge queue. The form API enables
 // auto-merge (squash) on each event PR; GitHub places it in the queue once its
@@ -10,9 +11,12 @@
 // main advances — and a sibling whose auto-merge was enabled against the previous
 // tip can be left stranded: auto-merge enabled, checks green (mergeStateStatus
 // CLEAN), mergeable, but with no mergeQueueEntry, so it never merges. Re-enabling
-// auto-merge is a no-op; only disabling and re-enabling it registers a fresh queue
-// entry against the current main. This script detects that exact signature and
-// toggles auto-merge off then on to recover the PR.
+// auto-merge is a no-op — GitHub only enqueues a PR at the moment its checks pass,
+// and that moment has already gone by. This script detects that exact signature and
+// places the PR back in the queue with the imperative enqueuePullRequest mutation
+// (the same one the form API uses at submission, 02-§113), then confirms a
+// mergeQueueEntry resulted. Enqueuing does not wait for main to advance, so a single
+// sweep durably re-queues a stranded PR.
 
 const { execFileSync } = require('node:child_process');
 
@@ -39,8 +43,8 @@ function isEventBranch(branch) {
  * minutes to recompute mergeStateStatus to CLEAN after checks finish and fires no
  * further check-suite event in that window (02-§112.18). So a checks-passed PR that
  * is not queued is treated as stranded even while mergeStateStatus still reads
- * BLOCKED/UNKNOWN. A real conflict (DIRTY) is left alone — re-enabling auto-merge
- * cannot resolve it.
+ * BLOCKED/UNKNOWN. A real conflict (DIRTY) is left alone — re-queuing cannot
+ * resolve it.
  *
  * Returns:
  *   'ignore'  – not an event-submission PR
@@ -119,22 +123,34 @@ function fetchPrState(owner, repo, number) {
   };
 }
 
-// Disable then re-enable auto-merge (squash) to register a fresh queue entry.
-// Disable runs once: if it fails the PR is left untouched (auto-merge still on)
-// and the next sweep retries the whole recovery. Enable is retried, because once
-// disable has succeeded a transient enable failure would otherwise leave the PR
-// with auto-merge off — worse than stranded (02-§112.11).
-function recoverPr(nodeId) {
-  gh([
-    'api', 'graphql',
-    '-f', 'query=mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}',
-    '-f', `id=${nodeId}`,
-  ]);
-  withRetry(() => gh([
-    'api', 'graphql',
-    '-f', 'query=mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}',
-    '-f', `id=${nodeId}`,
-  ]));
+// The imperative enqueue mutation: it places a pull request directly in the merge
+// queue, unlike auto-merge, which only enqueues at the checks-pass edge. Mirrors
+// buildEnqueueMutation() in source/api/github.js so submission and recovery use the
+// same call (02-§112.2, §113.1); STRAND-29 pins the shape.
+const ENQUEUE_MUTATION =
+  'mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){mergeQueueEntry{id}}}';
+
+function enqueue(nodeId) {
+  gh(['api', 'graphql', '-f', `query=${ENQUEUE_MUTATION}`, '-f', `id=${nodeId}`]);
+}
+
+// Recover a stranded PR by placing it back in the merge queue and confirming a
+// queue entry resulted. Auto-merge is left enabled throughout (never disabled), so a
+// failed enqueue never leaves the PR worse off than stranded (02-§112.3, §112.11).
+//
+// The enqueue-and-verify is wrapped in withRetry: after enqueuing, it re-reads the
+// PR and, if no mergeQueueEntry appeared yet (GitHub can lag), throws so the step is
+// retried with backoff. Each attempt checks the queue first, so a prior attempt that
+// took effect after a lag is recognised instead of enqueuing an already-queued PR.
+// enqueueFn/isQueued/retryOpts are injectable so the outcome logic is unit-testable.
+function enqueueAndVerify(nodeId, { enqueueFn = enqueue, isQueued, retryOpts } = {}) {
+  withRetry(() => {
+    if (isQueued()) return; // already in the queue (e.g. a prior attempt took effect)
+    enqueueFn(nodeId);
+    if (!isQueued()) {
+      throw new Error(`enqueue did not register a merge-queue entry for ${nodeId}`);
+    }
+  }, retryOpts);
 }
 
 /**
@@ -144,7 +160,7 @@ function recoverPr(nodeId) {
  *
  *   pr.number, pr.headRefName – the open pull request to consider
  *   fetchState(number)        – returns { nodeId, autoMergeEnabled, mergeStateStatus, inMergeQueue }
- *   recover(nodeId)           – toggles auto-merge off then on
+ *   recover(nodeId, number)   – places the PR back in the queue and verifies it
  *
  * Per-PR errors are caught here so one bad fetch or mutation does not abort the
  * sweep (02-§112.6). Returns one of: 'recovered', 'skipped', 'ignored', 'failed'.
@@ -155,8 +171,8 @@ function processPr(pr, { fetchState, recover, log = console.log }) {
     const verdict = classifyStrandedPr({ branch: pr.headRefName, ...state });
 
     if (verdict === 'recover') {
-      log(`Recovering stranded PR #${pr.number} (${pr.headRefName}) — auto-merge on, CLEAN, no queue entry; toggling auto-merge`);
-      recover(state.nodeId);
+      log(`Recovering stranded PR #${pr.number} (${pr.headRefName}) — auto-merge on, CLEAN, no queue entry; re-queuing`);
+      recover(state.nodeId, pr.number);
       return 'recovered';
     }
     log(`Skipping PR #${pr.number} (${pr.headRefName}) — ${verdict} (mergeStateStatus=${state.mergeStateStatus}, inQueue=${state.inMergeQueue}, autoMerge=${state.autoMergeEnabled})`);
@@ -202,7 +218,10 @@ function main() {
 
   const failures = runSweep(eventPrs, {
     fetchState: (number) => fetchPrState(owner, repo, number),
-    recover: recoverPr,
+    // Enqueue the PR, then re-read it to confirm a merge-queue entry resulted.
+    recover: (nodeId, number) => enqueueAndVerify(nodeId, {
+      isQueued: () => fetchPrState(owner, repo, number).inMergeQueue,
+    }),
   });
 
   // Fail the job loudly when any stranded PR could not be recovered, rather than
@@ -221,4 +240,6 @@ if (require.main === module) {
   }
 }
 
-module.exports = { classifyStrandedPr, withRetry, processPr, runSweep };
+module.exports = {
+  classifyStrandedPr, withRetry, processPr, runSweep, enqueueAndVerify, ENQUEUE_MUTATION,
+};

--- a/source/scripts/recover-stranded-event-prs.js
+++ b/source/scripts/recover-stranded-event-prs.js
@@ -17,6 +17,13 @@
 // (the same one the form API uses at submission, 02-§113), then confirms a
 // mergeQueueEntry resulted. Enqueuing does not wait for main to advance, so a single
 // sweep durably re-queues a stranded PR.
+//
+// Defense-in-depth (02-§112.2, §112.18): if the enqueue cannot be confirmed — the
+// checks have passed but GitHub's mergeable-state recompute lags (BLOCKED/UNKNOWN), so
+// the queue declines an immediate enqueue — recovery falls back to re-arming auto-merge
+// (disable then re-enable), which makes the PR enqueue at the BLOCKED→CLEAN transition.
+// The two mechanisms are complementary: enqueue covers the clean-at-rest case the
+// toggle alone misses; the re-arm covers the laggy case the enqueue alone misses.
 
 const { execFileSync } = require('node:child_process');
 
@@ -153,6 +160,41 @@ function enqueueAndVerify(nodeId, { enqueueFn = enqueue, isQueued, retryOpts } =
   }, retryOpts);
 }
 
+// Fallback recovery for the checks-passed-but-laggy case (02-§112.18): when the
+// mergeable state still reads BLOCKED/UNKNOWN the queue declines an enqueue, so
+// disabling then re-enabling auto-merge (squash) re-arms it to enqueue at the
+// BLOCKED→CLEAN transition. The re-enable is retried, because once auto-merge is
+// disabled a transient failure to re-enable it would leave the PR with auto-merge off
+// — worse than stranded; the disable is a single attempt (02-§112.11).
+function reArmAutoMerge(nodeId, retryOpts) {
+  gh([
+    'api', 'graphql',
+    '-f', 'query=mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}',
+    '-f', `id=${nodeId}`,
+  ]);
+  withRetry(() => gh([
+    'api', 'graphql',
+    '-f', 'query=mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}',
+    '-f', `id=${nodeId}`,
+  ]), retryOpts);
+}
+
+// Recover a stranded PR, defense-in-depth (02-§112.2): enqueue imperatively as the
+// primary (fixes the clean-at-rest tail), and if that cannot confirm a merge-queue
+// entry, fall back to re-arming auto-merge (fixes the laggy BLOCKED case, 02-§112.18).
+// A throw from both surfaces upward and is reported as a failed recovery (02-§112.13).
+// enqueueFn/isQueued/reArmFn/log injectable so the outcome logic is unit-testable.
+function recoverPr(nodeId, { enqueueFn = enqueue, isQueued, reArmFn = reArmAutoMerge, retryOpts, log = console.log } = {}) {
+  try {
+    enqueueAndVerify(nodeId, { enqueueFn, isQueued, retryOpts });
+  } catch (err) {
+    // Enqueue could not confirm a queue entry — likely the mergeable state still
+    // catching up. Re-arm auto-merge so it enqueues once the state converges.
+    log(`Enqueue did not confirm a queue entry for ${nodeId} (${err.message}); re-arming auto-merge`);
+    reArmFn(nodeId, retryOpts);
+  }
+}
+
 /**
  * Process one event pull request: read its state, classify it, and recover it if
  * stranded. Side effects (network reads, auto-merge toggles) are injected via
@@ -218,8 +260,9 @@ function main() {
 
   const failures = runSweep(eventPrs, {
     fetchState: (number) => fetchPrState(owner, repo, number),
-    // Enqueue the PR, then re-read it to confirm a merge-queue entry resulted.
-    recover: (nodeId, number) => enqueueAndVerify(nodeId, {
+    // Enqueue the PR and confirm a merge-queue entry resulted; fall back to re-arming
+    // auto-merge when the enqueue cannot be confirmed (02-§112.2, §112.18).
+    recover: (nodeId, number) => recoverPr(nodeId, {
       isQueued: () => fetchPrState(owner, repo, number).inMergeQueue,
     }),
   });
@@ -241,5 +284,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-  classifyStrandedPr, withRetry, processPr, runSweep, enqueueAndVerify, ENQUEUE_MUTATION,
+  classifyStrandedPr, withRetry, processPr, runSweep,
+  enqueueAndVerify, reArmAutoMerge, recoverPr, ENQUEUE_MUTATION,
 };

--- a/tests/recovery-trigger-workflow.test.js
+++ b/tests/recovery-trigger-workflow.test.js
@@ -24,8 +24,9 @@ const CONCURRENCY_GROUP = 'stranded-recovery';
 describe('merge-queue-recovery triggers (02-§112.16)', () => {
   const on = triggersOf(recovery);
 
-  it('RECTRIG-01: keeps schedule and workflow_dispatch triggers', () => {
+  it('RECTRIG-01: keeps schedule (120-minute backstop) and workflow_dispatch triggers', () => {
     assert.ok(on.schedule, 'schedule trigger must remain as the backstop');
+    assert.equal(on.schedule[0].cron, '0 */2 * * *', 'schedule is the 120-minute backstop');
     assert.ok('workflow_dispatch' in on, 'workflow_dispatch must remain');
   });
 

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -15,6 +15,7 @@ const {
   processPr,
   runSweep,
   enqueueAndVerify,
+  recoverPr,
   ENQUEUE_MUTATION,
 } = require('../source/scripts/recover-stranded-event-prs');
 
@@ -206,6 +207,46 @@ describe('enqueueAndVerify — imperative re-queue with confirmation (02-§112.2
     assert.match(ENQUEUE_MUTATION, /mergeQueueEntry/);
     assert.doesNotMatch(ENQUEUE_MUTATION, /enablePullRequestAutoMerge/);
     assert.doesNotMatch(ENQUEUE_MUTATION, /disablePullRequestAutoMerge/);
+  });
+});
+
+describe('recoverPr — defense-in-depth: enqueue primary, re-arm fallback (02-§112.2, 112.18)', () => {
+  it('STRAND-30: enqueue confirms a queue entry — recovers without the fallback', () => {
+    let reArmCalled = false;
+    let queued = false;
+    recoverPr('PR_1', {
+      enqueueFn: () => { queued = true; },
+      isQueued: () => queued,
+      reArmFn: () => { reArmCalled = true; },
+      retryOpts: { baseMs: 0 },
+      log: quiet,
+    });
+    assert.equal(reArmCalled, false);
+  });
+
+  it('STRAND-31: enqueue cannot confirm (laggy state) — falls back to re-arming auto-merge', () => {
+    let reArmed = null;
+    recoverPr('PR_1', {
+      enqueueFn: () => {},    // no-op enqueue: a queue entry never appears
+      isQueued: () => false,
+      reArmFn: (id) => { reArmed = id; },
+      retryOpts: { attempts: 2, baseMs: 0 },
+      log: quiet,
+    });
+    assert.equal(reArmed, 'PR_1');
+  });
+
+  it('STRAND-32: both enqueue and the fallback re-arm fail — recovery throws (fail-loud)', () => {
+    assert.throws(
+      () => recoverPr('PR_1', {
+        enqueueFn: () => {},
+        isQueued: () => false,
+        reArmFn: () => { throw new Error('Resource not accessible by integration'); },
+        retryOpts: { attempts: 2, baseMs: 0 },
+        log: quiet,
+      }),
+      /Resource not accessible/,
+    );
   });
 });
 

--- a/tests/stranded-recovery.test.js
+++ b/tests/stranded-recovery.test.js
@@ -1,9 +1,10 @@
 'use strict';
 
-// Unit tests for the stranded-auto-merge recovery decision (02-§112.1–112.10).
-// classifyStrandedPr is pure, so its full decision table is tested here; the
-// GitHub GraphQL wiring in the script's main() (read fields, disable→enable
-// auto-merge) is a manual/integration checkpoint (STRAND-M01).
+// Unit tests for the stranded-auto-merge recovery decision (02-§112.1–112.10) and
+// the enqueue-and-verify recovery action (02-§112.2, 112.11). classifyStrandedPr and
+// enqueueAndVerify are pure with respect to injected deps, so they are tested here;
+// the live GitHub GraphQL wiring in main() (read fields, enqueue, re-read) is a
+// manual/integration checkpoint (STRAND-M01).
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
@@ -13,6 +14,8 @@ const {
   withRetry,
   processPr,
   runSweep,
+  enqueueAndVerify,
+  ENQUEUE_MUTATION,
 } = require('../source/scripts/recover-stranded-event-prs');
 
 // A silent logger so the test output stays clean.
@@ -79,7 +82,7 @@ describe('classifyStrandedPr — stranded auto-merge recovery (02-§112.1–112.
 
   it('STRAND-10: idempotent — a non-stranded event PR always classifies as skip (02-§112.10)', () => {
     // Re-running recovery on a PR that is already queued or already merging must
-    // never re-toggle it.
+    // never re-recover it.
     assert.equal(
       classifyStrandedPr({ branch: 'event/2026-06-22-x-1', autoMergeEnabled: true, mergeStateStatus: 'CLEAN', inMergeQueue: true }),
       'skip',
@@ -164,6 +167,48 @@ describe('withRetry — enable-step resilience (02-§112.11)', () => {
   });
 });
 
+describe('enqueueAndVerify — imperative re-queue with confirmation (02-§112.2, 112.11)', () => {
+  it('STRAND-26: enqueues once and returns when the merge-queue entry appears', () => {
+    const enqueued = [];
+    let queued = false;
+    enqueueAndVerify('PR_1', {
+      enqueueFn: (id) => { enqueued.push(id); queued = true; },
+      isQueued: () => queued,
+      retryOpts: { baseMs: 0 },
+    });
+    assert.deepEqual(enqueued, ['PR_1']);
+  });
+
+  it('STRAND-27: retries when the queue entry lags, then succeeds', () => {
+    let calls = 0;
+    let queued = false;
+    // GitHub only reflects the merge-queue entry on the second enqueue attempt.
+    const enqueueFn = () => { calls += 1; if (calls >= 2) queued = true; };
+    enqueueAndVerify('PR_1', { enqueueFn, isQueued: () => queued, retryOpts: { attempts: 3, baseMs: 0 } });
+    assert.equal(calls, 2);
+  });
+
+  it('STRAND-28: throws after exhausting attempts when no queue entry ever appears (fail-loud)', () => {
+    let calls = 0;
+    assert.throws(
+      () => enqueueAndVerify('PR_1', {
+        enqueueFn: () => { calls += 1; },
+        isQueued: () => false,
+        retryOpts: { attempts: 3, baseMs: 0 },
+      }),
+      /did not register a merge-queue entry/,
+    );
+    assert.equal(calls, 3);
+  });
+
+  it('STRAND-29: ENQUEUE_MUTATION enqueues and selects mergeQueueEntry, not the auto-merge toggle', () => {
+    assert.match(ENQUEUE_MUTATION, /enqueuePullRequest/);
+    assert.match(ENQUEUE_MUTATION, /mergeQueueEntry/);
+    assert.doesNotMatch(ENQUEUE_MUTATION, /enablePullRequestAutoMerge/);
+    assert.doesNotMatch(ENQUEUE_MUTATION, /disablePullRequestAutoMerge/);
+  });
+});
+
 describe('processPr — per-PR outcome (02-§112.2, 112.6, 112.13)', () => {
   const strandedState = { nodeId: 'PR_1', ...STRANDED };
 
@@ -177,7 +222,7 @@ describe('processPr — per-PR outcome (02-§112.2, 112.6, 112.13)', () => {
     assert.equal(recovered, 'PR_1');
   });
 
-  it('STRAND-15: non-stranded event PR is skipped without toggling auto-merge', () => {
+  it('STRAND-15: non-stranded event PR is skipped without re-queuing', () => {
     let recoverCalled = false;
     const outcome = processPr(
       { number: 2, headRefName: 'event/2026-06-22-x-1' },


### PR DESCRIPTION
## Bakgrund

Folk tyckte väntetiden innan en tillagd aktivitet syns i schemat var för lång. En mätning av **alla 282 add/edit-submissions under junilägret 2026** (submit → deploy klar) visade att det typiska fallet är ~2,5 min, men att en **svans** gjorde ont: efter de tidiga merge-kö-fixarna (22 juni) återstod tre fall som tog 22–66 min (#647, #648, #724).

**Rotorsaken bevisades med Actions-loggar** — varken triggern eller cronen:

- `check_suite`-triggern fyrade snabbt och pålitligt i alla tre fallen (recovery kördes ~1 min efter att PR:en skapades).
- Men recovery-*åtgärden* köade inte PR:en. Den återhämtade genom `disable + enable auto-merge`, vilket bara registrerar en kö-entry när en mergebarhetshändelse följer. Mot en stillastående `main` är det en no-op.
- Renaste beviset (#724): togglad 12:59 (loggen ser `CLEAN`), `main` stod stilla i **64 minuter**, PR:en mergade inte — först när en orelaterad merge flyttade `main` 14:02 utlöstes en ny toggle och den mergade 14:03.

## Vad som ändras

- **Recovery köar imperativt** med `enqueuePullRequest` (samma mutation som submission-vägen, §113) och **verifierar** att en `mergeQueueEntry` uppstod, med återförsök. Det köar PR:en durabelt utan att `main` behöver röra sig — fixar CLEAN-i-vila-svansen.
- **Defense-in-depth-fallback:** om enqueue inte kan bekräftas för att mergebarhetstillståndet ligger efter (checks-passade men `BLOCKED`/`UNKNOWN`, §112.18, där kön avvisar en direktenqueue), faller recovery tillbaka till att **re-arma auto-merge** (disable→enable) så PR:en köas vid `BLOCKED`→`CLEAN`-övergången. Mekanismerna är komplementära: enqueue täcker fallet toggeln missar, re-armen täcker fallet enqueue missar.
- **`check_suite`-triggern behålls** (bevisat pålitlig); en tidigare `workflow_run`-ansats förkastades.
- **Schemat glesas ut till 120 min** (`0 */2 * * *`) som genuin sista-utväg, eftersom `check_suite`-recoveryn nu köar durabelt inom ~1 min. (Uppmätt: den gamla `*/15`-cronen levererade i praktiken bara ~1 gång/timme — GitHub strypter högfrekventa scheman.)
- `classifyStrandedPr` (*när* en PR är strandad) är oförändrad — bara *hur* den återhämtas ändras, vilket är grunden för att snabba PR:er inte påverkas.

## Testplan

- [x] `npm test` — 2201 tester gröna, inkl. nya STRAND-26..32 (enqueue-och-verifiera, återförsök, fail-loud, defense-in-depth-vägarna) och RECTRIG-01 (låser 120-min-cron)
- [x] `npm run lint` (ESLint) rent
- [x] `npm run lint:md` rent
- [ ] **Manuell live-checkpoint (STRAND-M01):** lägg till en aktivitet så den strandar under en lugn stund; bekräfta i Actions att första `check_suite`-recoveryn durabelt köar PR:en (`mergeQueueEntry` finns) och att den mergar inom ~1–2 min utan att `main` rör sig. Observera i loggen om enqueue lyckades direkt (CLEAN) eller om fallback-re-armen behövde köras (BLOCKED-lag). Detta kan inte köras i CI-miljön.
- [ ] **Öppen risk:** bekräfta att `EVENT_AUTOMERGE_TOKEN` får köra `enqueuePullRequest` (samma scope som auto-merge-mutationerna) — verifieras i samma checkpoint.

## Utanför scope

- 15-sekundersmålet (kräver optimistisk klient-visning — separat, större projekt).
- Om live-checkpointen visar att kön accepterar en checks-passad `BLOCKED`-PR är fallbacken överflödig och kan tas bort → tillbaka till ren enqueue-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167ie42N3XuYLF1g2wsiwwK

---
_Generated by [Claude Code](https://claude.ai/code/session_0167ie42N3XuYLF1g2wsiwwK)_