### PR TITLE
Skapa 2027 juni- och juli-läger från juli-skelettet

### DIFF
--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -576,7 +576,11 @@ requirements that flow from that design.
 The active QA camp stays open until the upcoming real camp opens for
 editing, then hands over to that real camp; a separate autumn QA camp
 reopens after the real-camp season ends. This keeps an open camp available
-for QA testing at all times except the real camp's own active window. See
+for QA testing at all times except the real camp's own active window.
+`camps.yaml` may hold real camps for more than one future season at a time
+(for example, next summer's camps staged a year ahead); the QA camps only
+need to stay clear of each real camp's own active window, so they may sit in
+the gaps between separate seasons. See
 `03-architecture/data-layer.md §2 "QA camp isolation"` for the spring/autumn
 camp descriptions and the off-season window.
 
@@ -589,9 +593,11 @@ camp descriptions and the off-season window.
   non-archived camp opens for editing (its `opens_for_editing`), so the QA
   camp stays open for testing right up until the real camp's pre-camp
   preparation period begins. <!-- 02-§42.32 -->
-- No QA-only camp's date range covers the period from the spring QA camp's
-  `end_date` (exclusive) until the autumn QA camp's `start_date` (exclusive),
-  so no QA camp is active in QA during the real-camp season. <!-- 02-§42.33 -->
+- No QA-only camp's date range overlaps the active window (`start_date`
+  through `end_date`, inclusive) of any non-QA, non-archived camp, so no QA
+  camp is active in QA while a real camp is running. This holds independently
+  for each real camp, so QA camps may sit in the gaps between separate
+  real-camp seasons. <!-- 02-§42.33 -->
 - The autumn QA camp's `start_date` is `YYYY-10-01` and its `end_date`
   is `YYYY-12-31`, where `YYYY` is the current calendar year. <!-- 02-§42.34 -->
 

--- a/docs/03-architecture/data-layer.md
+++ b/docs/03-architecture/data-layer.md
@@ -168,7 +168,7 @@ the `BUILD_ENV` environment variable:
   and normal derivation rules apply.
 
 Two QA-only camps coexist in `camps.yaml` to provide a continuous QA
-testing window without overlapping the real-camp season:
+testing window without overlapping any real camp's active window:
 
 - A spring QA camp (`qa-thisweek`) runs through the off-season and
   closes when the next real camp opens for editing (its
@@ -177,6 +177,12 @@ testing window without overlapping the real-camp season:
 - An autumn QA camp (`qa-testcamp`) covers October 1 through December
   31 of the current year, reopening QA testing once the real-camp
   season ends.
+
+`camps.yaml` may hold real camps for more than one future season at a time
+(next summer's camps can be staged a year ahead). Each QA camp only has to
+stay clear of every real camp's own active window (`start_date`..`end_date`),
+so it may sit in the gap between two separate seasons — the isolation rule is
+evaluated per real camp, not against a single span covering them all.
 
 See `02-requirements/event-data.md §42` for the full data model and seasonal rules.
 

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -549,7 +549,7 @@ Part of [the traceability index](./index.md).
 | `02-§42.29` | Yearly update is manual one-line change, no automation | — | — | — | implemented |
 | `02-§42.31` | Two QA-only camps coexist: spring + autumn | 02-requirements/event-data.md §42.9, 03-architecture/data-layer.md §2 | QSEAS-01, QSEAS-03 | `source/data/camps.yaml` | covered |
 | `02-§42.32` | Spring QA camp `end_date` equals the next real camp's `opens_for_editing` | 02-requirements/event-data.md §42.9, 03-architecture/data-layer.md §2 | QSEAS-04 | `source/data/camps.yaml` | covered |
-| `02-§42.33` | No QA camp covers the real-camp season window | 02-requirements/event-data.md §42.9 | QSEAS-05 | `source/data/camps.yaml` | covered |
+| `02-§42.33` | No QA camp overlaps any real camp's active window | 02-requirements/event-data.md §42.9 | QSEAS-05 | `source/data/camps.yaml` | covered |
 | `02-§42.34` | Autumn QA camp runs Oct 1 – Dec 31 of current year | 02-requirements/event-data.md §42.9 | QSEAS-02 | `source/data/camps.yaml` | covered |
 | `02-§43.1` | QA event data deploy uses SCP over SSH instead of FTP | 08-ENVIRONMENTS.md | manual: trigger event PR, verify QA pages update via SCP | `.github/workflows/event-data-deploy.yml` – `deploy-qa` job | implemented |
 | `02-§43.2` | QA event data upload uses existing SSH secrets | 08-ENVIRONMENTS.md | manual: inspect workflow secrets references | `.github/workflows/event-data-deploy.yml` | implemented |

--- a/source/data/2027-06-syssleback.yaml
+++ b/source/data/2027-06-syssleback.yaml
@@ -1,0 +1,7 @@
+camp:
+  id: 2027-06-syssleback
+  name: SB sommar 2027 juni
+  location: Sysslebäck
+  start_date: '2027-06-20'
+  end_date: '2027-06-27'
+events: []

--- a/source/data/2027-06-syssleback/avslutningsmöte-alla-deltar-2027-06-26-1800.yaml
+++ b/source/data/2027-06-syssleback/avslutningsmöte-alla-deltar-2027-06-26-1800.yaml
@@ -1,0 +1,30 @@
+event:
+  id: avslutningsmöte-alla-deltar-2027-06-26-1800
+  title: Avslutningsmöte (alla deltar)
+  date: '2027-06-26'
+  start: '18:00'
+  end: '20:00'
+  location: Annat
+  responsible: Andreas (Lägernissen)
+  description: |
+    **Möte:**
+    Vi börjar med avetablering, alla hjälps åt!
+    När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.
+    Ofta en gemensam bild på alla deltagare (som vill).
+
+    **Avetablering:**
+    Gemensam översyn på området med iordningställande och städ.
+
+    - Alla tält packas ner.
+    - All utrustning tas om hand.
+    - Alla gemensamma ytor sopas.
+    - Kyl/frys-skåp töms, torkas ur och tas till förrådet.
+    - Gräsytor utomhus gås igenom och skräp plockas upp.
+    Lost and found, vid ingång till GA-hallen.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/glass-på-chokladfabriken-2027-06-27-1200.yaml
+++ b/source/data/2027-06-syssleback/glass-på-chokladfabriken-2027-06-27-1200.yaml
@@ -1,0 +1,20 @@
+event:
+  id: glass-på-chokladfabriken-2027-06-27-1200
+  title: Glass på chokladfabriken
+  date: '2027-06-27'
+  start: '12:00'
+  end: '15:00'
+  location: Annat
+  responsible: Alla
+  description: |
+    Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.
+    Det finns parkering för de som vill vara redo för “hemfärd”.
+    Annars är det en lagom promenad på vägen bakom receptionen.
+    Tiden är för det brukar vara lite “drop-in”.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/infomoten-ungdomsstuga-datorsal-etc-2027-06-21-1030.yaml
+++ b/source/data/2027-06-syssleback/infomoten-ungdomsstuga-datorsal-etc-2027-06-21-1030.yaml
@@ -1,0 +1,18 @@
+event:
+  id: infomoten-ungdomsstuga-datorsal-etc-2027-06-21-1030
+  title: 'Infomöten, ungdomsstuga, datorsal, etc.'
+  date: '2027-06-21'
+  start: '10:30'
+  end: '11:30'
+  location: GA Idrott
+  responsible: Lite olika
+  description: |
+    Efter det gemensamma mötet delas det in i mindre grupper för lite olika saker.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-07-01 18:33
+    updated_at: 2026-07-01 18:33
+    location_set_at: 2026-07-01 18:33

--- a/source/data/2027-06-syssleback/lunch-2027-06-21-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-21-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-21-1200
+  title: Lunch
+  date: '2027-06-21'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-22-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-22-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-22-1200
+  title: Lunch
+  date: '2027-06-22'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-23-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-23-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-23-1200
+  title: Lunch
+  date: '2027-06-23'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-24-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-24-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-24-1200
+  title: Lunch
+  date: '2027-06-24'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-25-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-25-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-25-1200
+  title: Lunch
+  date: '2027-06-25'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-26-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-26-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-26-1200
+  title: Lunch
+  date: '2027-06-26'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/lunch-2027-06-27-1200.yaml
+++ b/source/data/2027-06-syssleback/lunch-2027-06-27-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-06-27-1200
+  title: Lunch
+  date: '2027-06-27'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-20-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-20-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-20-1700
+  title: Middag
+  date: '2027-06-20'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-21-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-21-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-21-1700
+  title: Middag
+  date: '2027-06-21'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-22-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-22-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-22-1700
+  title: Middag
+  date: '2027-06-22'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-23-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-23-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-23-1700
+  title: Middag
+  date: '2027-06-23'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-24-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-24-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-24-1700
+  title: Middag
+  date: '2027-06-24'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-25-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-25-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-25-1700
+  title: Middag
+  date: '2027-06-25'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/middag-2027-06-26-1700.yaml
+++ b/source/data/2027-06-syssleback/middag-2027-06-26-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-06-26-1700
+  title: Middag
+  date: '2027-06-26'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-06-20-1800.yaml
+++ b/source/data/2027-06-syssleback/obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-06-20-1800.yaml
@@ -1,0 +1,22 @@
+event:
+  id: obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-06-20-1800
+  title: '(OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall'
+  date: '2027-06-20'
+  start: '18:00'
+  end: '20:30'
+  location: Annat
+  responsible: Alla
+  description: |
+    Vi hjälps åt att hämta material från förrådet vid receptionen.
+    Bygger massa tält.
+    Gör iordning GA-hallen.
+    Nya deltagare har här chansen att komma in, bidra, och bli delaktiga i lägret!
+    Det blir vad vi gör det till. Fråga den jämte dig, vad du kan göra.
+    Passa på att fråga om namn också. :)
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/välkommen-2027-06-20-1200.yaml
+++ b/source/data/2027-06-syssleback/välkommen-2027-06-20-1200.yaml
@@ -1,0 +1,18 @@
+event:
+  id: välkommen-2027-06-20-1200
+  title: Välkommen
+  date: '2027-06-20'
+  start: '12:00'
+  end: '23:30'
+  location: Annat
+  responsible: Alla
+  description: |
+    Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+    Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt!
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-06-syssleback/välkomstmöte-2027-06-21-1000.yaml
+++ b/source/data/2027-06-syssleback/välkomstmöte-2027-06-21-1000.yaml
@@ -1,0 +1,17 @@
+event:
+  id: välkomstmöte-2027-06-21-1000
+  title: Välkomstmöte
+  date: '2027-06-21'
+  start: '10:00'
+  end: '10:30'
+  location: GA Idrott
+  responsible: Andreas (Lägernissen)
+  description: |
+    Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback.yaml
+++ b/source/data/2027-07-syssleback.yaml
@@ -1,0 +1,7 @@
+camp:
+  id: 2027-07-syssleback
+  name: SB sommar 2027 juli
+  location: Sysslebäck
+  start_date: '2027-07-25'
+  end_date: '2027-08-01'
+events: []

--- a/source/data/2027-07-syssleback/avslutningsmöte-alla-deltar-2027-07-31-1800.yaml
+++ b/source/data/2027-07-syssleback/avslutningsmöte-alla-deltar-2027-07-31-1800.yaml
@@ -1,0 +1,30 @@
+event:
+  id: avslutningsmöte-alla-deltar-2027-07-31-1800
+  title: Avslutningsmöte (alla deltar)
+  date: '2027-07-31'
+  start: '18:00'
+  end: '20:00'
+  location: Annat
+  responsible: Andreas (Lägernissen)
+  description: |
+    **Möte:**
+    Vi börjar med avetablering, alla hjälps åt!
+    När vi är klara så samlas vi för att lyssna på vad lägeransvariga har att säga.
+    Ofta en gemensam bild på alla deltagare (som vill).
+
+    **Avetablering:**
+    Gemensam översyn på området med iordningställande och städ.
+
+    - Alla tält packas ner.
+    - All utrustning tas om hand.
+    - Alla gemensamma ytor sopas.
+    - Kyl/frys-skåp töms, torkas ur och tas till förrådet.
+    - Gräsytor utomhus gås igenom och skräp plockas upp.
+    Lost and found, vid ingång till GA-hallen.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/glass-på-chokladfabriken-2027-08-01-1200.yaml
+++ b/source/data/2027-07-syssleback/glass-på-chokladfabriken-2027-08-01-1200.yaml
@@ -1,0 +1,20 @@
+event:
+  id: glass-på-chokladfabriken-2027-08-01-1200
+  title: Glass på chokladfabriken
+  date: '2027-08-01'
+  start: '12:00'
+  end: '15:00'
+  location: Annat
+  responsible: Alla
+  description: |
+    Många brukar besöka Chokladfabriken för att äta lite glass som avrundning och hej då.
+    Det finns parkering för de som vill vara redo för “hemfärd”.
+    Annars är det en lagom promenad på vägen bakom receptionen.
+    Tiden är för det brukar vara lite “drop-in”.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/infomoten-ungdomsstuga-datorsal-etc-2027-07-26-1030.yaml
+++ b/source/data/2027-07-syssleback/infomoten-ungdomsstuga-datorsal-etc-2027-07-26-1030.yaml
@@ -1,0 +1,18 @@
+event:
+  id: infomoten-ungdomsstuga-datorsal-etc-2027-07-26-1030
+  title: 'Infomöten, ungdomsstuga, datorsal, etc.'
+  date: '2027-07-26'
+  start: '10:30'
+  end: '11:30'
+  location: GA Idrott
+  responsible: Lite olika
+  description: |
+    Efter det gemensamma mötet delas det in i mindre grupper för lite olika saker.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-07-01 18:33
+    updated_at: 2026-07-01 18:33
+    location_set_at: 2026-07-01 18:33

--- a/source/data/2027-07-syssleback/lunch-2027-07-26-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-26-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-26-1200
+  title: Lunch
+  date: '2027-07-26'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-07-27-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-27-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-27-1200
+  title: Lunch
+  date: '2027-07-27'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-07-28-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-28-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-28-1200
+  title: Lunch
+  date: '2027-07-28'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-07-29-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-29-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-29-1200
+  title: Lunch
+  date: '2027-07-29'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-07-30-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-30-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-30-1200
+  title: Lunch
+  date: '2027-07-30'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-07-31-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-07-31-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-07-31-1200
+  title: Lunch
+  date: '2027-07-31'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/lunch-2027-08-01-1200.yaml
+++ b/source/data/2027-07-syssleback/lunch-2027-08-01-1200.yaml
@@ -1,0 +1,17 @@
+event:
+  id: lunch-2027-08-01-1200
+  title: Lunch
+  date: '2027-08-01'
+  start: '12:00'
+  end: '13:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-25-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-25-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-25-1700
+  title: Middag
+  date: '2027-07-25'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-26-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-26-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-26-1700
+  title: Middag
+  date: '2027-07-26'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-27-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-27-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-27-1700
+  title: Middag
+  date: '2027-07-27'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-28-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-28-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-28-1700
+  title: Middag
+  date: '2027-07-28'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-29-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-29-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-29-1700
+  title: Middag
+  date: '2027-07-29'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-30-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-30-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-30-1700
+  title: Middag
+  date: '2027-07-30'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/middag-2027-07-31-1700.yaml
+++ b/source/data/2027-07-syssleback/middag-2027-07-31-1700.yaml
@@ -1,0 +1,17 @@
+event:
+  id: middag-2027-07-31-1700
+  title: Middag
+  date: '2027-07-31'
+  start: '17:00'
+  end: '18:00'
+  location: Servicehus
+  responsible: Alla
+  description: |
+    Se tiden som en riktlinje då vi försöker att inte ha några aktiviteter igång. Man får givetvis äta precis när man vill.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-07-25-1800.yaml
+++ b/source/data/2027-07-syssleback/obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-07-25-1800.yaml
@@ -1,0 +1,22 @@
+event:
+  id: obs-alla-deltar-nya-lite-extra-rigga-tält-och-ställa-i-ordning-ga-hall-2027-07-25-1800
+  title: '(OBS! Alla deltar, nya lite extra) Rigga tält och ställa i ordning GA-hall'
+  date: '2027-07-25'
+  start: '18:00'
+  end: '20:30'
+  location: Annat
+  responsible: Alla
+  description: |
+    Vi hjälps åt att hämta material från förrådet vid receptionen.
+    Bygger massa tält.
+    Gör iordning GA-hallen.
+    Nya deltagare har här chansen att komma in, bidra, och bli delaktiga i lägret!
+    Det blir vad vi gör det till. Fråga den jämte dig, vad du kan göra.
+    Passa på att fråga om namn också. :)
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/välkommen-2027-07-25-1200.yaml
+++ b/source/data/2027-07-syssleback/välkommen-2027-07-25-1200.yaml
@@ -1,0 +1,18 @@
+event:
+  id: välkommen-2027-07-25-1200
+  title: Välkommen
+  date: '2027-07-25'
+  start: '12:00'
+  end: '23:30'
+  location: Annat
+  responsible: Alla
+  description: |
+    Första dagen. Besökare kommer vid olika tider. På eftermiddagen och kvällen hjälps vi åt att bygga tält, rigga datorsal, GA-hall med mera och komma iordning inför lägret.
+    Ta hand om varandra och tänk lite extra om ni ser nya ansikten. Ta kontakt!
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/2027-07-syssleback/välkomstmöte-2027-07-26-1000.yaml
+++ b/source/data/2027-07-syssleback/välkomstmöte-2027-07-26-1000.yaml
@@ -1,0 +1,17 @@
+event:
+  id: välkomstmöte-2027-07-26-1000
+  title: Välkomstmöte
+  date: '2027-07-26'
+  start: '10:00'
+  end: '10:30'
+  location: GA Idrott
+  responsible: Andreas (Lägernissen)
+  description: |
+    Lägeransvariga hälsar alla välkomna och presenterar upplägget för den här veckan och påminner om hur vi skapar lägret tillsammans.
+  link: null
+  owner:
+    name: ''
+    email: ''
+  meta:
+    created_at: 2026-02-27 09:16:57
+    updated_at: 2026-02-27 09:16:57

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -1,4 +1,30 @@
 camps:
+  - id: 2027-07-syssleback
+    name: SB sommar 2027 juli
+    start_date: '2027-07-25'
+    end_date: '2027-08-01'
+    opens_for_editing: '2027-07-18'
+    registration_opens: '2027-04-15'
+    registration_closes: '2027-07-18'
+    location: Sysslebäck
+    link: https://www.facebook.com/groups/syssleback2027
+    information: |
+      Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+    file: 2027-07-syssleback.yaml
+    archived: false
+  - id: 2027-06-syssleback
+    name: SB sommar 2027 juni
+    start_date: '2027-06-20'
+    end_date: '2027-06-27'
+    opens_for_editing: '2027-06-13'
+    registration_opens: '2027-04-15'
+    registration_closes: '2027-06-13'
+    location: Sysslebäck
+    link: https://www.facebook.com/groups/syssleback2027
+    information: |
+      Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+    file: 2027-06-syssleback.yaml
+    archived: false
   - id: 2026-07-syssleback
     name: SB sommar 2026 juli
     start_date: '2026-07-26'

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -9,7 +9,7 @@ camps:
     location: Sysslebäck
     link: https://www.facebook.com/groups/syssleback2027
     information: |
-      Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+      2026 lät vi Claude Code bygga om allt från WordPress. 2027 räcker det att vi tänker på ett läger så står schemat redan färdigt. Vi väntar fortfarande på att den ska lära sig grilla korven. 🌭
     file: 2027-07-syssleback.yaml
     archived: false
   - id: 2027-06-syssleback
@@ -22,7 +22,7 @@ camps:
     location: Sysslebäck
     link: https://www.facebook.com/groups/syssleback2027
     information: |
-      Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+      2026 lät vi Claude Code bygga om allt från WordPress. 2027 räcker det att vi tänker på ett läger så står schemat redan färdigt. Vi väntar fortfarande på att den ska lära sig grilla korven. 🌭
     file: 2027-06-syssleback.yaml
     archived: false
   - id: 2026-07-syssleback

--- a/tests/qa-camp-seasonal.test.js
+++ b/tests/qa-camp-seasonal.test.js
@@ -4,8 +4,10 @@
 //
 // The site keeps two QA-only camps (qa: true): a "spring" camp that closes when
 // the next real camp opens for editing, and an "autumn" camp covering Oct 1
-// – Dec 31 of the current year. Together they leave the real-camp window
-// QA-free while ensuring continuous QA coverage outside that window.
+// – Dec 31 of the current year. Together they leave every real camp's active
+// window QA-free while ensuring continuous QA coverage outside those windows.
+// The isolation rule is evaluated per real camp, so camps.yaml may stage more
+// than one future season at a time and QA camps may sit in the gaps between them.
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
@@ -59,17 +61,18 @@ describe('camps.yaml – seasonal QA camp model (02-§42.31–42.34)', () => {
     );
   });
 
-  it('QSEAS-05 (02-§42.33): no QA camp covers any date during the real-camp season window', () => {
-    if (realCamps.length === 0) return;
-    const seasonStart = realCamps.reduce((min, c) => c.start_date < min ? c.start_date : min, realCamps[0].start_date);
-    const seasonEnd = realCamps.reduce((max, c) => c.end_date > max ? c.end_date : max, realCamps[0].end_date);
-
+  it("QSEAS-05 (02-§42.33): no QA camp overlaps any real camp's active window", () => {
+    // Evaluated per real camp rather than against a single min..max span, so
+    // camps.yaml may stage more than one future season while QA camps stay in
+    // the gaps between them.
     for (const qc of qaCamps) {
-      const overlaps = qc.start_date <= seasonEnd && qc.end_date >= seasonStart;
-      assert.ok(
-        !overlaps,
-        `QA camp "${qc.id}" (${qc.start_date}..${qc.end_date}) overlaps real-camp season (${seasonStart}..${seasonEnd})`,
-      );
+      for (const rc of realCamps) {
+        const overlaps = qc.start_date <= rc.end_date && qc.end_date >= rc.start_date;
+        assert.ok(
+          !overlaps,
+          `QA camp "${qc.id}" (${qc.start_date}..${qc.end_date}) overlaps real camp "${rc.id}" active window (${rc.start_date}..${rc.end_date})`,
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
## Sammanfattning

Skapar två nya kommande läger för 2027 genom att kopiera juli-lägrets standardskelett (de återkommande aktiviteterna) med datumen förskjutna till varje ny vecka.

| | Juni 2027 | Juli 2027 |
|---|---|---|
| id | `2027-06-syssleback` | `2027-07-syssleback` |
| datum | 2027-06-20 – 2027-06-27 | 2027-07-25 – 2027-08-01 |
| aktiviteter | 20 (från juli-skelettet) | 20 (från juli-skelettet) |

- **Läger registrerade** i `camps.yaml` som kommande (`archived: false`). Redigerings-/anmälningsdatum använder dokumenterade standardvärden: `opens_for_editing` = start − 7 dagar, anmälan 2027-04-15 t.o.m. start − 7 dagar.
- **Skelettaktiviteter seedade** som fragmentfiler i `source/data/2027-06-syssleback/` och `source/data/2027-07-syssleback/`: Lunch, Middag, Välkommen, Välkomstmöte, Infomöten, "rigga tält", Avslutningsmöte och Glass — datumförskjutna, med beskrivningar och tider intakta.
- **Lättsam infotext** om nuläget på båda lägren (visas på arkivsidan när lägren så småningom arkiveras).

## QA-säsongsmodellen (per-läger-isolering)

Att lägga in en andra framtida säsong avslöjade att den säsongsbaserade QA-modellen (`02-§42.33`) räknade realläger-säsongen som ett enda `min..max`-spann över alla icke-arkiverade realläger. Med läger i både 2026 och 2027 svalde spannet höst-QA-lägret (okt–dec 2026) som ligger mellan dem.

Isoleringsregeln utvärderas nu **per realläger**: ett QA-läger behöver bara hålla sig utanför varje enskilt realägers aktiva fönster (`start_date..end_date`). QA-läger kan då ligga i glappen mellan separata säsonger, och off-season-täckningen bevaras. Uppdaterar krav, arkitekturnot, spårbarhet och `QSEAS-05`-testet.

## Testplan

- [x] `npm run validate:camps` — 14 läger validerade
- [x] `npm test` — 2201 tester, 0 fel
- [x] `npm run lint` (ESLint) — rent
- [x] `npm run lint:md` (markdownlint) — rent
- [x] `npm run build` — bygger rent; båda 2027-lägren renderas som kommande läger på startsidan med rätt datum (`20 jun – 27 jun 2027`, `25 jul – 1 aug 2027`) och anmälningsbanners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7gG7HSB95GsWnCYjoKLD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7gG7HSB95GsWnCYjoKLD2)_