### PR TITLE
data: recover "eller på plats" edit for karaoke-dans description

### DIFF
--- a/source/data/2026-07-syssleback/karaoke-dans-2026-07-30-1900.yaml
+++ b/source/data/2026-07-syssleback/karaoke-dans-2026-07-30-1900.yaml
@@ -7,7 +7,7 @@ event:
   location: GA Scen
   responsible: Milo Friberg Svensson
   description: |
-    För dig som vill uppträda för publik. Anmäl er via länken och berätta vilken låt och om det är karaoke, dans eller valfritt uppträdande. Dock tidsgräns på 5 minuter.
+    För dig som vill uppträda för publik. Anmäl er via länken eller på plats och berätta vilken låt och om det är karaoke, dans eller valfritt uppträdande. Dock tidsgräns på 5 minuter.
     
   link: 'https://forms.gle/aYFhHArHmtMorWEGA'
   moved:
@@ -19,5 +19,5 @@ event:
     email: ''
   meta:
     created_at: 2026-07-27 15:08
-    updated_at: 2026-07-29 10:12
+    updated_at: 2026-07-29 10:13
     location_set_at: 2026-07-27 15:08


### PR DESCRIPTION
## Vad

Lägger till "eller på plats" i beskrivningen för eventet `karaoke-dans-2026-07-30-1900`, ovanpå aktuell `main`.

## Varför

Den fastnade dubbletten #965 innehöll denna textändring men kunde inte mergas — den baserades på ett äldre läge av `main` och hamnade i konflikt efter att eventet flyttats/omschemalagts. Den enda äkta ändringen (tillägget "eller på plats") återskapas här utan att röra flytten eller schemat.

## Ändring

- `source/data/2026-07-syssleback/karaoke-dans-2026-07-30-1900.yaml`
  - `description`: "Anmäl er via länken **eller på plats** och berätta..."
  - `meta.updated_at`: `2026-07-29 10:13`

#965 stängs som dubblett.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nkw9qujP8jJV5XcqZZobg

---
_Generated by [Claude Code](https://claude.ai/code/session_012nkw9qujP8jJV5XcqZZobg)_