### PR TITLE
Recover title edit from stuck PR #1011 (experiment-aktivitet)

### DIFF
--- a/source/data/2026-07-syssleback/experiment-dar-du-far-labba-2026-08-01-1300.yaml
+++ b/source/data/2026-07-syssleback/experiment-dar-du-far-labba-2026-08-01-1300.yaml
@@ -1,6 +1,6 @@
 event:
   id: experiment-dar-du-far-labba-2026-08-01-1300
-  title: Experiment där du får labba
+  title: Experiment där du får labba – hjälp sökes
   date: '2026-08-01'
   start: '13:00'
   end: '13:30'


### PR DESCRIPTION
## Bakgrund

Edit-PR #1011 fastnade `dirty` genom samma double-submit-mekanism som #991: en andra edit-PR skapad ~1 min efter #1010, från samma ursprungsversion. Till skillnad från #991 var den **inte** identisk — #1010 (mergad) la till beskrivningstext + en edqhub-länk, medan #1011 bar en **titeländring** som inte fanns i #1010. Att bara stänga #1011 hade tappat titeländringen.

## Ändring

Sätter titeln på `experiment-dar-du-far-labba-2026-08-01-1300` till **"Experiment där du får labba – hjälp sökes"**, ovanpå nuvarande `main` (som redan har beskrivningen + länken från #1010). Slutresultatet blir alltså allt användaren avsåg.

#1011 stängs som ersatt av denna PR.

## Verifiering

- [x] `node source/scripts/lint-yaml.js …` — fragmentet validerar
- Data-only ändring i `source/data/` → CI hoppar över build/lint/test enligt `ci.yml` (CL-§9.4); deploy sker via `event-data-deploy-post-merge.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgAm1MaaEaVTbMPjkHM4N1)_