### PR TITLE
Fix EDQ Hub banner copy — communication only, not schedule/info

### DIFF
--- a/docs/02-requirements/design-and-content.md
+++ b/docs/02-requirements/design-and-content.md
@@ -539,11 +539,11 @@ an additional, more visible surface for the same destination.
 
 ### 121.3 Content
 
-- The banner title is "All info om lägret – på ett ställe". <!-- 02-§121.5 -->
-- The banner sub line is "Vi flyttar från Facebook till EDQ Hub. Här finns
-  schema, nyheter och kontakt före och under lägret.". It leads with the
-  concrete benefit and states the move from Facebook so participants understand
-  why they should join. <!-- 02-§121.6 -->
+- The banner title is "Vi migrerar Facebook mot EDQ Hub". <!-- 02-§121.5 -->
+- The banner sub line is "Lägrets kommunikation flyttar hit. Gå med för snabb
+  information och kontakt före och under lägret.". It concerns only the camp's
+  communication moving from the Facebook group — the website keeps the schedule
+  and all other information as before. <!-- 02-§121.6 -->
 - All banner text is in Swedish. <!-- 02-§121.7 -->
 
 ### 121.4 Appearance

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1925,8 +1925,8 @@ Doc ref: `02-requirements/design-and-content.md §121`;
 | `02-§121.2` | covered | HUBB-03, HUBB-04: anchor `href` is the `edqhubUrl` (defined in `source/build/build.js`), with `target="_blank"` + `rel="noopener noreferrer"` |
 | `02-§121.3` | covered | HUBB-11: hub banner is interpolated before `renderRegistrationBannersHtml` output; placement below the hero image is a manual/browser checkpoint (verified at 390 px) |
 | `02-§121.4` | covered | HUBB-09, HUBB-12: anchor has no `hidden` attribute and no `data-opens`; no date-gating script is emitted |
-| `02-§121.5` | covered | HUBB-07: title is "All info om lägret – på ett ställe" |
-| `02-§121.6` | covered | HUBB-08: sub line is "Vi flyttar från Facebook till EDQ Hub. Här finns schema, nyheter och kontakt före och under lägret." |
+| `02-§121.5` | covered | HUBB-07: title is "Vi migrerar Facebook mot EDQ Hub" |
+| `02-§121.6` | covered | HUBB-08: sub line is "Lägrets kommunikation flyttar hit. Gå med för snabb information och kontakt före och under lägret." |
 | `02-§121.7` | covered | HUBB-07, HUBB-08 assert the Swedish title and sub line strings |
 | `02-§121.8` | implemented | `source/assets/cs/style.css` `.hero-hub-banner { background: var(--color-sage-dark); color: var(--color-white) }` — white on sage-dark ≈6:1; visual appearance is a manual/browser checkpoint (verified at 390 px) |
 | `02-§121.9` | covered | HUBB-13, HUBB-14: `renderHubBannerHtml()` includes `.hero-hub-banner-icon` (shared `EDQHUB_ICON`) and a `.hero-hub-banner-btn` "Till EDQ Hub" pill; visual appearance is a manual/browser checkpoint |

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -489,8 +489,8 @@ function renderHubBannerHtml(edqhubUrl) {
   return `\n    <a href="${edqhubUrl}" class="hero-hub-banner" target="_blank" rel="noopener noreferrer" data-goatcounter-click="click-hub-banner">
       <span class="hero-hub-banner-icon">${EDQHUB_ICON}</span>
       <span class="hero-hub-banner-text">
-        <span class="hero-hub-banner-title">All info om lägret – på ett ställe</span>
-        <span class="hero-hub-banner-meta">Vi flyttar från Facebook till EDQ Hub. Här finns schema, nyheter och kontakt före och under lägret.</span>
+        <span class="hero-hub-banner-title">Vi migrerar Facebook mot EDQ Hub</span>
+        <span class="hero-hub-banner-meta">Lägrets kommunikation flyttar hit. Gå med för snabb information och kontakt före och under lägret.</span>
         <span class="hero-hub-banner-btn">Till EDQ Hub <span aria-hidden="true">→</span></span>
       </span>
     </a>`;

--- a/tests/hub-banner.test.js
+++ b/tests/hub-banner.test.js
@@ -92,19 +92,19 @@ describe('renderIndexPage – EDQ Hub community banner (02-§121)', () => {
     assert.ok(html.includes('data-goatcounter-click="click-hub-banner"'), 'Expected banner click event');
   });
 
-  it('HUBB-07: banner title leads with the benefit (02-§121.5)', () => {
+  it('HUBB-07: banner title names the move from Facebook (02-§121.5)', () => {
     const html = renderIndexPage(buildPage());
     assert.ok(
-      html.includes('All info om lägret – på ett ställe'),
-      'Expected the benefit-led Swedish banner title',
+      html.includes('Vi migrerar Facebook mot EDQ Hub'),
+      'Expected the Swedish banner title naming the Facebook move',
     );
   });
 
-  it('HUBB-08: banner sub line states the move from Facebook (02-§121.6)', () => {
+  it('HUBB-08: banner sub line says communication moves here (02-§121.6)', () => {
     const html = renderIndexPage(buildPage());
     assert.ok(
-      html.includes('Vi flyttar från Facebook till EDQ Hub. Här finns schema, nyheter och kontakt före och under lägret.'),
-      'Expected the Swedish banner sub line naming the Facebook move',
+      html.includes('Lägrets kommunikation flyttar hit. Gå med för snabb information och kontakt före och under lägret.'),
+      'Expected the Swedish banner sub line about moving communication',
     );
   });
 


### PR DESCRIPTION
## Summary

Corrects the EDQ Hub banner copy shipped in #798. The previous text claimed the schedule and "all info" live on EDQ Hub, which is factually wrong and implied the website is being replaced. EDQ Hub only takes over the camp's **communication** (the former Facebook group); the website keeps the schedule and all other information exactly as before.

- Title: ~~"All info om lägret – på ett ställe"~~ → **"Vi migrerar Facebook mot EDQ Hub"**
- Sub line: ~~"Vi flyttar från Facebook till EDQ Hub. Här finns schema, nyheter och kontakt före och under lägret."~~ → **"Lägrets kommunikation flyttar hit. Gå med för snabb information och kontakt före och under lägret."**
- The "Till EDQ Hub →" button, layout, colour, icon, and analytics are unchanged.

Only these two strings change, kept in sync across the renderer, tests, requirements (§121.5/§121.6), and traceability.

## Test plan

- [x] `npm test` — 2216 pass (HUBB-07/-08 updated to the corrected strings)
- [x] `npm run lint` (eslint), `npm run lint:css`, `npm run lint:md` — clean
- [x] `npm run build` + `npm run lint:html` — clean
- [x] Manual browser check in Chromium at 390px: corrected title and sub line render, "Till EDQ Hub →" button intact, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5LmPrBwqUiWXkrNkuSGs3)_