### PR TITLE
fix: per-event &lt;title&gt; respects 80-char limit after escaping

### DIFF
--- a/source/build/render-event.js
+++ b/source/build/render-event.js
@@ -25,8 +25,17 @@ const { findConflicts } = require('../assets/js/client/conflict-check.js');
 // contains legacy data with longer titles — render-time truncation means we
 // never emit an over-long <title> regardless of how a title ended up in YAML.
 function truncateForTitleTag(text, maxLen = 80) {
-  if (text.length <= maxLen) return text;
-  return text.slice(0, maxLen - 1).trimEnd() + '…';
+  // The caller HTML-escapes the return value, and escaping can lengthen the
+  // string (e.g. " → &quot;, & → &amp;). Measure the *escaped* length so the
+  // emitted <title> respects the maxLen budget (.htmlvalidate.json long-title)
+  // even when a title packs several special characters into ≤ maxLen raw chars.
+  if (escapeHtml(text).length <= maxLen) return text;
+  // Reserve one character for the ellipsis, which escaping leaves unchanged.
+  let truncated = text;
+  while (truncated.length > 0 && escapeHtml(truncated).length > maxLen - 1) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated.trimEnd() + '…';
 }
 
 // Build the conflict-warning banner HTML for a per-event page. Returns ''

--- a/source/data/2026-07-syssleback/rollspel-johans-kampanj-1-natten-som-aldrig-vill-2026-07-27-1000.yaml
+++ b/source/data/2026-07-syssleback/rollspel-johans-kampanj-1-natten-som-aldrig-vill-2026-07-27-1000.yaml
@@ -1,6 +1,6 @@
 event:
   id: rollspel-johans-kampanj-1-natten-som-aldrig-vill-2026-07-27-1000
-  title: 'Rollspel, Johans Kampanj 1 "Natten som aldrig vill ta slut" GÖRA KARAKTÄRER'
+  title: 'Rollspel, Johans kampanj 1 – Natten som aldrig vill ta slut, göra karaktärer'
   date: '2026-07-27'
   start: '10:00'
   end: '11:00'

--- a/tests/render-event.test.js
+++ b/tests/render-event.test.js
@@ -171,6 +171,33 @@ describe('renderEventPage (02-§36)', () => {
     assert.ok(titleMatch[1].includes('Fotboll'), 'title should include event name');
   });
 
+  it('EVT-26: <title> stays within 80 chars after escaping when the raw title is short but escapes long', () => {
+    // A 75-char title whose two quote characters each expand to &quot; (6 chars)
+    // produces an 85-char escaped <title> — over the long-title limit of 80.
+    // The truncation guard must measure the escaped length, not the raw length.
+    const longEvent = {
+      ...fullEvent,
+      title: 'Rollspel, Johans Kampanj 1 "Natten som aldrig vill ta slut" GÖRA KARAKTÄRER',
+    };
+    const html = renderEventPage(longEvent, camp, siteUrl);
+    const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/);
+    assert.ok(titleMatch, 'should have title element');
+    assert.ok(
+      titleMatch[1].length <= 80,
+      `escaped <title> should be ≤ 80 chars, got ${titleMatch[1].length}: ${titleMatch[1]}`,
+    );
+    assert.ok(titleMatch[1].endsWith('…'), 'a truncated title should end with an ellipsis');
+  });
+
+  it('EVT-27: a title that fits within 80 chars after escaping is left untouched', () => {
+    const okEvent = { ...fullEvent, title: 'Rollspel, Johans kampanj 1 – göra karaktärer' };
+    const html = renderEventPage(okEvent, camp, siteUrl);
+    const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/);
+    assert.ok(titleMatch, 'should have title element');
+    assert.strictEqual(titleMatch[1], 'Rollspel, Johans kampanj 1 – göra karaktärer');
+    assert.ok(!titleMatch[1].endsWith('…'), 'a short title should not be truncated');
+  });
+
   it('EVT-21 (02-§45.8): page includes iCal download link', () => {
     const html = renderEventPage(fullEvent, camp, siteUrl);
     assert.ok(html.includes('event.ics'), 'should link to event.ics');


### PR DESCRIPTION
## Bakgrund

Merge-kön bygger hela sajten och kör `lint:html` mot aktuell `main`. Den failade på `html-validate`-regeln `long-title` för en per-event-sida, vilket kastade ut varje PR ur kön — bl.a. de två Dependabot-bumparna (#816, #817) trots att deras egen CI var grön. Felet uppstod först i kön, eftersom event-data-PR:ar hoppar över bygg/lint och den för långa titeln därför landade på `main` utan att lintas.

## Ändringar

- **Build-fix (`source/build/render-event.js`):** `truncateForTitleTag` mätte den råa titellängden, men anroparen HTML-escapear resultatet. En titel på ≤ 80 råa tecken vars `"`/`&` expanderar vid escaping (`"` → `&quot;`) kunde därför ge en `<title>` över 80 tecken. Trunkeringen mäter nu den **escapeade** längden och kortar tills resultatet (inklusive ellipsen) ryms.
- **Data-fix (`source/data/2026-07-syssleback/rollspel-...-2026-07-27-1000.yaml`):** titeln escapeade till 85 tecken. Kampanjnamnet och noteringen "göra karaktärer" behålls, men de omgivande citattecknen byts mot tankstreck (matchar de fyra syskoneventen) så titeln syns i sin helhet i stället för att ellips-trunkeras.
- **Test (`tests/render-event.test.js`):** EVT-26 verifierar att en titel som är kort rått men lång escapead trunkeras till ≤ 80; EVT-27 verifierar att en titel som ryms lämnas orörd.

## Test plan

- [x] `npm test` — 2218/2218 gröna (inkl. EVT-26/27)
- [x] `npm run lint:html` — 0 problem (gaten som failade i kön)
- [x] `npm run build` med `SITE_URL` satt — bygger rent
- [x] eslint, `lint:css`, `lint:md`, `lint:yaml`, `check:security`, `validate:camps` — alla gröna

## Effekt

När den här landar på `main` blir merge-köns bygg+lint grön igen. #817 (body-parser, säkerhetsfix) och #816 (brace-expansion) har auto-merge på och återgår då till kön mot fixad `main` → mergas → öppna PR-listan tom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gkhDy4s8kfyL5kr8M78qF

---
_Generated by [Claude Code](https://claude.ai/code/session_015gkhDy4s8kfyL5kr8M78qF)_