### PR TITLE
Point footer to info@edq.se and EDQ Hub

### DIFF
--- a/source/content/footer.md
+++ b/source/content/footer.md
@@ -1,3 +1,3 @@
-Epost: info@sbsommar.se
+Epost: info@edq.se
 
-Diskussioner: [Facebook - SB sommarläger 2026 i Sysslebäck](https://www.facebook.com/groups/syssleback2026)
+Diskussioner: [EDQ Hub](https://edqhub.com/join/sb-sommarlager-2026)


### PR DESCRIPTION
## Sammanfattning

Uppdaterar den delade sidfoten (`source/content/footer.md`), som visas både på hemsidan och schemasidan:

- **Epost:** `info@edq.se` (tidigare `info@sbsommar.se`)
- **Diskussioner:** länkar nu till **EDQ Hub** (`https://edqhub.com/join/sb-sommarlager-2026`) istället för Facebook-gruppen. Detta är samma URL som redan används för EDQ Hub-knappen och -bannern i hero-sektionen (`source/build/build.js`).

Renderad sidfot:

```
Epost: info@edq.se
Diskussioner: EDQ Hub
```

## Testplan

- [x] `npm run build` genererar korrekt sidfot på både `index.html` och `schema.html`
- [x] `npm test` – alla 2216 tester passerar
- [x] Bekräftat att e-posten renderas som `mailto:`-länk och att EDQ Hub-länken öppnas i ny flik

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yJNJA6uok1DgpEMu2brF4)_