### PR TITLE
Prevent duplicate edit PRs by disabling all edit-form controls during writes

### DIFF
--- a/docs/02-requirements/add-edit-forms.md
+++ b/docs/02-requirements/add-edit-forms.md
@@ -603,6 +603,49 @@ before the backup step runs.
 
 ---
 
+## 122. Double-Submit Protection on the Edit Form
+
+Context: the edit form (`redigera.html`) exposes three controls that write to
+the event data: the "Spara ändringar" submit button inside the form's
+`<fieldset>`, and — in the header actions area **outside** the `<fieldset>` —
+the "Ställ in aktiviteten" / "Återställ aktiviteten" toggle and the
+"Radera aktivitet" button. Each write goes through the edit-event API, which
+opens and auto-merges a pull request. When a control can be activated a second
+time before the first request resolves, the API produces a second, identical
+pull request. Because the cancel/restore toggle only flips its remembered state
+on success, two quick activations both send the same `cancelled` value, so one
+activity ends up with two duplicate edit pull requests — one of which is left
+open and un-mergeable.
+
+### 122.1 In-flight lock covers every mutating control (site requirements)
+
+- While an edit-form write (save, cancel/restore toggle, or delete) is in
+  progress, the fieldset, the "Spara ändringar" submit button, the
+  "Ställ in aktiviteten" / "Återställ aktiviteten" toggle button, and the
+  "Radera aktivitet" button are all disabled. <!-- 02-§122.1 -->
+- The edit form's `lock()` disables all four controls and `unlock()` re-enables
+  all four; disabling the `<fieldset>` alone is not sufficient because the
+  toggle and delete buttons sit outside it. <!-- 02-§122.2 -->
+
+### 122.2 Re-entry guard (site requirements)
+
+- The edit form tracks whether a write is in progress. While one is in
+  progress, activating the submit handler, the cancel/restore toggle, or the
+  delete action starts no second request. <!-- 02-§122.3 -->
+- The in-progress flag is cleared when the form is unlocked after an error, so
+  the user can retry; a successful write leaves the controls disabled behind the
+  terminal success modal. <!-- 02-§122.4 -->
+
+### 122.3 Delete flow parity (site requirements)
+
+- Confirming a deletion locks the form for the duration of the request — the
+  same lock used by saving and by the cancel/restore toggle — and the delete
+  error-retry path unlocks it again. <!-- 02-§122.5 -->
+
+---
+
+---
+
 ## 54. Midnight-Crossing Events
 
 Events at a summer camp can legitimately cross midnight (e.g. an evening party

--- a/docs/03-architecture/forms-and-api.md
+++ b/docs/03-architecture/forms-and-api.md
@@ -419,6 +419,28 @@ form). Setting `fieldset.disabled = true` disables all child inputs and the
 submit button atomically. CSS communicates the locked state visually via
 `opacity` and `cursor: not-allowed` on `fieldset:disabled`.
 
+### Double-submit protection across all mutating controls (02-§122)
+
+The edit form has three controls that each trigger an edit-event API write:
+the "Spara ändringar" submit button (inside the `<fieldset>`), the
+"Ställ in aktiviteten" / "Återställ aktiviteten" toggle (`#btn-cancel`), and the
+"Radera aktivitet" button (`#btn-delete`). The toggle and delete buttons live in
+the header actions area, **outside** the `<fieldset>`, so `fieldset.disabled`
+does not reach them — leaving them clickable while a request is in flight. A
+second activation before the first request resolves makes the API open a second,
+identical pull request (the duplicate/stuck-PR failure mode).
+
+`lock()` therefore disables the fieldset, the submit button, `#btn-cancel`, and
+`#btn-delete`; `unlock()` re-enables all four. A module-level `submitting` flag
+guards re-entry: the submit handler, `submitCancelToggle()`, and
+`performDelete()` return early when a write is already in progress, so even a
+click that slips past the disabled state before the browser applies it starts no
+second request. `submitting` is set in `lock()` and cleared in `unlock()`, so a
+successful write leaves the controls disabled behind the terminal success modal,
+while an error's "Försök igen" path unlocks and clears the flag for a retry. The
+delete flow calls `lock()` when the deletion is confirmed and unlocks on its own
+error-retry path, giving it the same protection as saving and the toggle.
+
 ### Edit progress modal
 
 The modal uses the same `#submit-modal` HTML skeleton and CSS as the add form —

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1957,3 +1957,17 @@ Doc ref: `02-requirements/design-and-content.md §121`;
 | `02-§121.12` | covered | HUBB-12: no inline `.hero-hub-banner[data-opens]` script; the banner is static markup with no new JS file |
 | `02-§121.13` | implemented | No dependency added to `package.json`; the icon is inline SVG and reuses the existing `EDQHUB_ICON` constant — review checkpoint |
 | `02-§121.14` | covered | HUBB-14, HUBB-15: the "Till EDQ Hub" call-to-action is a `<span class="hero-hub-banner-btn">` inside the single card anchor (no nested link/button); `html-validate` (`lint:html`) passes on the built page |
+
+### §122 — Double-Submit Protection on the Edit Form
+
+Doc ref: `02-requirements/add-edit-forms.md §122`;
+`03-architecture/forms-and-api.md §31` (edit form field locking, double-submit
+protection).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§122.1` | gap | EDS-01/-02: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. Visual disabled appearance is a manual/browser checkpoint |
+| `02-§122.2` | gap | EDS-03: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
+| `02-§122.3` | gap | EDS-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
+| `02-§122.4` | gap | EDS-07: `submitting` is set in `lock()` and cleared in `unlock()`; the error "Försök igen" paths call `unlock()` so a retry is possible, while the success modal is terminal (controls stay disabled). Manual/browser checkpoint |
+| `02-§122.5` | gap | EDS-08: `performDelete()` calls `lock()` on confirm and the delete error-retry path calls `unlock()`, matching the save and cancel/restore toggle flows |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1966,7 +1966,7 @@ protection).
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§122.1` | covered | EDS-01/-02: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. Visual disabled appearance is a manual/browser checkpoint |
+| `02-§122.1` | covered | EDS-01: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. EDS-10: `.btn-cancel-activity:disabled`/`.btn-delete-pill:disabled` dim to `opacity: 0.5` (matching the disabled fieldset, §19.2). Live appearance is a manual/browser checkpoint |
 | `02-§122.2` | covered | EDS-03: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
 | `02-§122.3` | covered | EDS-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
 | `02-§122.4` | covered | EDS-07: `submitting` is set in `lock()` and cleared in `unlock()`; the error "Försök igen" paths call `unlock()` so a retry is possible, while the success modal is terminal (controls stay disabled). Manual/browser checkpoint |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1967,7 +1967,7 @@ protection).
 | ID | Status | Notes |
 | --- | --- | --- |
 | `02-§122.1` | covered | EDS-01: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. EDS-10: `.btn-cancel-activity:disabled`/`.btn-delete-pill:disabled` dim to `opacity: 0.5` (matching the disabled fieldset, §19.2). Live appearance is a manual/browser checkpoint |
-| `02-§122.2` | covered | EDS-03: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
-| `02-§122.3` | covered | EDS-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
+| `02-§122.2` | covered | EDS-02: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
+| `02-§122.3` | covered | EDS-03/-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
 | `02-§122.4` | covered | EDS-07: `submitting` is set in `lock()` and cleared in `unlock()`; the error "Försök igen" paths call `unlock()` so a retry is possible, while the success modal is terminal (controls stay disabled). Manual/browser checkpoint |
-| `02-§122.5` | covered | EDS-08: `performDelete()` calls `lock()` on confirm and the delete error-retry path calls `unlock()`, matching the save and cancel/restore toggle flows |
+| `02-§122.5` | covered | EDS-08/-09: `performDelete()` calls `lock()` on confirm and the delete error-retry path (`setDeleteModalError`) calls `unlock()`, matching the save and cancel/restore toggle flows |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1966,8 +1966,8 @@ protection).
 
 | ID | Status | Notes |
 | --- | --- | --- |
-| `02-§122.1` | gap | EDS-01/-02: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. Visual disabled appearance is a manual/browser checkpoint |
-| `02-§122.2` | gap | EDS-03: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
-| `02-§122.3` | gap | EDS-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
-| `02-§122.4` | gap | EDS-07: `submitting` is set in `lock()` and cleared in `unlock()`; the error "Försök igen" paths call `unlock()` so a retry is possible, while the success modal is terminal (controls stay disabled). Manual/browser checkpoint |
-| `02-§122.5` | gap | EDS-08: `performDelete()` calls `lock()` on confirm and the delete error-retry path calls `unlock()`, matching the save and cancel/restore toggle flows |
+| `02-§122.1` | covered | EDS-01/-02: `redigera.js` `lock()` disables `submitBtn`, `cancelBtn`, and `deleteBtn` in addition to `fieldset`; the header toggle/delete buttons sit outside the `<fieldset>`. Visual disabled appearance is a manual/browser checkpoint |
+| `02-§122.2` | covered | EDS-03: `unlock()` re-enables all four controls (fieldset, submit, cancel toggle, delete) |
+| `02-§122.3` | covered | EDS-04/-05/-06: a module-level `submitting` flag guards re-entry — the submit handler, `submitCancelToggle()`, and `performDelete()` return early when a write is already in progress |
+| `02-§122.4` | covered | EDS-07: `submitting` is set in `lock()` and cleared in `unlock()`; the error "Försök igen" paths call `unlock()` so a retry is possible, while the success modal is terminal (controls stay disabled). Manual/browser checkpoint |
+| `02-§122.5` | covered | EDS-08: `performDelete()` calls `lock()` on confirm and the delete error-retry path calls `unlock()`, matching the save and cancel/restore toggle flows |

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -1431,6 +1431,17 @@ h1.is-cancelled {
   outline-offset: 2px;
 }
 
+/* While an edit-form write is in flight the whole form is locked (02-§122).
+   These pills sit outside the <fieldset>, so JS disables them directly; give
+   them the same dimmed, inert look the disabled fieldset gets (02-§19.2), so a
+   locked button never reads as clickable. pointer-events:none also suppresses
+   the hover recolor while disabled. */
+.btn-cancel-activity:disabled,
+.btn-delete-pill:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 
 .delete-actions {
   display: flex;

--- a/source/assets/js/client/redigera.js
+++ b/source/assets/js/client/redigera.js
@@ -184,16 +184,31 @@
     });
   }
 
-  // ── Form lock / unlock ────────────────────────────────────────────────────────
+  // ── Form lock / unlock (02-§122) ──────────────────────────────────────────────
 
+  // True while an edit-form write (save, cancel/restore toggle, or delete) is
+  // in flight. The submit handler, submitCancelToggle(), and performDelete()
+  // all bail out when it is set, so a second activation cannot open a duplicate
+  // pull request even if a click slips past the disabled state.
+  var submitting = false;
+
+  // The cancel toggle (#btn-cancel) and delete button (#btn-delete) live in the
+  // header actions area, outside the <fieldset>, so fieldset.disabled does not
+  // reach them — they must be disabled explicitly (02-§122.1).
   function lock() {
+    submitting = true;
     fieldset.disabled = true;
     submitBtn.disabled = true;
+    if (cancelBtn) cancelBtn.disabled = true;
+    if (deleteBtn) deleteBtn.disabled = true;
   }
 
   function unlock() {
+    submitting = false;
     fieldset.disabled = false;
     submitBtn.disabled = false;
+    if (cancelBtn) cancelBtn.disabled = false;
+    if (deleteBtn) deleteBtn.disabled = false;
   }
 
   // ── Cookie helper ────────────────────────────────────────────────────────────
@@ -373,6 +388,7 @@
   // confirmation step. `cancelledState` only flips on success.
   function submitCancelToggle() {
     if (!form) return;
+    if (submitting) return; // a write is already in flight (02-§122.3)
     var els = form.elements;
     var target = !cancelledState;
     var body = {
@@ -757,6 +773,7 @@
 
   if (form) {
     form.addEventListener('submit', function (e) {
+      if (submitting) return; // a write is already in flight (02-§122.3)
       e.preventDefault();
       clearAllErrors();
 
@@ -947,6 +964,7 @@
     focusFirstInModal();
     document.getElementById('modal-retry-delete-btn').addEventListener('click', function () {
       closeModal();
+      unlock(); // re-enable the controls so the user can retry (02-§122.5)
       if (deleteBtn) deleteBtn.focus();
     });
   }
@@ -969,11 +987,13 @@
 
   function performDelete() {
     if (!form) return;
+    if (submitting) return; // a write is already in flight (02-§122.3)
     var els = form.elements;
     var id = els.id.value;
     var title = els.title.value || '';
     var date = els.date.value || '';
 
+    lock(); // disable all mutating controls for the duration (02-§122.5)
     setDeleteModalLoading();
 
     var deleteBody = { id: id, date: date };

--- a/tests/edit-double-submit.test.js
+++ b/tests/edit-double-submit.test.js
@@ -32,6 +32,11 @@ const EDIT_SRC = fs.readFileSync(
   'utf8',
 );
 
+const CSS_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'assets', 'cs', 'style.css'),
+  'utf8',
+);
+
 // Extract a named function's body (from its opening brace to the matching
 // close), so a guard/disable assertion is scoped to the right function rather
 // than matching anywhere in the file.
@@ -120,5 +125,18 @@ describe('02-§122.5 — delete flow parity (EDS-08)', () => {
     const body = funcBody(EDIT_SRC, 'setDeleteModalError');
     assert.ok(body, 'setDeleteModalError() found');
     assert.match(body, /\bunlock\(\);/, 'delete retry calls unlock()');
+  });
+});
+
+describe('02-§122.1 — disabled header pills are visually dimmed (EDS-10)', () => {
+  it('EDS-10: the cancel toggle and delete pill have a :disabled dim rule', () => {
+    // The header pills sit outside the <fieldset>, so they need their own
+    // disabled styling to match the dimmed fieldset (02-§19.2) rather than
+    // reading as clickable while locked.
+    assert.match(
+      CSS_SRC,
+      /\.btn-cancel-activity:disabled\s*,\s*\.btn-delete-pill:disabled\s*\{[^}]*opacity:\s*0\.5/,
+      ':disabled rule dims both header pills',
+    );
   });
 });

--- a/tests/edit-double-submit.test.js
+++ b/tests/edit-double-submit.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// Tests for 02-§122 — Double-submit protection on the edit form.
+//
+// The edit form's three mutating controls each trigger an edit-event API write
+// that opens and auto-merges a pull request: "Spara ändringar" (submit, inside
+// the <fieldset>), the "Ställ in aktiviteten" / "Återställ aktiviteten" toggle
+// (#btn-cancel), and "Radera aktivitet" (#btn-delete). The toggle and delete
+// buttons sit outside the <fieldset>, so disabling the fieldset alone leaves
+// them clickable — a second activation before the first request resolves makes
+// the API open a duplicate pull request (the stuck-PR failure mode). lock()
+// therefore disables all four controls, a `submitting` flag guards re-entry,
+// and unlock() restores everything on the error-retry paths.
+//
+// All behaviour is browser-only DOM manipulation that cannot run in Node.js,
+// so these are source-code structural checks (same convention as
+// tests/submit-progress.test.js). The live disabled appearance and click
+// behaviour are manual checkpoints in the traceability matrix:
+//   EDS-M01 (02-§122.1): open redigera.html, press "Ställ in aktiviteten", and
+//     confirm the button, delete button, submit button, and fields are all
+//     disabled while the modal is open.
+//   EDS-M02 (02-§122.4): disconnect the API, submit, press "Försök igen", and
+//     confirm every control is usable again.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const EDIT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'source', 'assets', 'js', 'client', 'redigera.js'),
+  'utf8',
+);
+
+// Extract a named function's body (from its opening brace to the matching
+// close), so a guard/disable assertion is scoped to the right function rather
+// than matching anywhere in the file.
+function funcBody(src, name) {
+  const start = src.indexOf('function ' + name);
+  if (start === -1) return '';
+  const open = src.indexOf('{', start);
+  if (open === -1) return '';
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  return '';
+}
+
+describe('02-§122.1 — lock() disables every mutating control (EDS-01)', () => {
+  const lock = funcBody(EDIT_SRC, 'lock');
+
+  it('EDS-01: lock() disables submit, cancel toggle, and delete buttons', () => {
+    assert.ok(lock, 'lock() function found');
+    assert.match(lock, /fieldset\.disabled\s*=\s*true/, 'fieldset disabled');
+    assert.match(lock, /submitBtn\.disabled\s*=\s*true/, 'submit button disabled');
+    assert.match(lock, /cancelBtn\.disabled\s*=\s*true/, 'cancel toggle disabled');
+    assert.match(lock, /deleteBtn\.disabled\s*=\s*true/, 'delete button disabled');
+  });
+});
+
+describe('02-§122.2 — unlock() re-enables every mutating control (EDS-02)', () => {
+  const unlock = funcBody(EDIT_SRC, 'unlock');
+
+  it('EDS-02: unlock() re-enables submit, cancel toggle, and delete buttons', () => {
+    assert.ok(unlock, 'unlock() function found');
+    assert.match(unlock, /fieldset\.disabled\s*=\s*false/, 'fieldset enabled');
+    assert.match(unlock, /submitBtn\.disabled\s*=\s*false/, 'submit button enabled');
+    assert.match(unlock, /cancelBtn\.disabled\s*=\s*false/, 'cancel toggle enabled');
+    assert.match(unlock, /deleteBtn\.disabled\s*=\s*false/, 'delete button enabled');
+  });
+});
+
+describe('02-§122.3 — re-entry guard blocks concurrent writes (EDS-03..06)', () => {
+  it('EDS-03: a `submitting` flag is declared', () => {
+    assert.match(EDIT_SRC, /var\s+submitting\s*=\s*false/, '`submitting` declared and seeded false');
+  });
+
+  it('EDS-04: submitCancelToggle() returns early while a write is in progress', () => {
+    const body = funcBody(EDIT_SRC, 'submitCancelToggle');
+    assert.ok(body, 'submitCancelToggle() found');
+    assert.match(body, /if\s*\(submitting\)\s*return;/, 'guard present in cancel toggle');
+  });
+
+  it('EDS-05: the submit handler returns early while a write is in progress', () => {
+    // Anonymous submit handler: anchor on its registration and require the
+    // guard as the first statement.
+    assert.match(
+      EDIT_SRC,
+      /addEventListener\('submit',\s*function\s*\(e\)\s*\{\s*if\s*\(submitting\)\s*return;/,
+      'guard is the first statement of the submit handler',
+    );
+  });
+
+  it('EDS-06: performDelete() returns early while a write is in progress', () => {
+    const body = funcBody(EDIT_SRC, 'performDelete');
+    assert.ok(body, 'performDelete() found');
+    assert.match(body, /if\s*\(submitting\)\s*return;/, 'guard present in delete flow');
+  });
+});
+
+describe('02-§122.4 — the flag tracks the in-flight state (EDS-07)', () => {
+  it('EDS-07: lock() sets submitting=true and unlock() clears it', () => {
+    assert.match(funcBody(EDIT_SRC, 'lock'), /submitting\s*=\s*true/, 'lock sets the flag');
+    assert.match(funcBody(EDIT_SRC, 'unlock'), /submitting\s*=\s*false/, 'unlock clears the flag');
+  });
+});
+
+describe('02-§122.5 — delete flow parity (EDS-08)', () => {
+  it('EDS-08: performDelete() locks the form for the duration of the request', () => {
+    const body = funcBody(EDIT_SRC, 'performDelete');
+    assert.match(body, /\block\(\);/, 'performDelete calls lock()');
+  });
+
+  it('EDS-09: the delete error-retry path unlocks the form', () => {
+    const body = funcBody(EDIT_SRC, 'setDeleteModalError');
+    assert.ok(body, 'setDeleteModalError() found');
+    assert.match(body, /\bunlock\(\);/, 'delete retry calls unlock()');
+  });
+});


### PR DESCRIPTION
## Bakgrund

PR #991 fastnade som en olöslig dublett av #990: båda satte `cancelled: true` på samma aktivitet, skapade ~45 s isär. Rotorsaken är att "Ställ in aktiviteten"- (`#btn-cancel`) och "Radera aktivitet"-knapparna (`#btn-delete`) ligger **utanför** `<fieldset>`, så formulärets `lock()` (som bara stänger av fieldset + submit-knappen) lämnade dem klickbara medan en request pågick. Ett andra klick — innan `cancelledState` hunnit flippas vid success — skickade samma `cancelled`-värde igen, vilket öppnade ännu en identisk pull request.

## Ändring

- `lock()` / `unlock()` stänger nu av / återaktiverar **alla fyra** muterande kontroller: fieldset, "Spara ändringar", cancel/restore-toggeln och radera-knappen.
- En `submitting`-flagga blockerar återinträde — submit-handlern, `submitCancelToggle()` och `performDelete()` avbryter direkt om en skrivning redan pågår.
- Radera-flödet låser nu formuläret under hela requesten (som spara och toggeln), och dess "Försök igen"-väg låser upp igen.
- De två header-pillren får en `:disabled`-stil (`opacity: 0.5` + `pointer-events: none`) så en låst knapp inte längre ser klickbar ut — konsekvent med det dimmade fieldset:et (§19.2).

## Krav & dokumentation

- Nytt krav **02-§122** (dubbelsubmit-skydd) i `docs/02-requirements/add-edit-forms.md`.
- Arkitekturnot i `docs/03-architecture/forms-and-api.md` (§31, edit form field locking).
- Traceability §122.1–.5 i `docs/99-traceability/02-requirements.md`, status `covered`.

## Testplan

- [x] 10 nya källkods-/CSS-strukturtester (EDS-01..10) i `tests/edit-double-submit.test.js`
- [x] `npm test` — 2258 tester passerar
- [x] `npm run lint` (eslint), `lint:css` (stylelint), `lint:md` (markdownlint) rena
- [ ] Manuell webbläsarkontroll: öppna `/redigera.html?id=…`, klicka "Ställ in aktiviteten" och bekräfta att de tre knapparna + fälten är utgråade medan modalen visas; utlös ett fel och bekräfta att "Försök igen" återaktiverar allt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgAm1MaaEaVTbMPjkHM4N1)_