### PR TITLE
EDQ Hub-länk i arkivet för juli 2026

### DIFF
--- a/docs/02-requirements/design-and-content.md
+++ b/docs/02-requirements/design-and-content.md
@@ -573,3 +573,27 @@ an additional, more visible surface for the same destination.
 - The banner is static markup: it requires no new JavaScript file and no inline
   script. <!-- 02-§121.12 -->
 - The banner introduces no new runtime dependencies. <!-- 02-§121.13 -->
+
+### 121.7 EDQ Hub in the archive
+
+The archive presents each past camp with a link to its community. For a camp
+whose community has moved to EDQ Hub, the archive shows the EDQ Hub link
+alongside the historical Facebook-group link and states that the move happened.
+
+- A camp entry in `source/data/camps.yaml` may carry an optional `edqhub` field
+  holding the camp's EDQ Hub join URL. <!-- 02-§121.15 -->
+- In the archive (`arkiv.html`), a camp whose `edqhub` field holds a valid URL
+  shows an EDQ Hub link beside its Facebook-group link in the camp panel. The
+  link carries the shared EDQ Hub hub-node icon, opens in a new tab with
+  `target="_blank"` and `rel="noopener noreferrer"`, and has the accessible name
+  "EDQ Hub". <!-- 02-§121.16 -->
+- The statement that a camp's communication has moved from Facebook to EDQ Hub
+  is part of that camp's existing `information` text, not a separate element. The
+  July 2026 camp's `information` ends with "Från och med detta läger flyttar
+  kommunikationen från Facebook till EDQ Hub.". <!-- 02-§121.17 -->
+- A camp without an `edqhub` field, or whose `edqhub` value is not a safe
+  `http(s)` URL, shows no EDQ Hub link in the archive; its Facebook-group link is
+  unaffected. <!-- 02-§121.18 -->
+- The archive EDQ Hub link uses only the design tokens defined in
+  `07-design/css-strategy.md §7`; no colours, spacing, or typography values are
+  hardcoded. <!-- 02-§121.19 -->

--- a/docs/99-traceability/02-requirements.md
+++ b/docs/99-traceability/02-requirements.md
@@ -1957,6 +1957,11 @@ Doc ref: `02-requirements/design-and-content.md §121`;
 | `02-§121.12` | covered | HUBB-12: no inline `.hero-hub-banner[data-opens]` script; the banner is static markup with no new JS file |
 | `02-§121.13` | implemented | No dependency added to `package.json`; the icon is inline SVG and reuses the existing `EDQHUB_ICON` constant — review checkpoint |
 | `02-§121.14` | covered | HUBB-14, HUBB-15: the "Till EDQ Hub" call-to-action is a `<span class="hero-hub-banner-btn">` inside the single card anchor (no nested link/button); `html-validate` (`lint:html`) passes on the built page |
+| `02-§121.15` | covered | ARCHUB-01, ARCHUB-04: `renderArkivPage` reads the optional `camp.edqhub` field; a camp carrying it renders the hub link, one without renders none. Set on `2026-07-syssleback` in `source/data/camps.yaml` |
+| `02-§121.16` | covered | ARCHUB-01/-02/-03: `source/build/render-arkiv.js` emits a `.camp-hub-link` anchor with `href` = `edqhub`, the shared `EDQHUB_ICON` SVG, `aria-label="EDQ Hub"`, `target="_blank"` + `rel="noopener noreferrer"` |
+| `02-§121.17` | covered | Content in `source/data/camps.yaml` — the `2026-07-syssleback` `information` ends with "Från och med detta läger flyttar kommunikationen från Facebook till EDQ Hub.", rendered inside the existing `.camp-information` paragraph, not a separate element (manual/data checkpoint) |
+| `02-§121.18` | covered | ARCHUB-04, ARCHUB-05: absent `edqhub`, or an unsafe URL (`safeLinkHref` returns falsy), yields no hub link; the Facebook link is unaffected |
+| `02-§121.19` | implemented | `source/assets/cs/style.css` `.camp-hub-link` uses only `07-design/css-strategy.md §7` tokens; `stylelint` (`lint:css`) passes — token-only usage is a review checkpoint |
 
 ### §122 — Edit Duplicate Hardening
 

--- a/source/assets/cs/style.css
+++ b/source/assets/cs/style.css
@@ -2609,6 +2609,19 @@ body.modal-open {
   vertical-align: middle;
 }
 
+/* EDQ Hub link in a camp's archive panel, beside the Facebook link (02-§121.16) */
+.camp-hub-link {
+  display: inline-block;
+  margin-bottom: var(--space-sm);
+  margin-left: var(--space-sm);
+}
+
+.camp-hub-link svg {
+  width: 28px;
+  height: 28px;
+  vertical-align: middle;
+}
+
 /* Archive event list */
 .archive-events {
   margin-top: var(--space-sm);

--- a/source/build/render-arkiv.js
+++ b/source/build/render-arkiv.js
@@ -5,6 +5,7 @@ const { escapeHtml, toDateString, formatDate, safeLinkHref } = require('./utils'
 const { renderDescriptionHtml } = require('./markdown');
 const { goatcounterScript } = require('./analytics');
 const { pwaHeadTags } = require('./pwa');
+const { EDQHUB_ICON } = require('./render-index');
 
 const MONTHS_SV = [
   'januari', 'februari', 'mars', 'april', 'maj', 'juni',
@@ -111,6 +112,7 @@ function renderArkivPage(allCamps, footerHtml = '', navSections = [], campEvents
     const location = escapeHtml(camp.location || '');
     const info = (camp.information || '').trim();
     const link = (camp.link || '').trim();
+    const edqhub = safeLinkHref(camp.edqhub);
 
     const infoHtml = info
       ? `\n        <p class="camp-information">${escapeHtml(info)}</p>`
@@ -118,6 +120,14 @@ function renderArkivPage(allCamps, footerHtml = '', navSections = [], campEvents
 
     const linkHtml = link
       ? `\n        <a class="camp-fb-link" href="${escapeHtml(link)}" target="_blank" rel="noopener noreferrer"><img src="images/facebook-ikon.webp" alt="Facebookgrupp" class="camp-fb-logo" width="24" height="24"></a>`
+      : '';
+
+    // A camp that carries an `edqhub` join URL shows an EDQ Hub link beside the
+    // Facebook link (02-§121.16), gated on the sanitised URL so camps without
+    // the field show none. The migration statement itself lives in the camp's
+    // `information` text (02-§121.17), not in a separate element.
+    const hubLinkHtml = edqhub
+      ? `\n        <a class="camp-hub-link" href="${escapeHtml(edqhub)}" target="_blank" rel="noopener noreferrer" aria-label="EDQ Hub">${EDQHUB_ICON}</a>`
       : '';
 
     const campEvents = campEventsMap[camp.id] || [];
@@ -131,7 +141,7 @@ function renderArkivPage(allCamps, footerHtml = '', navSections = [], campEvents
         <span class="timeline-meta">${headerDateRange} · ${location}</span>
         <span class="timeline-chevron" aria-hidden="true"></span>
       </button>
-      <div class="timeline-panel" id="${panelId}" hidden>${linkHtml}${infoHtml}${eventsHtml}
+      <div class="timeline-panel" id="${panelId}" hidden>${linkHtml}${hubLinkHtml}${infoHtml}${eventsHtml}
       </div>
     </div>
   </li>`;

--- a/source/build/render-index.js
+++ b/source/build/render-index.js
@@ -544,4 +544,4 @@ function injectRegistrationCta(sectionHtml) {
   return sectionHtml.slice(0, insertPoint) + cta + '\n' + sectionHtml.slice(insertPoint);
 }
 
-module.exports = { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, wrapTestimonialCards, renderRegistrationBannersHtml, injectRegistrationCta, formatLongSvDate, REGISTRATION_URL };
+module.exports = { renderIndexPage, convertMarkdown, extractHeroImage, extractH1, renderUpcomingCampsHtml, renderLocationAccordions, wrapTestimonialCards, renderRegistrationBannersHtml, injectRegistrationCta, formatLongSvDate, REGISTRATION_URL, EDQHUB_ICON };

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -36,6 +36,8 @@ camps:
     link: https://www.facebook.com/groups/syssleback2026
     information: |
       Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+      Från och med detta läger flyttar kommunikationen från Facebook till EDQ Hub.
+    edqhub: https://edqhub.com/join/sb-sommarlager-2026
     file: 2026-07-syssleback.yaml
     archived: true
   - id: 2026-06-syssleback

--- a/source/data/camps.yaml
+++ b/source/data/camps.yaml
@@ -36,6 +36,7 @@ camps:
     link: https://www.facebook.com/groups/syssleback2026
     information: |
       Claude code har nu fixat systemet. Ingen wordpress längre. Ren kod endast för våra behov. Kanske kan vi snart skriva önskemål och det införs nästan automatiskt.
+      De som anordnade aktiviteter redigerade även själva i schemat, och det fungerade.
       Från och med detta läger flyttar kommunikationen från Facebook till EDQ Hub.
     edqhub: https://edqhub.com/join/sb-sommarlager-2026
     file: 2026-07-syssleback.yaml

--- a/tests/archive-edqhub.test.js
+++ b/tests/archive-edqhub.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderArkivPage } = require('../source/build/render-arkiv');
+
+const EDQHUB_URL = 'https://edqhub.com/join/sb-sommarlager-2026';
+
+function makeCamp(overrides = {}) {
+  return {
+    id: '2026-07-syssleback',
+    name: 'SB sommar 2026 juli',
+    start_date: '2026-07-26',
+    end_date: '2026-08-02',
+    location: 'Sysslebäck',
+    link: 'https://www.facebook.com/groups/syssleback2026',
+    archived: true,
+    ...overrides,
+  };
+}
+
+// Isolates the archive panel anchor for the EDQ Hub link.
+function hubAnchor(html) {
+  return html.match(/<a[^>]*class="camp-hub-link"[^>]*>/);
+}
+
+describe('renderArkivPage – EDQ Hub link in the archive (02-§121.15, §121.16, §121.18)', () => {
+  it('ARCHUB-01: a camp with an edqhub field renders a .camp-hub-link anchor', () => {
+    const html = renderArkivPage([makeCamp({ edqhub: EDQHUB_URL })]);
+    assert.ok(hubAnchor(html), 'Expected a .camp-hub-link anchor for a camp with edqhub');
+  });
+
+  it('ARCHUB-02: the hub link href is the edqhub URL, opening in a new tab safely (02-§121.16)', () => {
+    const html = renderArkivPage([makeCamp({ edqhub: EDQHUB_URL })]);
+    const a = hubAnchor(html);
+    assert.ok(a, 'Expected the hub link anchor');
+    assert.ok(a[0].includes(`href="${EDQHUB_URL}"`), `Expected href="${EDQHUB_URL}", got: ${a[0]}`);
+    assert.ok(a[0].includes('target="_blank"'), `Expected target="_blank", got: ${a[0]}`);
+    assert.ok(a[0].includes('rel="noopener noreferrer"'), `Expected rel="noopener noreferrer", got: ${a[0]}`);
+    assert.ok(a[0].includes('aria-label="EDQ Hub"'), `Expected aria-label="EDQ Hub", got: ${a[0]}`);
+  });
+
+  it('ARCHUB-03: the hub link carries the shared EDQ Hub icon SVG (02-§121.16)', () => {
+    const html = renderArkivPage([makeCamp({ edqhub: EDQHUB_URL })]);
+    assert.ok(/<a[^>]*class="camp-hub-link"[^>]*>\s*<svg/.test(html), 'Expected the SVG badge inside the hub link');
+  });
+
+  it('ARCHUB-04: a camp without an edqhub field shows no hub link; the Facebook link remains (02-§121.18)', () => {
+    const html = renderArkivPage([makeCamp()]);
+    assert.ok(!hubAnchor(html), 'Expected no hub link when edqhub is absent');
+    assert.ok(html.includes('class="camp-fb-link"'), 'Expected the Facebook link to remain');
+  });
+
+  it('ARCHUB-05: an unsafe edqhub URL is rejected — no hub link (02-§121.18)', () => {
+    const html = renderArkivPage([makeCamp({ edqhub: 'javascript:alert(1)' })]);
+    assert.ok(!hubAnchor(html), 'Expected an unsafe edqhub URL to produce no hub link');
+  });
+});


### PR DESCRIPTION
## Sammanfattning

Arkivet kan nu visa en **EDQ Hub-länk** bredvid Facebook-länken för läger som migrerat dit, och juli 2026-lägrets beskrivning nämner migreringen.

- **Nytt valfritt `edqhub`-fält** i `camps.yaml` (join-URL). Satt på `2026-07-syssleback`.
- I arkivpanelen visar ett läger med `edqhub` en **EDQ Hub-länk** (delade `EDQHUB_ICON`, exporterad från `render-index`) bredvid Facebook-ikonen. Öppnas i ny flik med `rel="noopener noreferrer"`, `aria-label="EDQ Hub"`.
- **Migreringsnotisen är en del av lägrets befintliga `information`-text**, inte ett eget element: juli-lägrets beskrivning slutar med "Från och med detta läger flyttar kommunikationen från Facebook till EDQ Hub."
- Läger utan `edqhub`-fält (eller med osäker URL) visar ingen EDQ Hub-länk; Facebook-länken är orörd.

Följer feature-lifecyklen: requirements (02-§121.15–121.19) + traceability + tester + implementation.

## Testplan

- [x] `npm test` — 2265/2265 pass (5 nya `ARCHUB`-tester)
- [x] `npm run validate:camps` — 14 camps OK
- [x] `npm run lint` (eslint), `lint:css`, `lint:html`, `lint:md` — rent
- [x] `npm run build` — juli-panelen visar EDQ Hub-länken; notisen ingår i `.camp-information`; övriga läger oförändrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gDf7q3S66bpuNTLcLzxbv

---
_Generated by [Claude Code](https://claude.ai/code/session_018gDf7q3S66bpuNTLcLzxbv)_