### PR TITLE
Dedup edit-event PRs: no-op guard + one open PR per activity

### DIFF
--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -210,25 +210,11 @@ final class GitHub
             throw new \RuntimeException("Event not found: {$eventId}");
         }
 
-        // If an edit pull request for this event is already open, accumulate the
-        // new change on top of ITS current content so earlier unmerged edits are
-        // preserved, not overwritten (02-§122.5).
+        // If an edit pull request for this event is already open, accumulate onto
+        // it rather than opening a rival (02-§122.4, §122.5).
         $openPr = $this->findOpenPrForBranch($branchName);
         if ($openPr !== null) {
-            $branchFrag = $this->getFileMaybe($fragPath, $branchName) ?? $mainFrag;
-            [$baseContent, $baseSha] = $branchFrag;
-            $baseDoc = Yaml::parse($baseContent);
-            $baseEvent = (is_array($baseDoc) && is_array($baseDoc['event'] ?? null)) ? $baseDoc['event'] : $mainDoc['event'];
-            $patched = self::patchEventObject($baseEvent, $updates, $now);
-            $content = self::buildFragmentYaml($patched) . "\n";
-            self::assertFragmentYamlValid($content, $eventId);
-            // Nothing new relative to what the open PR already carries → no commit.
-            if (self::fragmentEqualsIgnoringUpdatedAt($baseContent, $content)) {
-                return;
-            }
-            $this->putFile($fragPath, $content, $baseSha, $commitMsg, $branchName);
-            // Re-nudge the merge queue; best-effort (02-§113.1, §113.4).
-            $this->enqueueBestEffort($openPr['node_id']);
+            $this->accumulateEditOnto($openPr, $eventId, $fragPath, $branchName, $updates, $now, $commitMsg, $mainFrag, $mainDoc);
             return;
         }
 
@@ -243,17 +229,53 @@ final class GitHub
         }
 
         $mainSha = $this->getMainSha();
-        // A branch may linger from an already-merged edit PR (auto-delete off);
-        // reset it onto main rather than treating it as open (02-§122.7).
-        if ($this->getRefMaybe($branchName) !== null) {
-            $this->updateRef($branchName, $mainSha);
-        } else {
+        // Create the deterministic branch. If it already exists, another edit
+        // raced us or a stale branch lingers from an already-merged PR
+        // (auto-delete off). Only then look closer — this avoids resetting a
+        // branch a concurrent request is mid-way through creating.
+        try {
             $this->createBranch($branchName, $mainSha);
+        } catch (\RuntimeException) {
+            $racePr = $this->findOpenPrForBranch($branchName);
+            if ($racePr !== null) {
+                $this->accumulateEditOnto($racePr, $eventId, $fragPath, $branchName, $updates, $now, $commitMsg, $mainFrag, $mainDoc);
+                return;
+            }
+            // No open PR → stale branch from an already-merged edit: reset onto
+            // main and reuse it (02-§122.7).
+            $this->updateRef($branchName, $mainSha);
         }
         $this->putFile($fragPath, $content, $mainSha0, $commitMsg, $branchName);
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar edit-event API.');
         $this->enableAutoMerge($pr['node_id']);
         // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
+        $this->enqueueBestEffort($pr['node_id']);
+    }
+
+    /**
+     * Apply an edit on top of an open edit PR's own branch content, so an earlier
+     * unmerged edit is preserved, not overwritten (02-§122.5). A change that adds
+     * nothing to what the branch already carries makes no commit.
+     *
+     * @param array{number:int,node_id:string} $pr
+     * @param array<string,mixed>              $updates
+     * @param array{string,string}             $mainFrag
+     * @param array<string,mixed>              $mainDoc
+     */
+    private function accumulateEditOnto(array $pr, string $eventId, string $fragPath, string $branchName, array $updates, string $now, string $commitMsg, array $mainFrag, array $mainDoc): void
+    {
+        $branchFrag = $this->getFileMaybe($fragPath, $branchName) ?? $mainFrag;
+        [$baseContent, $baseSha] = $branchFrag;
+        $baseDoc   = Yaml::parse($baseContent);
+        $baseEvent = (is_array($baseDoc) && is_array($baseDoc['event'] ?? null)) ? $baseDoc['event'] : $mainDoc['event'];
+        $patched   = self::patchEventObject($baseEvent, $updates, $now);
+        $content   = self::buildFragmentYaml($patched) . "\n";
+        self::assertFragmentYamlValid($content, $eventId);
+        if (self::fragmentEqualsIgnoringUpdatedAt($baseContent, $content)) {
+            return;
+        }
+        $this->putFile($fragPath, $content, $baseSha, $commitMsg, $branchName);
+        // Re-nudge the merge queue; best-effort (02-§113.1, §113.4).
         $this->enqueueBestEffort($pr['node_id']);
     }
 
@@ -705,8 +727,11 @@ final class GitHub
      */
     private function getFile(string $filePath, ?string $ref = null): array
     {
+        // $useRef is a controlled slug (main, or event-edit/<event-id>); its
+        // slash stays raw — GitHub's `ref` query accepts `/` literally and a
+        // percent-encoded slash can 404.
         $useRef  = $ref ?? $this->branch;
-        $apiPath = "/repos/{$this->owner}/{$this->repo}/contents/{$filePath}?ref=" . rawurlencode($useRef);
+        $apiPath = "/repos/{$this->owner}/{$this->repo}/contents/{$filePath}?ref={$useRef}";
         $data = $this->githubRequest('GET', $apiPath);
 
         $content = base64_decode($data['content'], true);
@@ -780,23 +805,6 @@ final class GitHub
         ]);
     }
 
-    /**
-     * Return the SHA a branch ref points at, or null when the branch does not
-     * exist (HTTP 404) — tells a live edit branch from a stale one (02-§122.7).
-     */
-    private function getRefMaybe(string $branch): ?string
-    {
-        try {
-            $data = $this->githubRequest('GET', "/repos/{$this->owner}/{$this->repo}/git/refs/heads/{$branch}");
-            return $data['object']['sha'];
-        } catch (\RuntimeException $e) {
-            if (str_starts_with($e->getMessage(), 'GitHub API 404')) {
-                return null;
-            }
-            throw $e;
-        }
-    }
-
     /** Force a branch ref onto a new commit SHA — resets a stale edit branch (02-§122.7). */
     private function updateRef(string $branch, string $sha): void
     {
@@ -815,7 +823,9 @@ final class GitHub
      */
     private function findOpenPrForBranch(string $branch): ?array
     {
-        $head = rawurlencode("{$this->owner}:{$branch}");
+        // owner and branch are controlled slugs; `:` and `/` are valid raw in a
+        // query value and are what GitHub's `head` filter (user:ref) expects.
+        $head = "{$this->owner}:{$branch}";
         $data = $this->githubRequest('GET', "/repos/{$this->owner}/{$this->repo}/pulls?head={$head}&state=open&per_page=1");
         if (is_array($data) && count($data) > 0) {
             return ['number' => $data[0]['number'], 'node_id' => $data[0]['node_id']];

--- a/api/src/GitHub.php
+++ b/api/src/GitHub.php
@@ -193,26 +193,64 @@ final class GitHub
         $camp       = $this->resolveActiveCamp();
         $now        = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i');
         $commitMsg  = "Edit event in {$camp['name']}: {$eventId}";
-        $mainSha    = $this->getMainSha();
-        $branchName = "event-edit/{$eventId}-" . time();
+        // One deterministic branch per event, so a repeated or concurrent edit
+        // reuses the same open pull request instead of opening a rival (02-§122.4).
+        $branchName = "event-edit/{$eventId}";
 
         // Edit operates only on the event's fragment file; no fragment → no
         // change, error raised (02-§109.12).
         $fragPath = self::fragmentPath($camp['file'], $eventId);
-        $frag     = $this->getFileMaybe($fragPath);
-        if ($frag === null) {
+        $mainFrag = $this->getFileMaybe($fragPath);
+        if ($mainFrag === null) {
             throw new \RuntimeException("Event not found: {$eventId}");
         }
-        [$fragContent, $fragSha] = $frag;
-        $doc = Yaml::parse($fragContent);
-        if (!is_array($doc) || !is_array($doc['event'] ?? null)) {
+        [$mainContent, $mainSha0] = $mainFrag;
+        $mainDoc = Yaml::parse($mainContent);
+        if (!is_array($mainDoc) || !is_array($mainDoc['event'] ?? null)) {
             throw new \RuntimeException("Event not found: {$eventId}");
         }
-        $patched = self::patchEventObject($doc['event'], $updates, $now);
+
+        // If an edit pull request for this event is already open, accumulate the
+        // new change on top of ITS current content so earlier unmerged edits are
+        // preserved, not overwritten (02-§122.5).
+        $openPr = $this->findOpenPrForBranch($branchName);
+        if ($openPr !== null) {
+            $branchFrag = $this->getFileMaybe($fragPath, $branchName) ?? $mainFrag;
+            [$baseContent, $baseSha] = $branchFrag;
+            $baseDoc = Yaml::parse($baseContent);
+            $baseEvent = (is_array($baseDoc) && is_array($baseDoc['event'] ?? null)) ? $baseDoc['event'] : $mainDoc['event'];
+            $patched = self::patchEventObject($baseEvent, $updates, $now);
+            $content = self::buildFragmentYaml($patched) . "\n";
+            self::assertFragmentYamlValid($content, $eventId);
+            // Nothing new relative to what the open PR already carries → no commit.
+            if (self::fragmentEqualsIgnoringUpdatedAt($baseContent, $content)) {
+                return;
+            }
+            $this->putFile($fragPath, $content, $baseSha, $commitMsg, $branchName);
+            // Re-nudge the merge queue; best-effort (02-§113.1, §113.4).
+            $this->enqueueBestEffort($openPr['node_id']);
+            return;
+        }
+
+        // No open pull request: build the edit on top of main.
+        $patched = self::patchEventObject($mainDoc['event'], $updates, $now);
         $content = self::buildFragmentYaml($patched) . "\n";
         self::assertFragmentYamlValid($content, $eventId);
-        $this->createBranch($branchName, $mainSha);
-        $this->putFile($fragPath, $content, $fragSha, $commitMsg, $branchName);
+        // No-op edit (only updated_at would change) → create no branch or PR
+        // (02-§122.1, §122.2).
+        if (self::fragmentEqualsIgnoringUpdatedAt($mainContent, $content)) {
+            return;
+        }
+
+        $mainSha = $this->getMainSha();
+        // A branch may linger from an already-merged edit PR (auto-delete off);
+        // reset it onto main rather than treating it as open (02-§122.7).
+        if ($this->getRefMaybe($branchName) !== null) {
+            $this->updateRef($branchName, $mainSha);
+        } else {
+            $this->createBranch($branchName, $mainSha);
+        }
+        $this->putFile($fragPath, $content, $mainSha0, $commitMsg, $branchName);
         $pr = $this->createPullRequest($commitMsg, $branchName, 'Automatically created by the SB Sommar edit-event API.');
         $this->enableAutoMerge($pr['node_id']);
         // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
@@ -665,9 +703,10 @@ final class GitHub
     /**
      * @return array{string,string} [content, sha]
      */
-    private function getFile(string $filePath): array
+    private function getFile(string $filePath, ?string $ref = null): array
     {
-        $apiPath = "/repos/{$this->owner}/{$this->repo}/contents/{$filePath}?ref={$this->branch}";
+        $useRef  = $ref ?? $this->branch;
+        $apiPath = "/repos/{$this->owner}/{$this->repo}/contents/{$filePath}?ref=" . rawurlencode($useRef);
         $data = $this->githubRequest('GET', $apiPath);
 
         $content = base64_decode($data['content'], true);
@@ -678,14 +717,15 @@ final class GitHub
     /**
      * Like getFile, but returns null when the file does not exist (HTTP 404)
      * instead of throwing — used to decide whether an event lives in a fragment
-     * file (02-§109.9).
+     * file (02-§109.9). `$ref` defaults to main; pass an edit branch to read that
+     * branch's version of the file (02-§122.5).
      *
      * @return array{string,string}|null [content, sha] or null
      */
-    private function getFileMaybe(string $filePath): ?array
+    private function getFileMaybe(string $filePath, ?string $ref = null): ?array
     {
         try {
-            return $this->getFile($filePath);
+            return $this->getFile($filePath, $ref);
         } catch (\RuntimeException $e) {
             if (str_starts_with($e->getMessage(), 'GitHub API 404')) {
                 return null;
@@ -738,6 +778,60 @@ final class GitHub
             'ref' => "refs/heads/{$name}",
             'sha' => $sha,
         ]);
+    }
+
+    /**
+     * Return the SHA a branch ref points at, or null when the branch does not
+     * exist (HTTP 404) — tells a live edit branch from a stale one (02-§122.7).
+     */
+    private function getRefMaybe(string $branch): ?string
+    {
+        try {
+            $data = $this->githubRequest('GET', "/repos/{$this->owner}/{$this->repo}/git/refs/heads/{$branch}");
+            return $data['object']['sha'];
+        } catch (\RuntimeException $e) {
+            if (str_starts_with($e->getMessage(), 'GitHub API 404')) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    /** Force a branch ref onto a new commit SHA — resets a stale edit branch (02-§122.7). */
+    private function updateRef(string $branch, string $sha): void
+    {
+        $this->githubRequest('PATCH', "/repos/{$this->owner}/{$this->repo}/git/refs/heads/{$branch}", [
+            'sha'   => $sha,
+            'force' => true,
+        ]);
+    }
+
+    /**
+     * Return the open pull request whose head is $branch, or null when none is
+     * open. With one deterministic branch per event there is at most one
+     * (02-§122.4).
+     *
+     * @return array{number:int,node_id:string}|null
+     */
+    private function findOpenPrForBranch(string $branch): ?array
+    {
+        $head = rawurlencode("{$this->owner}:{$branch}");
+        $data = $this->githubRequest('GET', "/repos/{$this->owner}/{$this->repo}/pulls?head={$head}&state=open&per_page=1");
+        if (is_array($data) && count($data) > 0) {
+            return ['number' => $data[0]['number'], 'node_id' => $data[0]['node_id']];
+        }
+        return null;
+    }
+
+    /**
+     * Compare two fragment YAML strings ignoring the `updated_at:` line. Pure so
+     * it can be unit-tested. An edit that changes nothing but the timestamp is a
+     * no-op and must not open a pull request (02-§122.1, §122.2).
+     */
+    public static function fragmentEqualsIgnoringUpdatedAt(string $a, string $b): bool
+    {
+        $strip = static fn (string $s): string => trim(preg_replace('/^[ \t]*updated_at:.*$/m', '', $s));
+        return $strip($a) === $strip($b);
     }
 
     /**

--- a/api/tests/GitHubTest.php
+++ b/api/tests/GitHubTest.php
@@ -467,4 +467,27 @@ final class GitHubTest extends TestCase
     {
         $this->assertStringNotContainsString('location_set_at:', GitHub::buildFragmentYaml(self::baseEvent()));
     }
+
+    // ── 02-§122 — no-op comparison parity (mirrors DEDUPE-01..03) ─────────────
+
+    public function testFragmentEqualsIgnoringUpdatedAtTrueWhenOnlyTimestampDiffers(): void
+    {
+        $a = "event:\n  title: Foo\n  cancelled: false\n  meta:\n    updated_at: 2026-08-01 09:00\n";
+        $b = "event:\n  title: Foo\n  cancelled: false\n  meta:\n    updated_at: 2026-08-01 12:34\n";
+        $this->assertTrue(GitHub::fragmentEqualsIgnoringUpdatedAt($a, $b));
+    }
+
+    public function testFragmentEqualsIgnoringUpdatedAtFalseWhenRealFieldDiffers(): void
+    {
+        $a = "event:\n  title: Foo\n  meta:\n    updated_at: 2026-08-01 09:00\n";
+        $b = "event:\n  title: Bar\n  meta:\n    updated_at: 2026-08-01 12:00\n";
+        $this->assertFalse(GitHub::fragmentEqualsIgnoringUpdatedAt($a, $b));
+    }
+
+    public function testFragmentEqualsIgnoringUpdatedAtFalseWhenCancelledFlips(): void
+    {
+        $a = "event:\n  title: Foo\n  cancelled: false\n  meta:\n    updated_at: 2026-08-01 09:00\n";
+        $b = "event:\n  title: Foo\n  cancelled: true\n  meta:\n    updated_at: 2026-08-01 12:00\n";
+        $this->assertFalse(GitHub::fragmentEqualsIgnoringUpdatedAt($a, $b));
+    }
 }

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -947,8 +947,11 @@ pull request.
 - When the patched event is identical to the current state on `main` apart from
   `meta.updated_at`, the edit is a no-op: no branch and no pull request are
   created, and the API returns success. <!-- 02-§122.2 -->
-- The no-op check runs synchronously before the success response is sent, in
-  both the PHP runtime and the Node runtime. <!-- 02-§122.3 -->
+- The no-op check is part of the edit operation itself and runs before any
+  branch or pull request is created, so no redundant pull request is ever
+  opened. This holds in both runtimes regardless of when the HTTP response is
+  sent (the PHP edit is synchronous with the response; the Node edit runs in a
+  background task, as the edit write already does). <!-- 02-§122.3 -->
 
 ### 122.3 At most one open edit pull request per activity (site requirements)
 

--- a/docs/02-requirements/event-data.md
+++ b/docs/02-requirements/event-data.md
@@ -917,6 +917,59 @@ error.
   it is logged for manual attention rather than closed silently, so the residual
   edge stays visible. <!-- 02-§111.9 -->
 
+## 122. Edit Duplicate Hardening
+
+### 122.1 Context
+
+The edit-event API (`POST /edit-event`) rewrites an activity's fragment file on
+a fresh branch and opens an auto-merging pull request (§109.4). Each call names
+its branch `event-edit/<id>-<timestamp>`, so every save opens a separate pull
+request — including when a user repeats a save because the previous one has not
+yet appeared on the live site (an edit takes up to a few minutes to deploy, and
+a cached page can show the old state even longer). When two edit pull requests
+for the same activity are open at once, the first merges and the second is left
+behind: redundant when it carried the same change, or un-mergeable (`dirty`) and
+needing a maintainer to close it by hand when the two carried different changes
+from the same base (observed as #990/#991 and #1010/#1011).
+
+The empty-diff cleanup of §111.7 does not help here: it covers only `event/*`
+add branches, and because every edit bumps `meta.updated_at`, an edit pull
+request's net diff against `main` is never empty. The id formula and the
+fragment-per-event model (§109) are unchanged. The desired state is that
+repeated or concurrent edits of one activity never leave a stuck or redundant
+pull request.
+
+### 122.2 No-op edits create no pull request (site requirements)
+
+- Before any branch or pull request is created, the edit flow compares the
+  patched event to the activity's current state on `main`, ignoring
+  `meta.updated_at`. <!-- 02-§122.1 -->
+- When the patched event is identical to the current state on `main` apart from
+  `meta.updated_at`, the edit is a no-op: no branch and no pull request are
+  created, and the API returns success. <!-- 02-§122.2 -->
+- The no-op check runs synchronously before the success response is sent, in
+  both the PHP runtime and the Node runtime. <!-- 02-§122.3 -->
+
+### 122.3 At most one open edit pull request per activity (site requirements)
+
+- At any time there is at most one open edit pull request per
+  activity. <!-- 02-§122.4 -->
+- When an activity already has an open edit pull request, a further edit updates
+  that pull request in place rather than opening a second one; the further edit
+  is applied on top of the pull request's current content, so changes from
+  earlier unmerged edits are preserved, not overwritten. <!-- 02-§122.5 -->
+- When an activity has no open edit pull request, an edit opens a new one from
+  the current `main`. <!-- 02-§122.6 -->
+- A stale edit branch left behind by an already-merged or closed edit pull
+  request is not treated as an open pull request; an edit that finds such a
+  branch bases its change on the current `main`. <!-- 02-§122.7 -->
+
+### 122.4 Runtime parity (site requirements)
+
+- The no-op check and the single-open-pull-request behaviour hold identically in
+  the PHP runtime (`api/src/GitHub.php`) and the Node runtime
+  (`source/api/github.js`). <!-- 02-§122.8 -->
+
 ## 112. Stranded Auto-Merge Recovery
 
 ### 112.1 Context

--- a/docs/02-requirements/index.md
+++ b/docs/02-requirements/index.md
@@ -21,7 +21,7 @@ Sections §1 and §1a (audiences, crawler policy) are kept here because they fra
 | [`pages-navigation.md`](./pages-navigation.md) | Pages and Navigation | §2, §3, §11, §17, §22, §24, §35, §61, §70, §71, §72, §74, §75, §79, §114, §115 |
 | [`schedule-and-detail.md`](./schedule-and-detail.md) | Schedule and Activity Detail | §4, §5, §15, §36, §45, §46, §56, §59 |
 | [`add-edit-forms.md`](./add-edit-forms.md) | Add and Edit Forms | §6, §7, §8, §9, §10, §19, §20, §26, §27, §48, §53, §54, §57, §58, §80, §81, §82, §85, §89, §90, §99, §101 |
-| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111, §112 |
+| [`event-data.md`](./event-data.md) | Event Data | §16, §18, §21, §28, §29, §34, §37, §42, §107, §109, §110, §111, §112, §122 |
 | [`build-deploy.md`](./build-deploy.md) | Build and Deploy | §23, §32, §33, §40, §41, §43, §44, §50, §51, §52, §60, §62, §97, §103, §108 |
 | [`caching-performance.md`](./caching-performance.md) | Caching and Performance | §25, §38, §65, §66, §67, §68, §69, §77, §78, §86 |
 | [`platform-security.md`](./platform-security.md) | Platform and Security | §12, §13, §14, §39, §49, §63, §73, §83, §84, §87, §88, §91, §92, §93, §95, §96, §100, §102, §104, §105, §106 |

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -245,15 +245,23 @@ one edit branch per activity. Before creating anything, the flow calls
   unmerged edit is preserved rather than overwritten, and the commit lands on the
   existing branch — updating the open PR instead of opening a rival (02-§122.5).
   A no-op relative to the branch content adds no commit.
-- **No edit PR is open** → the edit is built on top of `main`. If a branch of that
-  name lingers from an already-merged edit PR (auto-delete off), it is reset onto
-  `main` with `updateRef(..., force)` rather than treated as open; otherwise a
-  fresh branch is created (`getRefMaybe` distinguishes the two, 02-§122.7). Then
-  the PR is opened with auto-merge as before.
+- **No edit PR is open** → the edit is built on top of `main` and the branch is
+  created. If `createBranch` reports the branch already exists — a stale branch
+  left by an already-merged PR (auto-delete off), or a concurrent request that
+  raced us — the flow re-checks for an open PR: if one now exists it accumulates
+  onto it, otherwise it resets the stale branch onto `main` with
+  `updateRef(..., force)` and opens the PR. Doing the reset only in this failure
+  handler (never pre-emptively) avoids clobbering a branch a concurrent request is
+  mid-way through creating (02-§122.7).
 
 Both mechanisms run synchronously before the response in both runtimes (02-§122.8),
 so the eventual-consistency window can no longer turn an impatient re-save into a
-second, stuck pull request (observed as #990/#991 and #1010/#1011).
+second, stuck pull request (observed as #990/#991 and #1010/#1011). A residual
+sub-second window remains only for two *different* edits submitted within the few
+milliseconds between one request's `createBranch` and its `createPullRequest`;
+a human's separate edits are always seconds apart, by which point the first PR is
+open and the second accumulates onto it. True double-click resubmits of the *same*
+edit are collapsed by the no-op guard.
 
 ### 11.7 Required repository settings
 

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -256,8 +256,8 @@ one edit branch per activity. Before creating anything, the flow calls
 
 Both mechanisms live inside `updateEventInActiveCamp` and run before any branch or
 pull request is created, so the eventual-consistency window can no longer turn an
-impatient re-save into a second, stuck pull request (observed as #990/#991 and
-#1010/#1011). This holds in both runtimes (02-§122.8) regardless of response
+impatient re-save into a second, stuck pull request (observed as #990/#991
+and #1010/#1011). This holds in both runtimes (02-§122.8) regardless of response
 timing: the PHP edit is synchronous with the response, while the Node edit runs in
 the same fire-and-forget background task as the existing edit write (`app.js`
 sends `res.json` then calls `updateEventInActiveCamp(...).catch(...)`), so — unlike

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -254,9 +254,15 @@ one edit branch per activity. Before creating anything, the flow calls
   handler (never pre-emptively) avoids clobbering a branch a concurrent request is
   mid-way through creating (02-§122.7).
 
-Both mechanisms run synchronously before the response in both runtimes (02-§122.8),
-so the eventual-consistency window can no longer turn an impatient re-save into a
-second, stuck pull request (observed as #990/#991 and #1010/#1011). A residual
+Both mechanisms live inside `updateEventInActiveCamp` and run before any branch or
+pull request is created, so the eventual-consistency window can no longer turn an
+impatient re-save into a second, stuck pull request (observed as #990/#991 and
+#1010/#1011). This holds in both runtimes (02-§122.8) regardless of response
+timing: the PHP edit is synchronous with the response, while the Node edit runs in
+the same fire-and-forget background task as the existing edit write (`app.js`
+sends `res.json` then calls `updateEventInActiveCamp(...).catch(...)`), so — unlike
+the add flow's 409 duplicate pre-check (§111.3) — an edit always answers success
+and the dedup happens in the background. A residual
 sub-second window remains only for two *different* edits submitted within the few
 milliseconds between one request's `createBranch` and its `createPullRequest`;
 a human's separate edits are always seconds apart, by which point the first PR is

--- a/docs/03-architecture/ci-and-deploy.md
+++ b/docs/03-architecture/ci-and-deploy.md
@@ -217,6 +217,44 @@ identical content. A post-merge cleanup — a job in/alongside
 non-empty diff; it is left open and logged for manual attention rather than closed
 silently (02-§111.9).
 
+#### Edit duplicate hardening (02-§122)
+
+The §111 defences are add-only: the empty-diff cleanup matches `event/*` branches
+(`close-redundant-event-prs.js` ignores `event-edit/*` and `event-delete/*`), and
+because every edit bumps `meta.updated_at`, an edit pull request's net diff
+against `main` is never empty — so a redundant edit could never be auto-closed.
+Edits therefore dedupe at creation time in `updateEventInActiveCamp`
+(`source/api/github.js` and `GitHub::updateEventInActiveCamp()` in PHP), with two
+mechanisms.
+
+**No-op guard (02-§122.1–122.3).** The flow builds the patched fragment and
+compares it to the base it is applied on top of, ignoring the `updated_at:` line
+(`fragmentEqualsIgnoringUpdatedAt`, a pure exported/`public static` helper mirrored
+in both runtimes). When nothing but the timestamp would change, the edit is a
+no-op: it returns success and creates no branch and no pull request. This is the
+common case behind the observed duplicates — a user re-saving because the change
+has not yet appeared on the live site (deploy + PWA cache lag).
+
+**One open pull request per activity (02-§122.4–122.7).** The edit branch is
+deterministic — `event-edit/<id>`, with no timestamp suffix — so there is at most
+one edit branch per activity. Before creating anything, the flow calls
+`findOpenPrForBranch(event-edit/<id>)`:
+
+- **An edit PR is already open** → the new change is applied on top of *that
+  branch's* current fragment (`getFileMaybe(fragPath, branchName)`), so an earlier
+  unmerged edit is preserved rather than overwritten, and the commit lands on the
+  existing branch — updating the open PR instead of opening a rival (02-§122.5).
+  A no-op relative to the branch content adds no commit.
+- **No edit PR is open** → the edit is built on top of `main`. If a branch of that
+  name lingers from an already-merged edit PR (auto-delete off), it is reset onto
+  `main` with `updateRef(..., force)` rather than treated as open; otherwise a
+  fresh branch is created (`getRefMaybe` distinguishes the two, 02-§122.7). Then
+  the PR is opened with auto-merge as before.
+
+Both mechanisms run synchronously before the response in both runtimes (02-§122.8),
+so the eventual-consistency window can no longer turn an impatient re-save into a
+second, stuck pull request (observed as #990/#991 and #1010/#1011).
+
 ### 11.7 Required repository settings
 
 - **"Allow auto-merge"** must be enabled in Settings > General > Pull Requests.

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1971,5 +1971,5 @@ Doc ref: `02-requirements/event-data.md §122`;
 | `02-§122.4` | covered | DEDUPE-04 (deterministic `event-edit/<id>` branch, no `Date.now()`/`time()` suffix) + DEDUPE-05/-10/-11 (`findOpenPrForBranch` before `createPullRequest`) → at most one open edit PR per activity |
 | `02-§122.5` | covered | DEDUPE-07: the open-PR path reads the fragment from the PR branch (`getFileMaybe(fragPath, branchName)`) and commits on that branch, accumulating onto earlier unmerged edits instead of overwriting |
 | `02-§122.6` | covered | DEDUPE-06: with no open PR the edit is built on `main` and a PR opened; the no-op guard precedes creation |
-| `02-§122.7` | covered | DEDUPE-08/-13: `getRefMaybe`/`updateRef` reset a stale merged edit branch onto `main` rather than reusing it as if open |
+| `02-§122.7` | covered | DEDUPE-08/-13: a stale merged edit branch is reset onto `main` with `updateRef`, but only inside the `createBranch` failure handler (never pre-emptively), so a branch a concurrent request is mid-creating is adopted via its open PR rather than clobbered |
 | `02-§122.8` | covered | DEDUPE-10..13: `GitHub.php` mirrors the deterministic branch, open-PR lookup, no-op guard, and stale-branch reset; PHP `testFragmentEqualsIgnoringUpdatedAt*` mirrors the pure helper |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1957,3 +1957,19 @@ Doc ref: `02-requirements/design-and-content.md §121`;
 | `02-§121.12` | covered | HUBB-12: no inline `.hero-hub-banner[data-opens]` script; the banner is static markup with no new JS file |
 | `02-§121.13` | implemented | No dependency added to `package.json`; the icon is inline SVG and reuses the existing `EDQHUB_ICON` constant — review checkpoint |
 | `02-§121.14` | covered | HUBB-14, HUBB-15: the "Till EDQ Hub" call-to-action is a `<span class="hero-hub-banner-btn">` inside the single card anchor (no nested link/button); `html-validate` (`lint:html`) passes on the built page |
+
+### §122 — Edit Duplicate Hardening
+
+Doc ref: `02-requirements/event-data.md §122`;
+`03-architecture/ci-and-deploy.md §11.6` (edit duplicate hardening).
+
+| ID | Status | Notes |
+| --- | --- | --- |
+| `02-§122.1` | covered | DEDUPE-01/-02/-03 + PHP `testFragmentEqualsIgnoringUpdatedAt*`: `fragmentEqualsIgnoringUpdatedAt()` (pure, both runtimes) is true only when fragments differ solely in the `updated_at:` line |
+| `02-§122.2` | covered | DEDUPE-06: `updateEventInActiveCamp` runs the no-op comparison before `createBranch`/`createPullRequest` and returns early; manual DEDUPE-M01 (re-apply same edit → success, no second PR) |
+| `02-§122.3` | implemented | The no-op check is an awaited step inside `updateEventInActiveCamp` before the response in both runtimes (PHP synchronous; Node awaited before `res.json`, mirroring §53.2/§111.3). Review/manual checkpoint |
+| `02-§122.4` | covered | DEDUPE-04 (deterministic `event-edit/<id>` branch, no `Date.now()`/`time()` suffix) + DEDUPE-05/-10/-11 (`findOpenPrForBranch` before `createPullRequest`) → at most one open edit PR per activity |
+| `02-§122.5` | covered | DEDUPE-07: the open-PR path reads the fragment from the PR branch (`getFileMaybe(fragPath, branchName)`) and commits on that branch, accumulating onto earlier unmerged edits instead of overwriting |
+| `02-§122.6` | covered | DEDUPE-06: with no open PR the edit is built on `main` and a PR opened; the no-op guard precedes creation |
+| `02-§122.7` | covered | DEDUPE-08/-13: `getRefMaybe`/`updateRef` reset a stale merged edit branch onto `main` rather than reusing it as if open |
+| `02-§122.8` | covered | DEDUPE-10..13: `GitHub.php` mirrors the deterministic branch, open-PR lookup, no-op guard, and stale-branch reset; PHP `testFragmentEqualsIgnoringUpdatedAt*` mirrors the pure helper |

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1967,7 +1967,7 @@ Doc ref: `02-requirements/event-data.md §122`;
 | --- | --- | --- |
 | `02-§122.1` | covered | DEDUPE-01/-02/-03 + PHP `testFragmentEqualsIgnoringUpdatedAt*`: `fragmentEqualsIgnoringUpdatedAt()` (pure, both runtimes) is true only when fragments differ solely in the `updated_at:` line |
 | `02-§122.2` | covered | DEDUPE-06: `updateEventInActiveCamp` runs the no-op comparison before `createBranch`/`createPullRequest` and returns early; manual DEDUPE-M01 (re-apply same edit → success, no second PR) |
-| `02-§122.3` | implemented | The no-op check is an awaited step inside `updateEventInActiveCamp` before the response in both runtimes (PHP synchronous; Node awaited before `res.json`, mirroring §53.2/§111.3). Review/manual checkpoint |
+| `02-§122.3` | implemented | The no-op check runs inside `updateEventInActiveCamp` before any branch/PR is created, so no redundant PR is opened regardless of response timing. PHP (`index.php`) is synchronous with the response; Node (`app.js`) runs the edit in a fire-and-forget background task (`res.json` then `updateEventInActiveCamp(...).catch`), so the check runs there rather than before the response. Review/manual checkpoint |
 | `02-§122.4` | covered | DEDUPE-04 (deterministic `event-edit/<id>` branch, no `Date.now()`/`time()` suffix) + DEDUPE-05/-10/-11 (`findOpenPrForBranch` before `createPullRequest`) → at most one open edit PR per activity |
 | `02-§122.5` | covered | DEDUPE-07: the open-PR path reads the fragment from the PR branch (`getFileMaybe(fragPath, branchName)`) and commits on that branch, accumulating onto earlier unmerged edits instead of overwriting |
 | `02-§122.6` | covered | DEDUPE-06: with no open PR the edit is built on `main` and a PR opened; the no-op guard precedes creation |

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -225,13 +225,15 @@ function githubRequest(method, path, body, token) {
 }
 
 // Fetch a file from the repo. Returns { content: string, sha: string }.
-async function getFile(filePath) {
+// `ref` defaults to the configured main branch; pass an edit branch name to read
+// that branch's version of the file (02-§122.5).
+async function getFile(filePath, ref) {
   const owner  = env('GITHUB_OWNER');
   const repo   = env('GITHUB_REPO');
-  const branch = env('GITHUB_BRANCH');
   const token  = env('GITHUB_TOKEN');
+  const useRef = ref || env('GITHUB_BRANCH');
 
-  const apiPath = `/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+  const apiPath = `/repos/${owner}/${repo}/contents/${filePath}?ref=${encodeURIComponent(useRef)}`;
   const { data } = await githubRequest('GET', apiPath, null, token);
 
   const content = Buffer.from(data.content, 'base64').toString('utf8');
@@ -241,9 +243,9 @@ async function getFile(filePath) {
 // Like getFile, but returns null when the file does not exist (HTTP 404) instead
 // of throwing — used to decide whether an event lives in a fragment file
 // (02-§109.9).
-async function getFileMaybe(filePath) {
+async function getFileMaybe(filePath, ref) {
   try {
-    return await getFile(filePath);
+    return await getFile(filePath, ref);
   } catch (e) {
     if (e.status === 404) return null;
     throw e;
@@ -298,6 +300,53 @@ async function createBranch(name, sha) {
     ref: `refs/heads/${name}`,
     sha,
   }, token);
+}
+
+// Return the SHA a branch ref points at, or null when the branch does not exist
+// (HTTP 404). Used to tell a live edit branch from a stale one (02-§122.7).
+async function getRefMaybe(branch) {
+  const owner = env('GITHUB_OWNER');
+  const repo  = env('GITHUB_REPO');
+  const token = env('GITHUB_TOKEN');
+  try {
+    const { data } = await githubRequest('GET', `/repos/${owner}/${repo}/git/refs/heads/${branch}`, null, token);
+    return data.object.sha;
+  } catch (e) {
+    if (e.status === 404) return null;
+    throw e;
+  }
+}
+
+// Force a branch ref to point at a new commit SHA. Used to reset a stale edit
+// branch (left by an already-merged pull request) back onto main before
+// reusing its name (02-§122.7).
+async function updateRef(branch, sha) {
+  const owner = env('GITHUB_OWNER');
+  const repo  = env('GITHUB_REPO');
+  const token = env('GITHUB_TOKEN');
+  await githubRequest('PATCH', `/repos/${owner}/${repo}/git/refs/heads/${branch}`, { sha, force: true }, token);
+}
+
+// Return the open pull request whose head is `branch`, or null when none is open.
+// With one deterministic branch per event there is at most one (02-§122.4).
+async function findOpenPrForBranch(branch) {
+  const owner = env('GITHUB_OWNER');
+  const repo  = env('GITHUB_REPO');
+  const token = env('GITHUB_TOKEN');
+  const head  = encodeURIComponent(`${owner}:${branch}`);
+  const { data } = await githubRequest('GET', `/repos/${owner}/${repo}/pulls?head=${head}&state=open&per_page=1`, null, token);
+  if (Array.isArray(data) && data.length > 0) {
+    return { number: data[0].number, node_id: data[0].node_id };
+  }
+  return null;
+}
+
+// Compare two fragment YAML strings ignoring the `updated_at:` line. Pure (no
+// network) so it can be unit-tested. An edit that changes nothing but the
+// timestamp is a no-op and must not open a pull request (02-§122.1, §122.2).
+function fragmentEqualsIgnoringUpdatedAt(a, b) {
+  const strip = (s) => String(s).replace(/^[ \t]*updated_at:.*$/m, '').trim();
+  return strip(a) === strip(b);
 }
 
 // Open a pull request from head into the configured main branch.
@@ -486,20 +535,54 @@ async function updateEventInActiveCamp(eventId, updates) {
   const camp       = await resolveActiveCampFromGitHub();
   const now        = new Date().toISOString().replace('T', ' ').slice(0, 16);
   const commitMsg  = `Edit event in ${camp.name}: ${eventId}`;
-  const mainSha    = await getMainSha();
-  const branchName = `event-edit/${eventId}-${Date.now()}`;
+  // One deterministic branch per event, so a repeated or concurrent edit reuses
+  // the same open pull request instead of opening a rival one (02-§122.4).
+  const branchName = `event-edit/${eventId}`;
 
   const fragPath = fragmentPath(camp.file, eventId);
-  const frag     = await getFileMaybe(fragPath);
-  if (!frag) throw new Error(`Event not found: ${eventId}`);
+  const mainFrag = await getFileMaybe(fragPath);
+  if (!mainFrag) throw new Error(`Event not found: ${eventId}`);
+  const mainDoc = yaml.load(mainFrag.content) || {};
+  if (!mainDoc.event) throw new Error(`Event not found: ${eventId}`);
 
-  const doc = yaml.load(frag.content) || {};
-  if (!doc.event) throw new Error(`Event not found: ${eventId}`);
-  const patched = patchEventObject(doc.event, updates, now);
+  // If an edit pull request for this event is already open, accumulate the new
+  // change on top of ITS current content so earlier unmerged edits are
+  // preserved, not overwritten (02-§122.5).
+  const openPr = await findOpenPrForBranch(branchName);
+  if (openPr) {
+    const branchFrag = await getFileMaybe(fragPath, branchName);
+    // Fall back to main if the branch somehow lacks the fragment.
+    const base    = branchFrag || mainFrag;
+    const baseDoc = yaml.load(base.content) || {};
+    const patched = patchEventObject(baseDoc.event || mainDoc.event, updates, now);
+    const content = buildFragmentYaml(patched) + '\n';
+    assertFragmentYamlValid(content, eventId);
+    // Nothing new relative to what the open PR already carries → no commit.
+    if (fragmentEqualsIgnoringUpdatedAt(base.content, content)) return;
+    await putFile(fragPath, content, base.sha, commitMsg, branchName);
+    // Re-nudge the merge queue; best-effort (02-§113.1, §113.4).
+    await enqueueBestEffort(openPr.node_id);
+    return;
+  }
+
+  // No open pull request: build the edit on top of main.
+  const patched = patchEventObject(mainDoc.event, updates, now);
   const content = buildFragmentYaml(patched) + '\n';
   assertFragmentYamlValid(content, eventId);
-  await createBranch(branchName, mainSha);
-  await putFile(fragPath, content, frag.sha, commitMsg, branchName);
+  // No-op edit (only updated_at would change) → create no branch or PR
+  // (02-§122.1, §122.2).
+  if (fragmentEqualsIgnoringUpdatedAt(mainFrag.content, content)) return;
+
+  const mainSha = await getMainSha();
+  // A branch may linger from an already-merged edit PR (auto-delete off); reset
+  // it onto main rather than treating it as open (02-§122.7).
+  const staleSha = await getRefMaybe(branchName);
+  if (staleSha) {
+    await updateRef(branchName, mainSha);
+  } else {
+    await createBranch(branchName, mainSha);
+  }
+  await putFile(fragPath, content, mainFrag.sha, commitMsg, branchName);
   const pr = await createPullRequest(commitMsg, branchName, 'Automatically created by the SB Sommar edit-event API.');
   await enableAutoMerge(pr.node_id);
   // Proactive merge-queue enqueue, best-effort (02-§113.1, §113.4).
@@ -527,4 +610,4 @@ async function removeEventFromActiveCamp(eventId) {
   await enqueueBestEffort(pr.node_id);
 }
 
-module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, buildEnqueueMutation, enqueuePullRequest, enqueueBestEffort, githubRequest, env };
+module.exports = { addEventToActiveCamp, updateEventInActiveCamp, removeEventFromActiveCamp, isDuplicateEvent, DUPLICATE_EVENT_MESSAGE, slugify, yamlScalar, buildEventYaml, buildFragmentYaml, fragmentEqualsIgnoringUpdatedAt, fragmentDir, fragmentPath, assertFragmentYamlValid, detectEventIndent, assertEventYamlValid, buildEnqueueMutation, enqueuePullRequest, enqueueBestEffort, githubRequest, env };

--- a/source/api/github.js
+++ b/source/api/github.js
@@ -233,7 +233,10 @@ async function getFile(filePath, ref) {
   const token  = env('GITHUB_TOKEN');
   const useRef = ref || env('GITHUB_BRANCH');
 
-  const apiPath = `/repos/${owner}/${repo}/contents/${filePath}?ref=${encodeURIComponent(useRef)}`;
+  // `useRef` is a controlled slug (main, or event-edit/<event-id>). Its slash is
+  // left raw: GitHub's `ref` query accepts branch names with `/` literally, and
+  // percent-encoding the slash (%2F) can 404.
+  const apiPath = `/repos/${owner}/${repo}/contents/${filePath}?ref=${useRef}`;
   const { data } = await githubRequest('GET', apiPath, null, token);
 
   const content = Buffer.from(data.content, 'base64').toString('utf8');
@@ -302,21 +305,6 @@ async function createBranch(name, sha) {
   }, token);
 }
 
-// Return the SHA a branch ref points at, or null when the branch does not exist
-// (HTTP 404). Used to tell a live edit branch from a stale one (02-§122.7).
-async function getRefMaybe(branch) {
-  const owner = env('GITHUB_OWNER');
-  const repo  = env('GITHUB_REPO');
-  const token = env('GITHUB_TOKEN');
-  try {
-    const { data } = await githubRequest('GET', `/repos/${owner}/${repo}/git/refs/heads/${branch}`, null, token);
-    return data.object.sha;
-  } catch (e) {
-    if (e.status === 404) return null;
-    throw e;
-  }
-}
-
 // Force a branch ref to point at a new commit SHA. Used to reset a stale edit
 // branch (left by an already-merged pull request) back onto main before
 // reusing its name (02-§122.7).
@@ -333,7 +321,9 @@ async function findOpenPrForBranch(branch) {
   const owner = env('GITHUB_OWNER');
   const repo  = env('GITHUB_REPO');
   const token = env('GITHUB_TOKEN');
-  const head  = encodeURIComponent(`${owner}:${branch}`);
+  // owner and branch are controlled slugs; `:` and `/` are valid raw in a query
+  // value and are what GitHub's `head` filter (user:ref) expects.
+  const head  = `${owner}:${branch}`;
   const { data } = await githubRequest('GET', `/repos/${owner}/${repo}/pulls?head=${head}&state=open&per_page=1`, null, token);
   if (Array.isArray(data) && data.length > 0) {
     return { number: data[0].number, node_id: data[0].node_id };
@@ -545,25 +535,25 @@ async function updateEventInActiveCamp(eventId, updates) {
   const mainDoc = yaml.load(mainFrag.content) || {};
   if (!mainDoc.event) throw new Error(`Event not found: ${eventId}`);
 
-  // If an edit pull request for this event is already open, accumulate the new
-  // change on top of ITS current content so earlier unmerged edits are
-  // preserved, not overwritten (02-§122.5).
-  const openPr = await findOpenPrForBranch(branchName);
-  if (openPr) {
-    const branchFrag = await getFileMaybe(fragPath, branchName);
-    // Fall back to main if the branch somehow lacks the fragment.
-    const base    = branchFrag || mainFrag;
-    const baseDoc = yaml.load(base.content) || {};
-    const patched = patchEventObject(baseDoc.event || mainDoc.event, updates, now);
-    const content = buildFragmentYaml(patched) + '\n';
+  // Apply the edit on top of the open PR's own branch content, so an earlier
+  // unmerged edit is preserved, not overwritten (02-§122.5). A change that adds
+  // nothing to what the branch already carries makes no commit.
+  async function accumulateOnto(pr) {
+    const branchFrag = (await getFileMaybe(fragPath, branchName)) || mainFrag;
+    const baseDoc    = yaml.load(branchFrag.content) || {};
+    const patched    = patchEventObject(baseDoc.event || mainDoc.event, updates, now);
+    const content    = buildFragmentYaml(patched) + '\n';
     assertFragmentYamlValid(content, eventId);
-    // Nothing new relative to what the open PR already carries → no commit.
-    if (fragmentEqualsIgnoringUpdatedAt(base.content, content)) return;
-    await putFile(fragPath, content, base.sha, commitMsg, branchName);
+    if (fragmentEqualsIgnoringUpdatedAt(branchFrag.content, content)) return;
+    await putFile(fragPath, content, branchFrag.sha, commitMsg, branchName);
     // Re-nudge the merge queue; best-effort (02-§113.1, §113.4).
-    await enqueueBestEffort(openPr.node_id);
-    return;
+    await enqueueBestEffort(pr.node_id);
   }
+
+  // If an edit pull request for this event is already open, accumulate onto it
+  // rather than opening a rival (02-§122.4, §122.5).
+  const openPr = await findOpenPrForBranch(branchName);
+  if (openPr) { await accumulateOnto(openPr); return; }
 
   // No open pull request: build the edit on top of main.
   const patched = patchEventObject(mainDoc.event, updates, now);
@@ -574,13 +564,18 @@ async function updateEventInActiveCamp(eventId, updates) {
   if (fragmentEqualsIgnoringUpdatedAt(mainFrag.content, content)) return;
 
   const mainSha = await getMainSha();
-  // A branch may linger from an already-merged edit PR (auto-delete off); reset
-  // it onto main rather than treating it as open (02-§122.7).
-  const staleSha = await getRefMaybe(branchName);
-  if (staleSha) {
-    await updateRef(branchName, mainSha);
-  } else {
+  // Create the deterministic branch. If it already exists, another edit raced us
+  // or a stale branch lingers from an already-merged PR (auto-delete off). Only
+  // then do we look closer — this avoids resetting a branch a concurrent request
+  // is mid-way through creating.
+  try {
     await createBranch(branchName, mainSha);
+  } catch {
+    const racePr = await findOpenPrForBranch(branchName);
+    if (racePr) { await accumulateOnto(racePr); return; }
+    // No open PR → stale branch from an already-merged edit: reset onto main and
+    // reuse it (02-§122.7).
+    await updateRef(branchName, mainSha);
   }
   await putFile(fragPath, content, mainFrag.sha, commitMsg, branchName);
   const pr = await createPullRequest(commitMsg, branchName, 'Automatically created by the SB Sommar edit-event API.');

--- a/tests/dedup-edit.test.js
+++ b/tests/dedup-edit.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// Tests for 02-§122 — Edit Duplicate Hardening.
+//
+// Two mechanisms keep repeated or concurrent edits of one activity from leaving
+// a stuck or redundant pull request:
+//   1. No-op guard: an edit that changes nothing but meta.updated_at opens no PR.
+//   2. One open edit PR per activity: the branch is deterministic
+//      (event-edit/<id>), so a further edit reuses the open PR and accumulates
+//      onto its content instead of opening a rival from a stale base.
+//
+// The no-op comparison (fragmentEqualsIgnoringUpdatedAt) is a pure function and
+// is unit-tested directly. The orchestration lives in the network-touching edit
+// flow (github.js / GitHub.php), which cannot run in Node tests, so — as with
+// dedup-submission.test.js — those are source-code structural checks that pin
+// the branch naming and call ordering. Live behaviour is a manual checkpoint:
+//   DEDUPE-M01 (02-§122.2): edit an activity, then immediately re-apply the same
+//     edit → the API answers success and no second PR appears.
+//   DEDUPE-M02 (02-§122.5): make two different quick edits before the first
+//     merges → one PR carries both changes; there is never a second open edit PR.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { fragmentEqualsIgnoringUpdatedAt } = require('../source/api/github');
+
+const root = (...p) => path.join(__dirname, '..', ...p);
+const read = (...p) => fs.readFileSync(root(...p), 'utf8');
+const GH_JS = read('source', 'api', 'github.js');
+const GH_PHP = read('api', 'src', 'GitHub.php');
+
+// Slice out one function/method body so ordering checks are scoped to it.
+function slice(src, startNeedle, endNeedle) {
+  const start = src.indexOf(startNeedle);
+  assert.ok(start >= 0, `expected to find "${startNeedle}"`);
+  const end = endNeedle ? src.indexOf(endNeedle, start + startNeedle.length) : src.length;
+  return src.slice(start, end > start ? end : src.length);
+}
+
+function frag(overrides = {}) {
+  const e = Object.assign({
+    title: 'Foo', cancelled: false, updated: '2026-08-01 09:00',
+  }, overrides);
+  return `event:
+  id: foo-2026-08-01-1300
+  title: ${e.title}
+  cancelled: ${e.cancelled}
+  meta:
+    created_at: 2026-08-01 09:00
+    updated_at: ${e.updated}
+`;
+}
+
+// ── Pure no-op comparison (02-§122.1, §122.2) ────────────────────────────────
+
+describe('02-§122.1 — fragmentEqualsIgnoringUpdatedAt (DEDUPE-01..03)', () => {
+  it('DEDUPE-01: two fragments differing only in updated_at are equal', () => {
+    assert.equal(
+      fragmentEqualsIgnoringUpdatedAt(frag({ updated: '2026-08-01 09:00' }), frag({ updated: '2026-08-01 12:34' })),
+      true,
+    );
+  });
+
+  it('DEDUPE-02: fragments differing in a real field are not equal', () => {
+    assert.equal(
+      fragmentEqualsIgnoringUpdatedAt(frag({ title: 'Foo' }), frag({ title: 'Bar', updated: '2026-08-01 12:00' })),
+      false,
+    );
+  });
+
+  it('DEDUPE-03: a flipped cancelled flag is not a no-op', () => {
+    assert.equal(
+      fragmentEqualsIgnoringUpdatedAt(frag({ cancelled: false }), frag({ cancelled: true, updated: '2026-08-01 12:00' })),
+      false,
+    );
+  });
+});
+
+// ── github.js orchestration (02-§122.2, §122.4–§122.7) ───────────────────────
+
+describe('02-§122 — github.js updateEventInActiveCamp (DEDUPE-04..09)', () => {
+  const body = slice(GH_JS, 'async function updateEventInActiveCamp', 'async function removeEventFromActiveCamp');
+
+  it('DEDUPE-04: the edit branch is deterministic per event (no Date.now suffix)', () => {
+    assert.ok(body.includes('`event-edit/${eventId}`'), 'stable branch name event-edit/<id>');
+    assert.ok(!/event-edit\/\$\{eventId\}-/.test(body), 'no timestamped edit branch');
+    assert.ok(!body.includes('Date.now()'), 'no Date.now() in the edit flow');
+  });
+
+  it('DEDUPE-05: it looks for an already-open edit PR before creating one', () => {
+    const findIdx = body.indexOf('findOpenPrForBranch');
+    const createIdx = body.indexOf('createPullRequest');
+    assert.ok(findIdx > 0, 'must call findOpenPrForBranch');
+    assert.ok(createIdx > 0, 'must call createPullRequest');
+    assert.ok(findIdx < createIdx, 'open-PR lookup runs before creating a PR');
+  });
+
+  it('DEDUPE-06: a no-op edit returns before creating a branch or PR', () => {
+    const noopIdx = body.indexOf('fragmentEqualsIgnoringUpdatedAt');
+    const branchIdx = body.indexOf('createBranch');
+    const createIdx = body.indexOf('createPullRequest');
+    assert.ok(noopIdx > 0, 'must use the no-op comparison');
+    assert.ok(noopIdx < branchIdx && noopIdx < createIdx, 'no-op check precedes branch/PR creation');
+  });
+
+  it('DEDUPE-07: the accumulate path reads the fragment from the open PR branch', () => {
+    assert.ok(body.includes('getFileMaybe(fragPath, branchName)'), 'reads branch content to accumulate');
+  });
+
+  it('DEDUPE-08: a stale merged branch is reset onto main, not treated as open', () => {
+    assert.ok(body.includes('getRefMaybe'), 'checks for a lingering branch');
+    assert.ok(body.includes('updateRef'), 'resets the lingering branch onto main');
+  });
+});
+
+// ── PHP parity (02-§122.8) ───────────────────────────────────────────────────
+
+describe('02-§122.8 — GitHub.php parity (DEDUPE-10..13)', () => {
+  const body = slice(GH_PHP, 'function updateEventInActiveCamp', 'function removeEventFromActiveCamp');
+
+  it('DEDUPE-10: PHP edit branch is deterministic per event', () => {
+    assert.ok(body.includes('"event-edit/{$eventId}"'), 'stable branch name');
+    assert.ok(!/event-edit\/\{\$eventId\}-/.test(body), 'no timestamped edit branch');
+    assert.ok(!body.includes('time()'), 'no time() suffix in the edit flow');
+  });
+
+  it('DEDUPE-11: PHP looks for an open edit PR before creating one', () => {
+    const findIdx = body.indexOf('findOpenPrForBranch');
+    const createIdx = body.indexOf('createPullRequest');
+    assert.ok(findIdx > 0 && findIdx < createIdx, 'open-PR lookup before createPullRequest');
+  });
+
+  it('DEDUPE-12: PHP no-op check precedes branch/PR creation', () => {
+    const noopIdx = body.indexOf('fragmentEqualsIgnoringUpdatedAt');
+    const branchIdx = body.indexOf('createBranch');
+    assert.ok(noopIdx > 0 && noopIdx < branchIdx, 'no-op check precedes createBranch');
+  });
+
+  it('DEDUPE-13: PHP resets a stale edit branch onto main', () => {
+    assert.ok(body.includes('getRefMaybe'), 'checks for a lingering branch');
+    assert.ok(body.includes('updateRef'), 'resets the lingering branch');
+  });
+});

--- a/tests/dedup-edit.test.js
+++ b/tests/dedup-edit.test.js
@@ -109,9 +109,12 @@ describe('02-§122 — github.js updateEventInActiveCamp (DEDUPE-04..09)', () =>
     assert.ok(body.includes('getFileMaybe(fragPath, branchName)'), 'reads branch content to accumulate');
   });
 
-  it('DEDUPE-08: a stale merged branch is reset onto main, not treated as open', () => {
-    assert.ok(body.includes('getRefMaybe'), 'checks for a lingering branch');
-    assert.ok(body.includes('updateRef'), 'resets the lingering branch onto main');
+  it('DEDUPE-08: a stale/raced branch is reset only after createBranch reports it exists', () => {
+    assert.ok(body.includes('updateRef'), 'resets a lingering branch onto main');
+    const createIdx = body.indexOf('createBranch');
+    const updateIdx = body.indexOf('updateRef');
+    assert.ok(createIdx > 0, 'attempts createBranch');
+    assert.ok(updateIdx > createIdx, 'updateRef runs after the createBranch attempt (in its catch), not pre-emptively');
   });
 });
 
@@ -138,8 +141,10 @@ describe('02-§122.8 — GitHub.php parity (DEDUPE-10..13)', () => {
     assert.ok(noopIdx > 0 && noopIdx < branchIdx, 'no-op check precedes createBranch');
   });
 
-  it('DEDUPE-13: PHP resets a stale edit branch onto main', () => {
-    assert.ok(body.includes('getRefMaybe'), 'checks for a lingering branch');
-    assert.ok(body.includes('updateRef'), 'resets the lingering branch');
+  it('DEDUPE-13: PHP resets a stale edit branch only after createBranch reports it exists', () => {
+    assert.ok(body.includes('updateRef'), 'resets a lingering branch');
+    const createIdx = body.indexOf('createBranch');
+    const updateIdx = body.indexOf('updateRef');
+    assert.ok(createIdx > 0 && updateIdx > createIdx, 'updateRef runs after the createBranch attempt (in its catch)');
   });
 });


### PR DESCRIPTION
## Bakgrund

Redigering av en aktivitet skapade tidigare alltid en ny PR (`event-edit/<id>-<timestamp>`). Eftersom en ändring tar minuter att synas (deploy + PWA-cache) sparar en otålig användare om, och man får dubletter — antingen redundanta eller olösliga `dirty`-PR:er som en maintainer får stänga för hand (observerat som #990/#991 och #1010/#1011). Den befintliga tomma-diff-städningen (§111.7) hjälper inte: den täcker bara `event/*`-brancher, och eftersom varje edit bumpar `updated_at` är en edit-PR:s netto-diff aldrig tom.

Detta ersätter den tidigare klient-fixen (#1009, reverterad i #1016), som bara stoppade dubbelklick inom samma sidladdning och inte deploy-lag-dubletterna.

## Ändring (server-side, Node + PHP-paritet)

- **No-op-vakt** (§122.1–122.3): innan någon branch/PR skapas jämförs det patchade fragmentet med basen det appliceras på, `updated_at` ignorerad (`fragmentEqualsIgnoringUpdatedAt`, ren funktion speglad i båda runtimes). Ändrar inget utom tidsstämpeln → ingen PR.
- **Max en öppen PR per aktivitet** (§122.4–122.7): deterministisk branch `event-edit/<id>`. Finns en öppen edit-PR ackumuleras den nya ändringen på *dess* innehåll (så tidigare oinmergade ändringar bevaras, inte skrivs över). Annars byggs edit:en på `main`. En stale branch från en redan mergad PR återställs mot `main` — men bara i `createBranch`-felhanteraren, aldrig i förväg, så en branch som en samtidig request just skapar aldrig klobbras.
- **Runtime-paritet** (§122.8): identiskt i `source/api/github.js` och `api/src/GitHub.php`.

Delete-flödet är utanför scope (dubbel-radering felar redan rent); add har redan dubblettskydd (§111).

## Krav & dokumentation

- Nytt krav **02-§122** i `docs/02-requirements/event-data.md` (+ index-karta).
- Arkitektur i `docs/03-architecture/ci-and-deploy.md §11.6`.
- Traceability §122.1–.8 i `docs/99-traceability/02-requirements.md`, status `covered`/`implemented`.

## Testplan

- [x] `tests/dedup-edit.test.js` — 12 tester: rena enhetstester för no-op-jämförelsen + strukturella ordningskontroller för Node & PHP
- [x] PHP-paritetstester i `api/tests/GitHubTest.php` (`testFragmentEqualsIgnoringUpdatedAt*`)
- [x] `npm test` — 2260 tester passerar; `npm run lint` (eslint), `lint:md`, `php -l` rena
- [ ] Manuell (kräver deploy): redigera en aktivitet, återupprepa samma sparning → success, ingen andra PR; gör två *olika* snabba ändringar → en PR bär båda; ingen fastnad `dirty`-PR

**Känd kvarvarande kant:** två *olika* edits inom de få millisekunderna mellan en requests `createBranch` och dess `createPullRequest` kan fortfarande ge ett övergående fel/rival; mänskliga separata ändringar är alltid sekunder isär (då är första PR:en öppen → ackumulering). Samma edit dubbelklickad kollapsas av no-op-vakten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgAm1MaaEaVTbMPjkHM4N1)_