### PR TITLE
Move PWA install button beside menu to avoid up-arrow overlap

### DIFF
--- a/docs/02-requirements/pages-navigation.md
+++ b/docs/02-requirements/pages-navigation.md
@@ -497,8 +497,10 @@ activity from anywhere on the site without opening the menu.
   (42 × 42 px), terracotta background, white icon, and
   `var(--radius-md)` border-radius. <!-- 02-§114.7 -->
 - The quick-add button displays a plus (+) icon. <!-- 02-§114.8 -->
-- The PWA-install button is positioned to the left of the quick-add button so
-  the two buttons never overlap. <!-- 02-§114.9 -->
+- The PWA-install button sits on the left side of the mobile navigation, beside
+  the menu (hamburger) button, so it never overlaps the quick-add button, the
+  other right-aligned floating buttons, or the centred scroll-to-top
+  button. <!-- 02-§114.9 -->
 
 ---
 

--- a/docs/02-requirements/platform-security.md
+++ b/docs/02-requirements/platform-security.md
@@ -512,7 +512,8 @@ discover this without being intrusive.
 ### 88.1 Install button in navigation (user requirements)
 
 - The header bar must include an install button alongside the existing
-  controls (hamburger menu, scroll-to-top, feedback). <!-- 02-§88.1 -->
+  controls (hamburger menu, scroll-to-top, feedback). On mobile it sits on the
+  left side of the navigation, beside the menu (hamburger) button. <!-- 02-§88.1 -->
 - The button must use a recognisable install/download icon, styled
   consistently with the other header buttons. <!-- 02-§88.2 -->
 - The button label/tooltip must be in Swedish

--- a/docs/03-architecture/pages-and-content.md
+++ b/docs/03-architecture/pages-and-content.md
@@ -116,16 +116,10 @@ It shares the 42 × 42 px terracotta pill styling of the other floating action
 buttons and is positioned with `position: fixed; top: var(--space-xs)` in the
 slot between the centred scroll-to-top button and the right-aligned feedback
 button (`right: calc(var(--space-sm) + 42px + var(--space-xs))`). The
-`.pwa-install-btn` moves one slot further left
-(`right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`) so the two
-never overlap. The button needs no client-side script — it is a plain link.
-
-The install button keeps that fixed slot on `lagg-till.html` even though the
-quick-add button is absent there, so an empty slot can sit between it and the
-feedback button. This is intentional: the install button is hidden unless the
-browser fires `beforeinstallprompt`, so the gap is only ever visible in the
-rare case the app is installable while the user is on the add page — not worth
-page-specific positioning rules.
+`.pwa-install-btn` is not part of this right-side row — it sits on the left
+beside the menu toggle (see `03-architecture/platform-and-security.md §28.7`) —
+so no right-side slot arithmetic has to account for it. The button needs no
+client-side script — it is a plain link.
 
 ### 12.8 Edit-shortcut button (02-§115)
 
@@ -166,11 +160,11 @@ It shares the 42 × 42 px terracotta pill styling of the other floating action
 buttons and is positioned with `position: fixed; top: var(--space-xs)` in the
 slot immediately left of the quick-add button
 (`right: calc(var(--space-sm) + 2 * (42px + var(--space-xs)))`). The
-`.pwa-install-btn` moves one slot further left
-(`right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))`) so the buttons
-never overlap. Because both the edit-shortcut and install buttons are usually
-hidden, the row collapses to just the feedback and quick-add buttons for most
-visitors, with no visible gaps.
+`.pwa-install-btn` is not part of this right-side row — it sits on the left
+beside the menu toggle (see `03-architecture/platform-and-security.md §28.7`) —
+so the edit-shortcut never has to yield a slot to it. Because the edit-shortcut
+is usually hidden, the right-side row collapses to just the feedback and
+quick-add buttons for most visitors, with no visible gaps.
 
 ---
 

--- a/docs/03-architecture/platform-and-security.md
+++ b/docs/03-architecture/platform-and-security.md
@@ -133,6 +133,15 @@ A discreet install button in the site header helps users discover that the
 site can be installed as an app. The button appears alongside the existing
 header controls (hamburger menu, scroll-to-top, feedback).
 
+On mobile (`≤ 767px`) the button (`.pwa-install-btn`) shares the 42 × 42 px
+terracotta pill styling of the other floating action buttons and is positioned
+with `position: fixed; top: var(--space-xs); left: calc(var(--space-sm) + 42px +
+var(--space-xs))` — the slot immediately right of the menu (hamburger) toggle.
+Sitting on the left keeps it clear of both the centred scroll-to-top button and
+the right-aligned floating buttons (feedback, quick-add, edit-shortcut),
+regardless of how many of those are visible. On desktop the button is instead
+positioned near the top-right of the content container.
+
 **Platform detection and behaviour:**
 
 | Platform | Detection | Button action |

--- a/docs/07-design/components.md
+++ b/docs/07-design/components.md
@@ -53,8 +53,8 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
   white plus icon, `border-radius: var(--radius-md)` — matching the
   scroll-to-top and PWA-install buttons. Hidden on desktop. <!-- 07-§6.126 -->
 - Positioned between the centred scroll-to-top button and the right-aligned
-  feedback button; the PWA-install button shifts one slot left so the
-  buttons never overlap. <!-- 07-§6.127 -->
+  feedback button. The PWA-install button is not part of this right-side row —
+  it sits on the left beside the menu toggle. <!-- 07-§6.127 -->
 
 ### Edit-shortcut button (mobile)
 
@@ -63,8 +63,7 @@ Part of [the design index](./index.md). Section IDs (`07-§N.M`) are stable and 
   linking to the edit page. <!-- 07-§6.128 -->
 - Mobile only (`≤ 767px`): `42 × 42px`, `background: var(--color-terracotta)`,
   white pencil icon, `border-radius: var(--radius-md)` — matching the other
-  floating action buttons. The PWA-install button shifts one slot left so they
-  never overlap. Hidden on desktop. <!-- 07-§6.129 -->
+  floating action buttons. Hidden on desktop. <!-- 07-§6.129 -->
 - Hidden by default; revealed by `nav.js` only for visitors who own an upcoming
   activity. An admin token does not reveal it. <!-- 07-§6.130 -->
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1792,7 +1792,7 @@ Doc ref: `02-requirements/pages-navigation.md §114`;
 | `02-§114.6` | covered | QADD-12: `right: calc(var(--space-sm) + 42px + var(--space-xs))` between scroll-top and feedback; `source/assets/cs/style.css`. Visual placement is manual checkpoint |
 | `02-§114.7` | covered | QADD-11: 42 × 42 px, `var(--color-terracotta)`, white icon, `var(--radius-md)`; `source/assets/cs/style.css` |
 | `02-§114.8` | covered | QADD-04: inline SVG plus icon inside the anchor; `source/build/layout.js` |
-| `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))` (one slot left of the edit-shortcut button, which took the slot beside quick-add); `source/assets/cs/style.css` |
+| `02-§114.9` | covered | QADD-13: `.pwa-install-btn` mobile rule uses `left: calc(var(--space-sm) + 42px + var(--space-xs))` (left side, beside the menu toggle) so it never overlaps the right-side buttons or the centred scroll-top; `source/assets/cs/style.css`. Visual non-overlap is manual checkpoint |
 
 ### §115 — Edit-Shortcut Button in Sticky Navigation
 

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2933,7 +2933,11 @@ body.modal-open {
     justify-content: center;
     position: fixed;
     top: var(--space-xs);
-    right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)));
+
+    /* On the left beside the menu toggle (one 42px slot right of it), so the
+       install button never overlaps the right-side floating buttons or the
+       centred scroll-to-top arrow (#795). */
+    left: calc(var(--space-sm) + 42px + var(--space-xs));
     width: 42px;
     height: 42px;
     background: var(--color-terracotta);
@@ -3080,7 +3084,8 @@ body.modal-open {
   .pwa-install-tooltip {
     position: fixed;
     top: calc(var(--space-xs) + 42px + var(--space-xs));
-    right: var(--space-sm);
+    right: auto;
+    left: var(--space-sm);
     white-space: normal;
     max-width: 260px;
   }

--- a/tests/quick-add-button.test.js
+++ b/tests/quick-add-button.test.js
@@ -149,12 +149,13 @@ describe('quick-add button – CSS rules (02-§114.5, §114.6, §114.7, §114.9)
     );
   });
 
-  it('QADD-13: PWA-install button shifts left of quick-add so they never overlap', () => {
-    // The edit-shortcut button (02-§115) sits in the slot immediately left of
-    // quick-add, so the PWA-install button moves one slot further still.
+  it('QADD-13: PWA-install button sits on the left beside the menu, not in the right-side row', () => {
+    // The PWA-install button is placed on the left of the mobile nav, one slot
+    // right of the 42px menu (hamburger) toggle, so it never overlaps the
+    // right-side floating buttons or the centred scroll-to-top arrow (#795).
     assert.ok(
-      CSS.includes('right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))'),
-      'PWA-install button should sit two slots left of quick-add',
+      CSS.includes('left: calc(var(--space-sm) + 42px + var(--space-xs))'),
+      'PWA-install button should be positioned on the left beside the menu toggle',
     );
   });
 });


### PR DESCRIPTION
## Sammanfattning

På mobil krockade den centrerade "scrolla upp"-pilen med "gör sidan till app"-knappen (PWA-install). Rotorsaken var att PWA-knappen satt i en hårdkodad höger-"slot" (`right: calc(var(--space-sm) + 3 * (42px + var(--space-xs)))` ≈ 166px), som på smala telefoner hamnade nära mitten där upp-pilen ligger (`left: 50%`).

PWA-install-knappen sitter nu i stället **på vänstersidan, precis intill hamburgermenyn** (`left: calc(var(--space-sm) + 42px + var(--space-xs))`), en 42px-slot till höger om menyn. Det håller den borta från både den centrerade upp-pilen och de högerankrade flytande knapparna, oavsett hur många av dem som visas. iOS-installationstooltipen följer med till vänster.

### Ändringar
- `source/assets/cs/style.css`: `.pwa-install-btn` och `.pwa-install-tooltip` mobil-block flyttade till vänster (desktop orört).
- Requirements, arkitektur, design och traceability uppdaterade till önskat läge (02-§114.9, 02-§88.1, §12.7/§12.8, §28.7, 07-§6.127/§6.129).
- `tests/quick-add-button.test.js`: QADD-13 verifierar nu vänster-placeringen.

## Test plan
- [x] `npm test` — alla 2201 tester passerar
- [x] `npm run lint` / `lint:md` / `lint:css` / `lint:html` — rena
- [x] `npm run build` — går igenom
- [x] Browser-check på 411×821 (reporterns viewport): meny (16px) → app-knapp (66px), upp-pil centrerad (185px), inga överlapp; högerklustret och desktop oförändrade

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012BMRQjqWLK4WRSTrBFrFVk)_